### PR TITLE
feat: 전략 DB 스키마 + 관리 Repository

### DIFF
--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -79,6 +79,8 @@ CREATE TABLE IF NOT EXISTS trades (
     profit_pct REAL,
     profit_krw REAL,
     hold_duration_minutes INTEGER,
+    strategy_params_json TEXT,
+    strategy_selection_reason TEXT,
     FOREIGN KEY (buy_trade_id) REFERENCES trades(id)
 );
 
@@ -127,6 +129,45 @@ CREATE TABLE IF NOT EXISTS daily_reports (
     FOREIGN KEY (active_param_id) REFERENCES strategy_params(id)
 );
 
+CREATE TABLE IF NOT EXISTS strategies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    description TEXT,
+    category TEXT NOT NULL,
+    market_states TEXT NOT NULL,
+    timeframe TEXT,
+    difficulty TEXT,
+    default_params_json TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    is_available BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS strategy_activations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    strategy_name TEXT NOT NULL,
+    action TEXT NOT NULL,
+    source TEXT NOT NULL,
+    market_state TEXT,
+    reason TEXT,
+    previous_strategy TEXT,
+    performance_at_switch_json TEXT,
+    FOREIGN KEY (strategy_name) REFERENCES strategies(name)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT,
+    is_admin BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_login_at DATETIME
+);
+
 CREATE TABLE IF NOT EXISTS llm_decisions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -164,6 +205,109 @@ INSERT INTO strategy_params (
 );
 """
 
+# 전략 마스터 데이터
+_DEFAULT_STRATEGIES = [
+    {
+        "name": "volatility_breakout",
+        "display_name": "변동성 돌파",
+        "description": "시가 + 전일 변동폭 × K 돌파 시 매수. 래리 윌리엄스의 단기 전략.",
+        "category": "volatility",
+        "market_states": "bullish",
+        "timeframe": "1d",
+        "difficulty": "easy",
+        "default_params_json": '{"k_value": 0.5}',
+        "is_active": True,
+    },
+    {
+        "name": "ma_crossover",
+        "display_name": "이동평균 교차",
+        "description": "단기 MA가 장기 MA를 돌파하면 매수/매도. 가장 고전적인 추세 추종 전략.",
+        "category": "trend",
+        "market_states": "bullish,bearish",
+        "timeframe": "1d",
+        "difficulty": "easy",
+        "default_params_json": '{"short_period": 5, "long_period": 20}',
+        "is_active": False,
+    },
+    {
+        "name": "macd",
+        "display_name": "MACD",
+        "description": "MACD-시그널 라인 교차로 추세 강도와 방향 판단.",
+        "category": "trend",
+        "market_states": "bullish,bearish",
+        "timeframe": "1d",
+        "difficulty": "easy",
+        "default_params_json": '{"fast": 12, "slow": 26, "signal_period": 9}',
+        "is_active": False,
+    },
+    {
+        "name": "supertrend",
+        "display_name": "슈퍼트렌드",
+        "description": "ATR 기반 동적 지지/저항선으로 추세 추종. 변동성 적응형.",
+        "category": "trend",
+        "market_states": "bullish,bearish",
+        "timeframe": "1d",
+        "difficulty": "medium",
+        "default_params_json": '{"st_period": 10, "st_multiplier": 3.0}',
+        "is_active": False,
+    },
+    {
+        "name": "rsi_mean_reversion",
+        "display_name": "RSI 평균 회귀",
+        "description": "RSI 과매도 반등 매수, 과매수 하락 매도. 횡보장 전용.",
+        "category": "mean_reversion",
+        "market_states": "sideways",
+        "timeframe": "1h",
+        "difficulty": "easy",
+        "default_params_json": '{"rsi_period": 14, "oversold": 30, "overbought": 70}',
+        "is_active": False,
+    },
+    {
+        "name": "bollinger_bands",
+        "display_name": "볼린저 밴드",
+        "description": "밴드 이탈 후 복귀 시 반전 진입. 횡보장에서 높은 승률.",
+        "category": "mean_reversion",
+        "market_states": "sideways",
+        "timeframe": "1h",
+        "difficulty": "easy",
+        "default_params_json": '{"bb_period": 20, "bb_std": 2.0}',
+        "is_active": False,
+    },
+    {
+        "name": "grid_trading",
+        "display_name": "그리드 트레이딩",
+        "description": "가격 범위를 격자로 나누어 분할 매수/매도. 추세 예측 불필요.",
+        "category": "grid",
+        "market_states": "sideways",
+        "timeframe": "1h",
+        "difficulty": "medium",
+        "default_params_json": '{"grid_count": 10, "range_pct": 10.0}',
+        "is_active": False,
+    },
+    {
+        "name": "breakout_momentum",
+        "display_name": "브레이크아웃 모멘텀",
+        "description": "N일 최고가 돌파 매수. 터틀 트레이딩 핵심 전략.",
+        "category": "momentum",
+        "market_states": "bullish,sideways",
+        "timeframe": "1d",
+        "difficulty": "easy",
+        "default_params_json": '{"entry_period": 20, "exit_period": 10}',
+        "is_active": False,
+    },
+    {
+        "name": "bollinger_squeeze",
+        "display_name": "볼린저 스퀴즈",
+        "description": "밴드 수축 후 폭발적 움직임 포착. 횡보→추세 전환 구간.",
+        "category": "volatility",
+        "market_states": "sideways,bullish",
+        "timeframe": "1d",
+        "difficulty": "medium",
+        "default_params_json": '{"bb_period": 20, "bb_std": 2.0, "squeeze_lookback": 120}',
+        "is_active": False,
+    },
+]
+
 
 class Database:
     """SQLite 데이터베이스 연결 관리.
