### PR TITLE
feat: 스프레드 필터 (#83)

### DIFF
--- a/src/cryptobot/bot/scanner.py
+++ b/src/cryptobot/bot/scanner.py
@@ -88,6 +88,20 @@ class CoinScanner:
                 if df is None or df.empty:
                     continue
 
+                # 스프레드 필터 (호가 차이 큰 코인 제외)
+                try:
+                    orderbook = pyupbit.get_orderbook(ticker)
+                    if orderbook and len(orderbook) > 0:
+                        units = orderbook[0].get("orderbook_units", [])
+                        if units:
+                            best_ask = units[0]["ask_price"]
+                            best_bid = units[0]["bid_price"]
+                            spread_pct = (best_ask - best_bid) / best_bid * 100
+                            if spread_pct > 0.3:  # 0.3% 초과면 제외
+                                continue
+                except Exception:
+                    pass  # 호가 조회 실패 시 스킵 (제외 안 함)
+
                 volume_krw = df.iloc[-1]["close"] * df.iloc[-1]["volume"]
                 if volume_krw < self._min_volume_krw:
                     continue


### PR DESCRIPTION
Freqtrade SpreadFilter 참고: https://github.com/freqtrade/freqtrade

호가 스프레드 0.3% 초과 코인을 스캐너에서 자동 제외.
소액 매매 시 스프레드가 수수료보다 큰 코인은 매매할수록 손해.

90개 테스트 통과.