### PR TITLE
fix: 타임스탬프 UTC 통일 + OHLCV 히스토리 저장 (#57)

### DIFF
--- a/src/cryptobot/api/routes/auth.py
+++ b/src/cryptobot/api/routes/auth.py
@@ -3,7 +3,7 @@
 NestJS의 AuthController와 동일.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -35,7 +35,7 @@ def login(form_data: OAuth2PasswordRequestForm = Depends()):
     # 마지막 로그인 시간 업데이트
     db.execute(
         "UPDATE users SET last_login_at = ? WHERE id = ?",
-        (datetime.now().isoformat(), row["id"]),
+        (datetime.now(timezone.utc).isoformat(), row["id"]),
     )
     db.commit()
 

--- a/src/cryptobot/api/routes/config.py
+++ b/src/cryptobot/api/routes/config.py
@@ -1,6 +1,6 @@
 """봇 설정 관리 라우트."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -59,7 +59,7 @@ def update_config(
 
     db.execute(
         "UPDATE bot_config SET value = ?, updated_at = ? WHERE key = ?",
-        (body.value, datetime.now().isoformat(), key),
+        (body.value, datetime.now(timezone.utc).isoformat(), key),
     )
     db.commit()
 

--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -11,7 +11,7 @@ import json
 import logging
 import signal
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 
@@ -311,7 +311,7 @@ class CryptoBot:
             profit_pct = (order.price - buy_price) / buy_price * 100
             profit_krw = order.total_krw - active_trade["total_krw"]
             buy_time = datetime.fromisoformat(active_trade["timestamp"])
-            hold_minutes = int((datetime.now() - buy_time).total_seconds() / 60)
+            hold_minutes = int((datetime.now(timezone.utc) - buy_time).total_seconds() / 60)
 
             trade_id = self._recorder.record_trade(
                 coin=config.bot.coin,

--- a/src/cryptobot/data/collector.py
+++ b/src/cryptobot/data/collector.py
@@ -1,11 +1,12 @@
 """시장 데이터 수집기.
 
-1분 간격으로 업비트에서 시세/거래량 데이터를 수집하고
+10초 간격으로 업비트에서 시세/거래량 데이터를 수집하고
 기술적 지표를 계산하여 market_snapshots에 저장한다.
+OHLCV 일봉 데이터는 ohlcv_daily 테이블에 별도 저장 (백테스팅/LLM용).
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pyupbit
 
@@ -17,13 +18,19 @@ from cryptobot.exceptions import APIError
 logger = logging.getLogger(__name__)
 
 
+def _utcnow() -> str:
+    """UTC ISO 포맷 타임스탬프."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
 class DataCollector:
     """시장 데이터 수집 및 저장."""
 
     def __init__(self, db: Database, coin: str = "KRW-BTC") -> None:
         self._db = db
         self._coin = coin
-        self._latest_df: "pd.DataFrame | None" = None  # 최근 OHLCV 캐시 (전략에서 사용)
+        self._latest_df: "pd.DataFrame | None" = None
+        self._last_ohlcv_save_date: str = ""  # 일봉 저장 중복 방지
 
     @property
     def latest_df(self) -> "pd.DataFrame | None":
@@ -42,6 +49,10 @@ class DataCollector:
                 return None
 
             snapshot_id = self._save_snapshot(snapshot)
+
+            # OHLCV 일봉 데이터 저장 (하루 1회)
+            self._save_ohlcv_daily()
+
             logger.debug("스냅샷 저장: id=%d, price=%s", snapshot_id, f"{snapshot['btc_price']:,.0f}")
             return snapshot_id
         except Exception as e:
@@ -74,7 +85,7 @@ class DataCollector:
             today = df.iloc[-1]
 
             return {
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": _utcnow(),
                 "btc_price": current_price,
                 "btc_open_24h": today["open"],
                 "btc_high_24h": today["high"],
@@ -125,6 +136,40 @@ class DataCollector:
         )
         self._db.commit()
         return cursor.lastrowid
+
+    def _save_ohlcv_daily(self) -> None:
+        """OHLCV 일봉 데이터를 ohlcv_daily 테이블에 저장.
+
+        매 틱마다 호출되지만 날짜 기준으로 중복 방지.
+        120일 캔들 전체를 upsert (과거 데이터도 보정).
+        """
+        if self._latest_df is None:
+            return
+
+        today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        if today_str == self._last_ohlcv_save_date:
+            return  # 오늘 이미 저장함
+
+        now = _utcnow()
+        rows = []
+        for idx, row in self._latest_df.iterrows():
+            date_str = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
+            rows.append((
+                self._coin, date_str,
+                row["open"], row["high"], row["low"], row["close"], row["volume"],
+                now,
+            ))
+
+        self._db.executemany(
+            """
+            INSERT OR REPLACE INTO ohlcv_daily (coin, date, open, high, low, close, volume, collected_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        self._db.commit()
+        self._last_ohlcv_save_date = today_str
+        logger.info("OHLCV 일봉 저장: %s %d일치", self._coin, len(rows))
 
     def get_latest_snapshot(self) -> dict | None:
         """가장 최근 스냅샷 조회."""

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -14,6 +14,19 @@ logger = logging.getLogger(__name__)
 
 # 테이블 생성 SQL
 _SCHEMA = """
+CREATE TABLE IF NOT EXISTS ohlcv_daily (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    coin TEXT NOT NULL,
+    date DATE NOT NULL,
+    open REAL NOT NULL,
+    high REAL NOT NULL,
+    low REAL NOT NULL,
+    close REAL NOT NULL,
+    volume REAL NOT NULL,
+    collected_at DATETIME NOT NULL,
+    UNIQUE(coin, date)
+);
+
 CREATE TABLE IF NOT EXISTS market_snapshots (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/cryptobot/data/strategy_repository.py
+++ b/src/cryptobot/data/strategy_repository.py
@@ -6,7 +6,7 @@ Admin API에서 사용.
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cryptobot.data.database import Database
 
@@ -81,7 +81,7 @@ class StrategyRepository:
             logger.warning("전략 '%s' 종료 중 — 전환 대기 필요", switching["name"])
             return False
 
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
 
         # 기존 활성 전략을 shutting_down으로 전환
         current_active = self._db.execute(
@@ -119,7 +119,7 @@ class StrategyRepository:
         ).fetchall()
 
         completed = []
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         for row in rows:
             name = row["name"]
             self._db.execute(
@@ -145,7 +145,7 @@ class StrategyRepository:
 
         self._db.execute(
             "UPDATE strategies SET is_active = FALSE, status = 'inactive', updated_at = ? WHERE name = ?",
-            (datetime.now().isoformat(), name),
+            (datetime.now(timezone.utc).isoformat(), name),
         )
         self._record_activation(name, "deactivate", source, reason)
         self._db.commit()
@@ -198,7 +198,7 @@ class StrategyRepository:
         """전략 기본 파라미터 업데이트."""
         self._db.execute(
             "UPDATE strategies SET default_params_json = ?, updated_at = ? WHERE name = ?",
-            (params_json, datetime.now().isoformat(), name),
+            (params_json, datetime.now(timezone.utc).isoformat(), name),
         )
         self._db.commit()
         return True


### PR DESCRIPTION
## Summary

### P0-1: 타임스탬프 UTC 통일
- collector, strategy_repository, config, auth 등 모든 `datetime.now()` → `datetime.now(timezone.utc)`
- SQLite `CURRENT_TIMESTAMP`(UTC)와 일치시켜 백테스팅 시 시간 정합성 보장
- 프론트는 이미 UTC→KST 변환 처리됨

### P0-2: OHLCV 히스토리 저장
- `ohlcv_daily` 테이블 추가 (coin, date, open, high, low, close, volume)
- collector가 매일 1회 120일치 일봉을 upsert
- 기존에는 120일 데이터를 가져와서 1행만 저장하고 나머지 119일 버렸음
- 이제 과거 캔들 데이터로 백테스팅/LLM 학습 가능

## Test plan

- [x] 65개 기존 테스트 전부 통과
- [x] ohlcv_daily 테이블 생성 확인
- [x] `datetime.now()` 전수 검색 → 로깅(로컬 날짜) 제외 전부 UTC 변환 확인

Related: #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)