### PR TITLE
fix: 코드 리뷰 버그 수정 (#96)

### DIFF
--- a/admin/src/components/strategies/ParamsEditor.tsx
+++ b/admin/src/components/strategies/ParamsEditor.tsx
@@ -21,7 +21,7 @@ export default function ParamsEditor({ strategy, onClose, onSaved }: {
       initial[k] = String(v);
     });
     setEditParams(initial);
-  }, [strategy.name]);
+  }, [strategy.name, strategy.default_params_json]);
 
   const hasChanges = Object.keys(editParams).some(
     (k) => editParams[k] !== String(currentParams[k])

--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -51,7 +51,7 @@ export default function DashboardPage() {
       setNewsStats(nStats);
       setLlmDecisions(llm as LLMDecision[]);
       setLoading(false);
-    });
+    }).catch(() => setLoading(false));
   }, []);
 
   useEffect(() => {
@@ -79,7 +79,7 @@ export default function DashboardPage() {
 
       {/* KPI Cards */}
       {(() => {
-        const pos = ((positions as any)?.positions || []) as any[];
+        const pos = positions?.positions || [];
         const totalCost = pos.reduce((s: number, p: any) => s + (p.total_krw || 0), 0);
         const totalValue = pos.reduce((s: number, p: any) => s + (p.amount || 0) * (p.current_price || 0), 0);
         const totalAsset = (balance?.krw_balance || 0) + totalValue;
@@ -221,9 +221,9 @@ export default function DashboardPage() {
       {/* 현재 포지션 */}
       <div className="card" style={{ marginBottom: 24 }}>
         <div className="card-title">현재 포지션</div>
-        {positions?.has_position && (positions as any).positions?.length > 0 ? (
+        {positions?.has_position && positions.positions?.length > 0 ? (
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))", gap: 12 }}>
-            {((positions as any).positions || []).map((p: any) => (
+            {positions.positions.map((p) => (
               <div key={p.id} style={{ padding: 12, borderRadius: 8, background: "var(--bg-secondary)" }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
                   <div style={{ display: "flex", alignItems: "center", gap: 6 }}>

--- a/admin/src/pages/NewsPage.tsx
+++ b/admin/src/pages/NewsPage.tsx
@@ -218,7 +218,7 @@ export default function NewsPage() {
 
       {totalPages > 1 && (
         <div style={{ marginTop: 16 }}>
-          <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+          <Pagination page={page} pages={totalPages} onPageChange={setPage} />
         </div>
       )}
     </div>

--- a/admin/src/pages/SignalsPage.tsx
+++ b/admin/src/pages/SignalsPage.tsx
@@ -205,7 +205,7 @@ export default function SignalsPage() {
         )}
 
         {totalPages > 1 && (
-          <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+          <Pagination page={page} pages={totalPages} onPageChange={setPage} />
         )}
       </div>
 
@@ -267,7 +267,7 @@ export default function SignalsPage() {
               <div style={{ borderTop: "1px solid var(--border)", margin: "16px 0", paddingTop: 16 }}>
                 <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 12 }}>적용된 전략 파라미터</div>
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-                  {Object.entries(JSON.parse(selected.strategy_params_json) as Record<string, number>).map(([key, value]) => {
+                  {Object.entries((() => { try { return JSON.parse(selected.strategy_params_json) as Record<string, number>; } catch { return {}; } })()).map(([key, value]) => {
                     const desc = getParamDesc(selected.strategy, key);
                     return (
                       <div key={key}>

--- a/admin/src/types/balance.ts
+++ b/admin/src/types/balance.ts
@@ -16,6 +16,7 @@ export interface Position extends Trade {
 
 export interface PositionsResponse {
   has_position: boolean;
+  positions: Position[];
   position: Position | null;
 }
 

--- a/src/cryptobot/api/auth.py
+++ b/src/cryptobot/api/auth.py
@@ -3,7 +3,7 @@
 NestJS의 AuthGuard + JwtStrategy와 동일한 역할.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
 from fastapi import Depends, HTTPException, status
@@ -43,7 +43,7 @@ def hash_password(password: str) -> str:
 def create_access_token(data: dict) -> str:
     """JWT 토큰 생성."""
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(hours=ACCESS_TOKEN_EXPIRE_HOURS)
+    expire = datetime.now(timezone.utc) + timedelta(hours=ACCESS_TOKEN_EXPIRE_HOURS)
     to_encode["exp"] = expire
     return jwt.encode(to_encode, get_jwt_secret(), algorithm=ALGORITHM)
 

--- a/src/cryptobot/api/deps.py
+++ b/src/cryptobot/api/deps.py
@@ -13,10 +13,13 @@ from cryptobot.data.recorder import DataRecorder
 from cryptobot.data.strategy_repository import StrategyRepository
 
 _thread_local = threading.local()
+_test_db_override: Database | None = None
 
 
 def get_db() -> Database:
     """스레드별 DB 커넥션. FastAPI 워커 스레드에서 안전하게 사용."""
+    if _test_db_override is not None:
+        return _test_db_override
     if not hasattr(_thread_local, "db") or _thread_local.db is None:
         _thread_local.db = Database(config.bot.db_path)
         _thread_local.db.initialize()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,13 +26,12 @@ def _test_db():
     )
     db.commit()
 
-    # deps 모듈의 DB를 테스트 DB로 교체
-    old_db = deps._db
-    deps._db = db
+    # 테스트 DB 오버라이드
+    deps._test_db_override = db
 
     yield db
 
-    deps._db = old_db
+    deps._test_db_override = None
     db.close()
 
 
@@ -80,7 +79,7 @@ def test_unauthorized(client):
 def test_get_strategies(client, auth_header):
     response = client.get("/api/strategies", headers=auth_header)
     assert response.status_code == 200
-    assert len(response.json()) == 9
+    assert len(response.json()) == 10
 
 
 def test_get_active_strategies(client, auth_header):


### PR DESCRIPTION
## Summary
- **test_api.py 11개 테스트 복구** — `deps._test_db_override` 방식으로 테스트 DB 주입
- **NewsPage/SignalsPage 페이지네이션 수정** — `totalPages` → `pages` prop 이름 일치
- **DashboardPage 타입 안전성** — `PositionsResponse`에 `positions[]` 추가, `as any` 제거
- **DashboardPage 에러 복원력** — `Promise.all` `.catch()` 추가
- **SignalsPage JSON.parse 안전성** — try-catch 추가
- **ParamsEditor useEffect 의존성** — `strategy.default_params_json` 추가
- **auth.py deprecation 수정** — `datetime.utcnow()` → `datetime.now(timezone.utc)`
- **테스트 assertion 갱신** — 전략 수 9 → 10

Related: #96

## Test plan
- [x] `pytest tests/` — 101 passed, 0 failed
- [x] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)