### PR TITLE
feat: 보안 강화 + Vercel 배포 준비 (#116)

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_BASE_URL = "http://localhost:8000/api";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
 
 const client = axios.create({
   baseURL: API_BASE_URL,
@@ -17,6 +17,11 @@ client.interceptors.request.use((config) => {
 client.interceptors.response.use(
   (response) => response,
   (error) => {
+    // 401 → 토큰 만료, 로그인 페이지로
+    if (error.response?.status === 401 && !error.config?.url?.includes("/auth/login")) {
+      localStorage.removeItem("token");
+      window.location.href = "/login";
+    }
     // 500 에러는 서버 로그로 전송
     if (error.response?.status >= 500) {
       const url = error.config?.url || "unknown";

--- a/admin/src/components/strategies/ParamsEditor.tsx
+++ b/admin/src/components/strategies/ParamsEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { updateStrategyParams, getStrategySimulation } from "../../api/strategies";
-import type { Strategy, StrategySimulation } from "../../types/strategies";
+import type { StrategySimulation } from "../../api/strategies";
+import type { Strategy } from "../../types/strategies";
 import { getParamDesc } from "../../utils/paramDescriptions";
 import SimulationResult from "./SimulationResult";
 

--- a/admin/src/components/strategies/StrategyCard.tsx
+++ b/admin/src/components/strategies/StrategyCard.tsx
@@ -10,7 +10,7 @@ interface Props {
   onDeactivate: () => void;
 }
 
-export default function StrategyCard({ strategy: s, hasSwitching, activeCoins, onEdit, onActivate, onDeactivate }: Props) {
+export default function StrategyCard({ strategy: s, hasSwitching: _hasSwitching, activeCoins, onEdit, onActivate: _onActivate, onDeactivate: _onDeactivate }: Props) {
   return (
     <div
       className="strategy-card"

--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -8,7 +8,7 @@ import type { BalanceResponse, PositionsResponse, BalanceHistory } from "../type
 import type { MarketSnapshot } from "../types/market";
 import type { Trade } from "../types/trades";
 import StatCard from "../components/StatCard";
-import { formatKRW, formatPercent, formatNumber, formatDateTime } from "../utils/format";
+import { formatKRW, formatPercent, formatDateTime } from "../utils/format";
 import { getMarketStateKR } from "../utils/indicatorDescriptions";
 
 interface LLMDecision {
@@ -22,7 +22,7 @@ interface LLMDecision {
 export default function DashboardPage() {
   const [balance, setBalance] = useState<BalanceResponse | null>(null);
   const [positions, setPositions] = useState<PositionsResponse | null>(null);
-  const [history, setHistory] = useState<BalanceHistory[]>([]);
+  const [, setHistory] = useState<BalanceHistory[]>([]);
   const [market, setMarket] = useState<MarketSnapshot | null>(null);
   const [recentTrades, setRecentTrades] = useState<Trade[]>([]);
   const [monitoredCoins, setMonitoredCoins] = useState<any[]>([]);
@@ -65,7 +65,6 @@ export default function DashboardPage() {
 
   if (loading) return <div className="loading">로딩 중...</div>;
 
-  const marketState = market && "market_state" in market ? market.market_state : null;
   const fg = newsStats?.fear_greed;
 
   return (

--- a/admin/src/pages/StrategiesPage.tsx
+++ b/admin/src/pages/StrategiesPage.tsx
@@ -17,8 +17,8 @@ const MARKET_SECTIONS = [
 
 export default function StrategiesPage() {
   const [strategies, setStrategies] = useState<Strategy[]>([]);
-  const [activations, setActivations] = useState<StrategyActivation[]>([]);
-  const [coinConfigs, setCoinConfigs] = useState<CoinStrategyConfig[]>([]);
+  const [, setActivations] = useState<StrategyActivation[]>([]);
+  const [, setCoinConfigs] = useState<CoinStrategyConfig[]>([]);
   const [coinStrategies, setCoinStrategies] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [confirm, setConfirm] = useState<{ name: string; action: "activate" | "deactivate" } | null>(null);

--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/((?!assets/).*)", "destination": "/index.html" }
+  ]
+}

--- a/src/cryptobot/api/deps.py
+++ b/src/cryptobot/api/deps.py
@@ -36,7 +36,13 @@ def get_strategy_repo() -> StrategyRepository:
 
 @lru_cache
 def get_jwt_secret() -> str:
-    """JWT 시크릿 키. .env의 JWT_SECRET 또는 기본값."""
+    """JWT 시크릿 키. .env의 JWT_SECRET 필수."""
     import os
 
-    return os.getenv("JWT_SECRET", "cryptobot-dev-secret-change-in-production")
+    secret = os.getenv("JWT_SECRET", "")
+    if not secret:
+        import secrets
+
+        secret = secrets.token_urlsafe(32)
+        logging.getLogger(__name__).warning("JWT_SECRET 미설정 — 임시 시크릿 생성 (재시작 시 세션 만료)")
+    return secret

--- a/src/cryptobot/api/main.py
+++ b/src/cryptobot/api/main.py
@@ -6,8 +6,11 @@ NestJS의 main.ts (bootstrap) + AppModule과 동일.
     uvicorn cryptobot.api.main:app --reload --port 8000
 """
 
-from fastapi import FastAPI
+import os
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, signals, strategies, trades
 from cryptobot.logging_config import setup_logging
@@ -23,18 +26,34 @@ app = FastAPI(
     openapi_url="/api/openapi.json",
 )
 
-# CORS — React dev 서버 (localhost:5173) 허용
+# CORS — 개발 + 프로덕션 도메인 허용
+_cors_origins = [
+    "http://localhost:5173",
+    "http://localhost:3000",
+    "http://127.0.0.1:5173",
+]
+_extra_origins = os.getenv("CORS_ORIGINS", "")
+if _extra_origins:
+    _cors_origins.extend([o.strip() for o in _extra_origins.split(",") if o.strip()])
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://localhost:3000",
-        "http://127.0.0.1:5173",
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
 )
+
+
+# 보안 헤더 미들웨어
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    """보안 헤더 추가."""
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
 
 # 라우트 등록 — NestJS의 imports: [AuthModule, TradeModule, ...]
 app.include_router(auth.router)
@@ -108,9 +127,22 @@ class _WebErrorReport(_BaseModel):
     user_agent: str | None = None
 
 
+import time as _time
+from collections import defaultdict as _defaultdict
+
+_error_report_attempts: dict[str, list[float]] = _defaultdict(list)
+
+
 @app.post("/api/error/report", tags=["system"])
-def report_web_error(error: _WebErrorReport):
-    """Admin 웹에서 발생한 에러를 서버 로그로 기록."""
+def report_web_error(request: Request, error: _WebErrorReport):
+    """Admin 웹에서 발생한 에러를 서버 로그로 기록 (rate limit: 10회/분)."""
+    client_ip = request.client.host if request.client else "unknown"
+    now = _time.time()
+    _error_report_attempts[client_ip] = [t for t in _error_report_attempts[client_ip] if now - t < 60]
+    if len(_error_report_attempts[client_ip]) >= 10:
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+    _error_report_attempts[client_ip].append(now)
+
     _web_logger.error(
         "[WEB] %s | source=%s | url=%s\n  %s",
         error.message,

--- a/src/cryptobot/api/routes/auth.py
+++ b/src/cryptobot/api/routes/auth.py
@@ -3,9 +3,12 @@
 NestJS의 AuthController와 동일.
 """
 
+import logging
+import time
+from collections import defaultdict
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from cryptobot.api.auth import (
@@ -17,16 +20,36 @@ from cryptobot.api.auth import (
 )
 from cryptobot.api.deps import get_db
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+# 로그인 rate limit (IP당 5회/분)
+_login_attempts: dict[str, list[float]] = defaultdict(list)
+LOGIN_MAX_ATTEMPTS = 5
+LOGIN_WINDOW_SECONDS = 60
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(form_data: OAuth2PasswordRequestForm = Depends()):
+def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends()):
     """로그인 → JWT 토큰 발급."""
+    client_ip = request.client.host if request.client else "unknown"
+
+    # rate limit 체크
+    now = time.time()
+    _login_attempts[client_ip] = [t for t in _login_attempts[client_ip] if now - t < LOGIN_WINDOW_SECONDS]
+    if len(_login_attempts[client_ip]) >= LOGIN_MAX_ATTEMPTS:
+        logger.warning("로그인 rate limit 초과: %s", client_ip)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="로그인 시도 횟수 초과. 1분 후 다시 시도하세요.",
+        )
+    _login_attempts[client_ip].append(now)
+
     db = get_db()
     row = db.execute("SELECT * FROM users WHERE username = ?", (form_data.username,)).fetchone()
 
     if row is None or not verify_password(form_data.password, row["password_hash"]):
+        logger.warning("로그인 실패: user=%s ip=%s", form_data.username, client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="아이디 또는 비밀번호가 올바르지 않습니다",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,10 @@ def _test_db():
     # 테스트 DB 오버라이드
     deps._test_db_override = db
 
+    # rate limit 초기화
+    from cryptobot.api.routes.auth import _login_attempts
+    _login_attempts.clear()
+
     yield db
 
     deps._test_db_override = None


### PR DESCRIPTION
## Summary
- 로그인 rate limit (5회/분)
- JWT 시크릿 강화
- CORS 프로덕션 도메인 환경변수 지원
- 보안 헤더 (X-Frame-Options, X-Content-Type-Options)
- API URL 환경변수화 (VITE_API_BASE_URL)
- vercel.json SPA 라우팅
- 빌드 에러 수정

Related: #116

## Test plan
- [x] pytest 101 passed
- [x] `npm run build` 성공
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)