### PR TITLE
hotfix: LLM 코인 추천 반영 (#104)

### DIFF
--- a/src/cryptobot/bot/coin_manager.py
+++ b/src/cryptobot/bot/coin_manager.py
@@ -1,9 +1,9 @@
 """멀티코인 관리 — 코인 목록 갱신 + collector 관리."""
 
+import json
 import logging
 import time as _time
 
-from cryptobot.bot.config import config
 from cryptobot.data.collector import DataCollector
 
 logger = logging.getLogger(__name__)
@@ -57,14 +57,41 @@ class CoinManager:
 
             if top_coins:
                 new_coins = [c["ticker"] for c in top_coins]
+
+                # LLM 추천 코인 반영
+                llm_add = self._get_llm_coins("llm_add_coins")
+                llm_remove = set(self._get_llm_coins("llm_remove_coins"))
+
+                for coin in llm_add:
+                    if coin not in new_coins and coin not in self.CORE_COINS:
+                        new_coins.append(coin)
+
+                # LLM 제거 추천 (CORE + 보유 중 코인은 제외 불가)
+                held_coins = self._get_held_coins()
+                new_coins = [
+                    c for c in new_coins
+                    if c not in llm_remove or c in self.CORE_COINS or c in held_coins
+                ]
+
+                # CORE 코인 보장
                 for core in reversed(self.CORE_COINS):
                     if core not in new_coins:
                         new_coins.insert(0, core)
 
-                held_coins = self._get_held_coins()
+                # 보유 중 코인 보장
                 for held in held_coins:
                     if held not in new_coins:
                         new_coins.append(held)
+
+                # max_coins 제한 (CORE + 보유 코인은 항상 포함)
+                max_coins = int(self._config.get("max_coins", "5"))
+                if len(new_coins) > max_coins:
+                    protected = set(self.CORE_COINS) | set(held_coins)
+                    trimmed = [c for c in new_coins if c in protected]
+                    for c in new_coins:
+                        if c not in protected and len(trimmed) < max_coins:
+                            trimmed.append(c)
+                    new_coins = trimmed
 
                 if set(new_coins) != set(self.active_coins):
                     logger.info("코인 목록 갱신: %s → %s", self.active_coins, new_coins)
@@ -85,6 +112,16 @@ class CoinManager:
             """
         ).fetchall()
         return [r["coin"] for r in rows]
+
+    def _get_llm_coins(self, key: str) -> list[str]:
+        """bot_config에서 LLM 추천 코인 목록 조회."""
+        row = self._db.execute("SELECT value FROM bot_config WHERE key = ?", (key,)).fetchone()
+        if row:
+            try:
+                return json.loads(dict(row)["value"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return []
 
     def get_category(self, coin: str) -> str:
         """코인 카테고리 (core / alt)."""

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -547,6 +547,22 @@ _DEFAULT_BOT_CONFIG = [
         "description": "현재가가 이 값 이상인 코인만 선별.",
     },
     {
+        "key": "llm_add_coins",
+        "value": "[]",
+        "value_type": "string",
+        "category": "coin",
+        "display_name": "LLM 추천 추가 코인",
+        "description": "LLM이 추천한 추가 모니터링 코인 목록 (JSON 배열).",
+    },
+    {
+        "key": "llm_remove_coins",
+        "value": "[]",
+        "value_type": "string",
+        "category": "coin",
+        "display_name": "LLM 추천 제거 코인",
+        "description": "LLM이 추천한 모니터링 제외 코인 목록 (JSON 배열).",
+    },
+    {
         "key": "k_value",
         "value": "0.5",
         "value_type": "float",

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -867,6 +867,26 @@ class LLMAnalyzer:
                 (json.dumps(strategy_params), now, strategy),
             )
 
+        # 코인 추천 반영
+        coin_recs = result.get("coin_recommendations", {})
+        add_coins = coin_recs.get("add", [])
+        remove_coins = coin_recs.get("remove", [])
+        if add_coins or remove_coins:
+            # KRW- 접두사 보장
+            add_coins = [c if c.startswith("KRW-") else f"KRW-{c}" for c in add_coins]
+            remove_coins = [c if c.startswith("KRW-") else f"KRW-{c}" for c in remove_coins]
+
+            self._db.execute(
+                "UPDATE bot_config SET value = ?, updated_at = ? WHERE key = 'llm_add_coins'",
+                (json.dumps(add_coins), now),
+            )
+            self._db.execute(
+                "UPDATE bot_config SET value = ?, updated_at = ? WHERE key = 'llm_remove_coins'",
+                (json.dumps(remove_coins), now),
+            )
+            reasons = coin_recs.get("reasons", "")
+            logger.info("LLM 코인 추천: add=%s, remove=%s (%s)", add_coins, remove_coins, reasons)
+
         # after 스냅샷 (전략 파라미터 포함)
         after = {k: str(v) for k, v in config_map.items() if v is not None}
         if result.get("allow_trading") is not None:


### PR DESCRIPTION
## Summary
- LLM `coin_recommendations` (add/remove)가 완전히 무시되던 버그 수정
- `analyzer.py`: 추천 코인을 `bot_config`에 저장
- `coin_manager.py`: 스캐너 결과 + LLM 추천 머지, 제거 추천 반영
- `database.py`: `llm_add_coins`, `llm_remove_coins` 설정 키 추가
- CORE 코인(BTC/ETH/XRP) + 보유 코인은 LLM이 제거 불가 (안전장치)

Related: #104

## Test plan
- [x] pytest 101 passed
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)