@@ -198,6 +342,32 @@ class Database:
             if row[0] == 0:
                 conn.executescript(_DEFAULT_PARAMS)
                 logger.info("기본 전략 파라미터 삽입 완료")
+
+            # 전략 마스터 데이터 삽입
+            row = conn.execute("SELECT COUNT(*) FROM strategies").fetchone()
+            if row[0] == 0:
+                for s in _DEFAULT_STRATEGIES:
+                    conn.execute(
+                        """
+                        INSERT INTO strategies (
+                            name, display_name, description, category,
+                            market_states, timeframe, difficulty,
+                            default_params_json, is_active
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            s["name"],
+                            s["display_name"],
+                            s["description"],
+                            s["category"],
+                            s["market_states"],
+                            s["timeframe"],
+                            s["difficulty"],
+                            s["default_params_json"],
+                            s["is_active"],
+                        ),
+                    )
+                logger.info("전략 마스터 데이터 삽입 완료 (%d개)", len(_DEFAULT_STRATEGIES))
 
             conn.commit()
             logger.info("데이터베이스 초기화 완료: %s", self._db_path)

--- a/src/cryptobot/data/strategy_repository.py
+++ b/src/cryptobot/data/strategy_repository.py
@@ -1,0 +1,208 @@
+"""전략 DB 관리 모듈.
+
+전략 마스터 정보 조회, 활성화/비활성화, 전환 이력 기록.
+Admin API에서 사용.
+"""
+
+import json
+import logging
+from datetime import datetime
+
+from cryptobot.data.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+class StrategyRepository:
+    """전략 DB 저장소."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    # ── 전략 마스터 조회 ──
+
+    def get_all(self) -> list[dict]:
+        """모든 전략 목록 조회."""
+        rows = self._db.execute("SELECT * FROM strategies ORDER BY category, name").fetchall()
+        return [dict(r) for r in rows]
+
+    def get_by_name(self, name: str) -> dict | None:
+        """전략 이름으로 조회."""
+        row = self._db.execute("SELECT * FROM strategies WHERE name = ?", (name,)).fetchone()
+        return dict(row) if row else None
+
+    def get_active(self) -> list[dict]:
+        """현재 활성화된 전략 목록."""
+        rows = self._db.execute("SELECT * FROM strategies WHERE is_active = TRUE ORDER BY name").fetchall()
+        return [dict(r) for r in rows]
+
+    def get_active_for_market(self, market_state: str) -> list[dict]:
+        """특정 시장 상태에 활성화된 전략 목록."""
+        rows = self._db.execute(
+            "SELECT * FROM strategies WHERE is_active = TRUE AND market_states LIKE ?",
+            (f"%{market_state}%",),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_by_category(self, category: str) -> list[dict]:
+        """카테고리별 전략 조회."""
+        rows = self._db.execute(
+            "SELECT * FROM strategies WHERE category = ? ORDER BY name",
+            (category,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ── 전략 활성화/비활성화 ──
+
+    def activate(self, name: str, source: str = "manual", reason: str | None = None) -> bool:
+        """전략 활성화.
+
+        Args:
+            name: 전략 이름
+            source: 누가 활성화했는지 ("manual" / "llm" / "auto")
+            reason: 활성화 사유
+
+        Returns:
+            성공 여부
+        """
+        strategy = self.get_by_name(name)
+        if strategy is None:
+            logger.warning("전략 '%s' 없음 — 활성화 실패", name)
+            return False
+
+        if strategy["is_active"]:
+            return True  # 이미 활성화됨
+
+        self._db.execute(
+            "UPDATE strategies SET is_active = TRUE, updated_at = ? WHERE name = ?",
+            (datetime.now().isoformat(), name),
+        )
+        self._record_activation(name, "activate", source, reason)
+        self._db.commit()
+        logger.info("전략 활성화: %s (by %s)", name, source)
+        return True
+
+    def deactivate(self, name: str, source: str = "manual", reason: str | None = None) -> bool:
+        """전략 비활성화."""
+        strategy = self.get_by_name(name)
+        if strategy is None:
+            return False
+
+        if not strategy["is_active"]:
+            return True
+
+        self._db.execute(
+            "UPDATE strategies SET is_active = FALSE, updated_at = ? WHERE name = ?",
+            (datetime.now().isoformat(), name),
+        )
+        self._record_activation(name, "deactivate", source, reason)
+        self._db.commit()
+        logger.info("전략 비활성화: %s (by %s)", name, source)
+        return True
+
+    def switch(
+        self,
+        from_strategy: str,
+        to_strategy: str,
+        source: str = "auto",
+        market_state: str | None = None,
+        reason: str | None = None,
+        performance: dict | None = None,
+    ) -> bool:
+        """전략 전환 (이전 전략 비활성화 + 새 전략 활성화).
+
+        Args:
+            from_strategy: 이전 전략
+            to_strategy: 새 전략
+            source: 전환 주체 ("auto" / "llm" / "manual")
+            market_state: 전환 시점 시장 상태
+            reason: 전환 사유
+            performance: 이전 전략의 성과 데이터
+        """
+        self.deactivate(from_strategy, source, f"전환: {from_strategy} → {to_strategy}")
+        self.activate(to_strategy, source, reason)
+
+        # 전환 이력에 추가 정보 기록
+        self._db.execute(
+            """
+            UPDATE strategy_activations
+            SET market_state = ?, previous_strategy = ?, performance_at_switch_json = ?
+            WHERE id = (SELECT MAX(id) FROM strategy_activations WHERE strategy_name = ?)
+            """,
+            (
+                market_state,
+                from_strategy,
+                json.dumps(performance) if performance else None,
+                to_strategy,
+            ),
+        )
+        self._db.commit()
+        logger.info("전략 전환: %s → %s (시장: %s, 사유: %s)", from_strategy, to_strategy, market_state, reason)
+        return True
+
+    # ── 전략 파라미터 관리 ──
+
+    def update_params(self, name: str, params_json: str) -> bool:
+        """전략 기본 파라미터 업데이트."""
+        self._db.execute(
+            "UPDATE strategies SET default_params_json = ?, updated_at = ? WHERE name = ?",
+            (params_json, datetime.now().isoformat(), name),
+        )
+        self._db.commit()
+        return True
+
+    # ── 활성화 이력 ──
+
+    def get_activation_history(self, limit: int = 50) -> list[dict]:
+        """전략 활성화/비활성화/전환 이력 조회."""
+        rows = self._db.execute(
+            "SELECT * FROM strategy_activations ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_strategy_stats(self, strategy_name: str) -> dict:
+        """특정 전략의 매매 통계.
+
+        Returns:
+            총 거래 수, 승률, 평균 수익률, 총 수익금 등
+        """
+        row = self._db.execute(
+            """
+            SELECT
+                COUNT(*) as total_trades,
+                SUM(CASE WHEN side='sell' AND profit_pct > 0 THEN 1 ELSE 0 END) as wins,
+                SUM(CASE WHEN side='sell' AND profit_pct <= 0 THEN 1 ELSE 0 END) as losses,
+                AVG(CASE WHEN side='sell' THEN profit_pct END) as avg_profit_pct,
+                SUM(CASE WHEN side='sell' THEN profit_krw ELSE 0 END) as total_profit_krw,
+                SUM(fee_krw) as total_fees
+            FROM trades WHERE strategy = ?
+            """,
+            (strategy_name,),
+        ).fetchone()
+
+        if row is None or row["total_trades"] == 0:
+            return {"total_trades": 0, "win_rate": 0, "avg_profit_pct": 0, "total_profit_krw": 0}
+
+        sells = (row["wins"] or 0) + (row["losses"] or 0)
+        win_rate = (row["wins"] or 0) / sells * 100 if sells > 0 else 0
+
+        return {
+            "total_trades": row["total_trades"],
+            "wins": row["wins"] or 0,
+            "losses": row["losses"] or 0,
+            "win_rate": round(win_rate, 1),
+            "avg_profit_pct": round(row["avg_profit_pct"] or 0, 2),
+            "total_profit_krw": round(row["total_profit_krw"] or 0, 2),
+            "total_fees": round(row["total_fees"] or 0, 2),
+        }
+
+    def _record_activation(self, name: str, action: str, source: str, reason: str | None) -> None:
+        """활성화 이력 기록."""
+        self._db.execute(
+            """
+            INSERT INTO strategy_activations (strategy_name, action, source, reason)
+            VALUES (?, ?, ?, ?)
+            """,
+            (name, action, source, reason),
+        )

--- a/tests/test_strategy_repository.py
+++ b/tests/test_strategy_repository.py
@@ -1,0 +1,131 @@
+"""전략 저장소 테스트."""
+
+import tempfile
+from pathlib import Path
+
+from cryptobot.data.database import Database
+from cryptobot.data.strategy_repository import StrategyRepository
+
+
+def _make_repo():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    return StrategyRepository(db), db
+
+
+def test_get_all_strategies():
+    """초기화 시 9개 전략이 삽입되는지."""
+    repo, db = _make_repo()
+    try:
+        strategies = repo.get_all()
+        assert len(strategies) == 9
+        names = [s["name"] for s in strategies]
+        assert "volatility_breakout" in names
+        assert "rsi_mean_reversion" in names
+    finally:
+        db.close()
+
+
+def test_get_by_name():
+    """이름으로 전략 조회."""
+    repo, db = _make_repo()
+    try:
+        s = repo.get_by_name("macd")
+        assert s is not None
+        assert s["display_name"] == "MACD"
+        assert s["category"] == "trend"
+
+        assert repo.get_by_name("nonexistent") is None
+    finally:
+        db.close()
+
+
+def test_get_active_default():
+    """초기 상태에서 변동성 돌파만 활성화."""
+    repo, db = _make_repo()
+    try:
+        active = repo.get_active()
+        assert len(active) == 1
+        assert active[0]["name"] == "volatility_breakout"
+    finally:
+        db.close()
+
+
+def test_activate_and_deactivate():
+    """전략 활성화/비활성화."""
+    repo, db = _make_repo()
+    try:
+        repo.activate("rsi_mean_reversion", source="manual", reason="횡보장 대비")
+        active = repo.get_active()
+        assert len(active) == 2
+
+        repo.deactivate("rsi_mean_reversion", source="manual")
+        active = repo.get_active()
+        assert len(active) == 1
+    finally:
+        db.close()
+
+
+def test_switch_strategy():
+    """전략 전환."""
+    repo, db = _make_repo()
+    try:
+        repo.switch(
+            from_strategy="volatility_breakout",
+            to_strategy="rsi_mean_reversion",
+            source="auto",
+            market_state="sideways",
+            reason="시장 횡보 전환",
+        )
+
+        active = repo.get_active()
+        assert len(active) == 1
+        assert active[0]["name"] == "rsi_mean_reversion"
+
+        # 이력 확인
+        history = repo.get_activation_history()
+        assert len(history) >= 2  # deactivate + activate
+    finally:
+        db.close()
+
+
+def test_activation_history():
+    """활성화 이력 기록."""
+    repo, db = _make_repo()
+    try:
+        repo.activate("macd", source="llm", reason="LLM 추천")
+        repo.deactivate("macd", source="manual")
+
+        history = repo.get_activation_history()
+        assert len(history) >= 2
+        assert history[0]["action"] == "deactivate"
+        assert history[1]["action"] == "activate"
+    finally:
+        db.close()
+
+
+def test_get_active_for_market():
+    """시장 상태별 활성 전략 조회."""
+    repo, db = _make_repo()
+    try:
+        repo.activate("rsi_mean_reversion")
+
+        bullish = repo.get_active_for_market("bullish")
+        assert any(s["name"] == "volatility_breakout" for s in bullish)
+
+        sideways = repo.get_active_for_market("sideways")
+        assert any(s["name"] == "rsi_mean_reversion" for s in sideways)
+    finally:
+        db.close()
+
+
+def test_strategy_stats_empty():
+    """매매 없을 때 통계."""
+    repo, db = _make_repo()
+    try:
+        stats = repo.get_strategy_stats("volatility_breakout")
+        assert stats["total_trades"] == 0
+        assert stats["win_rate"] == 0
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
Admin 대시보드와 전략 관리를 위한 DB 스키마 확장 및 Repository 구현

### 새 테이블
| 테이블 | 용도 |
|--------|------|
| `strategies` | 전략 마스터 (9개 전략 메타, 활성화 상태, 파라미터) |
| `strategy_activations` | 전략 활성화/비활성화/전환 이력 |
| `users` | Admin 인증용 |

### trades 테이블 보강
- `strategy_params_json` — 매매 시점 전략 파라미터 전체 (JSON)
- `strategy_selection_reason` — 전략 선택 사유 (LLM 학습용)

### StrategyRepository
- 전략 CRUD + 활성화/비활성화/전환
- 시장 상태별 조회
- 전략별 매매 통계

## Test plan
- [x] `pytest -v` — 61개 테스트 통과
- [x] `ruff check .` — 린트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)