### PR TITLE
feat: 공개 웹 — 비로그인 대시보드 (#120)

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -1,8 +1,8 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AuthProvider } from "./context/AuthContext";
-import ProtectedRoute from "./components/ProtectedRoute";
+import { AuthProvider, useAuth } from "./context/AuthContext";
 import Layout from "./components/Layout";
 import LoginPage from "./pages/LoginPage";
+import PublicDashboardPage from "./pages/PublicDashboardPage";
 import DashboardPage from "./pages/DashboardPage";
 import TradesPage from "./pages/TradesPage";
 import StrategiesPage from "./pages/StrategiesPage";
@@ -12,30 +12,48 @@ import SignalsPage from "./pages/SignalsPage";
 import LLMPage from "./pages/LLMPage";
 import NewsPage from "./pages/NewsPage";
 
+function AppRoutes() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) return <div className="loading">로딩 중...</div>;
+
+  // 비로그인: 공개 대시보드 (Layout 포함)
+  if (!isAuthenticated) {
+    return (
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<PublicDashboardPage />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    );
+  }
+
+  // 로그인: 관리자 전체 기능
+  return (
+    <Routes>
+      <Route path="/login" element={<Navigate to="/" replace />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/trades" element={<TradesPage />} />
+        <Route path="/strategies" element={<StrategiesPage />} />
+        <Route path="/profit" element={<ProfitAnalysisPage />} />
+        <Route path="/signals" element={<SignalsPage />} />
+        <Route path="/news" element={<NewsPage />} />
+        <Route path="/llm" element={<LLMPage />} />
+        <Route path="/config" element={<ConfigPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route
-            element={
-              <ProtectedRoute>
-                <Layout />
-              </ProtectedRoute>
-            }
-          >
-            <Route path="/" element={<DashboardPage />} />
-            <Route path="/trades" element={<TradesPage />} />
-            <Route path="/strategies" element={<StrategiesPage />} />
-            <Route path="/profit" element={<ProfitAnalysisPage />} />
-            <Route path="/signals" element={<SignalsPage />} />
-            <Route path="/news" element={<NewsPage />} />
-            <Route path="/llm" element={<LLMPage />} />
-            <Route path="/config" element={<ConfigPage />} />
-          </Route>
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+        <AppRoutes />
       </AuthProvider>
     </BrowserRouter>
   );

--- a/admin/src/components/Layout.tsx
+++ b/admin/src/components/Layout.tsx
@@ -1,8 +1,9 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 
 export default function Layout() {
-  const { user, logout } = useAuth();
+  const { user, isAuthenticated, logout } = useAuth();
+  const navigate = useNavigate();
 
   return (
     <div className="app-layout">
@@ -12,33 +13,43 @@ export default function Layout() {
           <NavLink to="/" end className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
             대시보드
           </NavLink>
-          <NavLink to="/trades" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            매매 내역
-          </NavLink>
-          <NavLink to="/strategies" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            전략 관리
-          </NavLink>
-          <NavLink to="/signals" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            매매 신호
-          </NavLink>
-          <NavLink to="/news" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            뉴스
-          </NavLink>
-          <NavLink to="/profit" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            수익률 분석
-          </NavLink>
-          <NavLink to="/llm" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            LLM 관리
-          </NavLink>
-          <NavLink to="/config" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
-            설정
-          </NavLink>
+          {isAuthenticated && (
+            <>
+              <NavLink to="/trades" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                매매 내역
+              </NavLink>
+              <NavLink to="/strategies" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                전략 관리
+              </NavLink>
+              <NavLink to="/signals" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                매매 신호
+              </NavLink>
+              <NavLink to="/news" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                뉴스
+              </NavLink>
+              <NavLink to="/profit" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                수익률 분석
+              </NavLink>
+              <NavLink to="/llm" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                LLM 관리
+              </NavLink>
+              <NavLink to="/config" className={({ isActive }) => `sidebar-link${isActive ? " active" : ""}`}>
+                설정
+              </NavLink>
+            </>
+          )}
         </nav>
         <div className="sidebar-footer">
-          <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 8 }}>
-            {user?.display_name || user?.username}
-          </div>
-          <button onClick={logout}>로그아웃</button>
+          {isAuthenticated ? (
+            <>
+              <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 8 }}>
+                {user?.display_name || user?.username}
+              </div>
+              <button onClick={logout}>로그아웃</button>
+            </>
+          ) : (
+            <button onClick={() => navigate("/login")}>관리자 로그인</button>
+          )}
         </div>
       </aside>
       <main className="main-content">

--- a/admin/src/pages/PublicDashboardPage.tsx
+++ b/admin/src/pages/PublicDashboardPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import StatCard from "../components/StatCard";
+import { formatPercent, formatDateTime } from "../utils/format";
+import { getMarketStateKR } from "../utils/indicatorDescriptions";
+
+interface PublicSummary {
+  total_trades: number;
+  win_rate: number;
+  avg_profit_pct: number;
+  today_trades: number;
+  today_win_rate: number;
+  today_avg_pct: number;
+}
+
+interface PublicTrade {
+  coin: string;
+  side: string;
+  strategy: string;
+  trigger_reason: string;
+  profit_pct: number | null;
+  timestamp: string;
+  hold_minutes: number | null;
+}
+
+interface PublicAnalysis {
+  market_state: string;
+  aggression: number;
+  summary: string;
+  timestamp: string;
+}
+
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
+
+export default function PublicDashboardPage() {
+  const { isAuthenticated } = useAuth();
+  const [summary, setSummary] = useState<PublicSummary | null>(null);
+  const [trades, setTrades] = useState<PublicTrade[]>([]);
+  const [analysis, setAnalysis] = useState<PublicAnalysis[]>([]);
+  const [news, setNews] = useState<any[]>([]);
+  const [fg, setFg] = useState<any>(null);
+  const [portfolio, setPortfolio] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAll = useCallback(() => {
+    const base = API.replace(/\/api$/, "");
+    Promise.all([
+      fetch(`${base}/api/public/summary`).then(r => r.json()).catch(() => null),
+      fetch(`${base}/api/public/trades?limit=10`).then(r => r.json()).catch(() => []),
+      fetch(`${base}/api/public/analysis?limit=3`).then(r => r.json()).catch(() => []),
+      fetch(`${base}/api/public/news?limit=6`).then(r => r.json()).catch(() => ({ news: [], fear_greed: null })),
+      fetch(`${base}/api/public/portfolio`).then(r => r.json()).catch(() => ({ positions: [] })),
+    ]).then(([s, t, a, n, p]) => {
+      setSummary(s);
+      setTrades(t);
+      setAnalysis(a);
+      setNews(n?.news || []);
+      setFg(n?.fear_greed || null);
+      setPortfolio(p?.positions || []);
+      setLoading(false);
+    }).catch(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(fetchAll, 60000);
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  if (loading) return <div className="loading">로딩 중...</div>;
+
+  return (
+    <div>
+      <div className="page-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <h1>CryptoBot Dashboard</h1>
+          <p>AI 기반 코인 자동매매 실시간 현황</p>
+        </div>
+        {!isAuthenticated && (
+          <Link to="/login" className="btn btn-primary btn-sm">관리자 로그인</Link>
+        )}
+      </div>
+
+      {/* KPI */}
+      {summary && (
+        <div className="kpi-grid">
+          <StatCard label="총 거래" value={`${summary.total_trades}건`} sub={`오늘 ${summary.today_trades}건`} />
+          <StatCard
+            label="전체 승률"
+            value={`${summary.win_rate}%`}
+            valueClass={summary.win_rate >= 50 ? "positive" : "negative"}
+            sub={`오늘 ${summary.today_win_rate}%`}
+          />
+          <StatCard
+            label="평균 수익률"
+            value={formatPercent(summary.avg_profit_pct)}
+            valueClass={summary.avg_profit_pct >= 0 ? "positive" : "negative"}
+            sub={`오늘 ${formatPercent(summary.today_avg_pct)}`}
+          />
+          <StatCard
+            label="공포/탐욕"
+            value={fg ? `${fg.value}` : "-"}
+            sub={fg ? (fg.classification === "Extreme Fear" ? "극도 공포" : fg.classification === "Fear" ? "공포" : fg.classification === "Neutral" ? "중립" : fg.classification === "Greed" ? "탐욕" : "극도 탐욕") : ""}
+            valueClass={fg && fg.value <= 25 ? "negative" : fg && fg.value >= 75 ? "positive" : ""}
+          />
+        </div>
+      )}
+
+      <div className="grid-2">
+        {/* AI 분석 */}
+        <div className="card">
+          <div className="card-title">AI 시장 분석</div>
+          {analysis.length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              {analysis.map((a, i) => (
+                <div key={i} style={{ padding: "10px 0", borderBottom: i < analysis.length - 1 ? "1px solid var(--border)" : "none" }}>
+                  <div style={{ display: "flex", gap: 6, marginBottom: 4 }}>
+                    <span className={`badge ${a.market_state === "bullish" ? "badge-green" : a.market_state === "bearish" ? "badge-red" : "badge-yellow"}`}>
+                      {getMarketStateKR(a.market_state)}
+                    </span>
+                    <span style={{ fontSize: 10, color: "var(--text-muted)" }}>{formatDateTime(a.timestamp)}</span>
+                  </div>
+                  <div style={{ fontSize: 13, lineHeight: 1.6 }}>{a.summary}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">분석 데이터 없음</div>
+          )}
+        </div>
+
+        {/* 보유 포트폴리오 */}
+        <div className="card">
+          <div className="card-title">포트폴리오 비중</div>
+          {portfolio.length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {portfolio.map((p: any) => (
+                <div key={p.coin} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <span style={{ fontWeight: 600 }}>{p.coin?.replace("KRW-", "")}</span>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, marginLeft: 16 }}>
+                    <div style={{ flex: 1, background: "var(--bg-secondary)", borderRadius: 4, height: 20 }}>
+                      <div style={{ width: `${p.weight_pct}%`, background: "#4a9eff", borderRadius: 4, height: "100%", minWidth: 2 }} />
+                    </div>
+                    <span style={{ fontSize: 13, fontWeight: 600, minWidth: 45, textAlign: "right" }}>{p.weight_pct}%</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">보유 포지션 없음</div>
+          )}
+        </div>
+      </div>
+
+      {/* 최근 매매 */}
+      <div className="card" style={{ marginTop: 24 }}>
+        <div className="card-title">최근 매매</div>
+        {trades.length > 0 ? (
+          <div className="table-container">
+            <table>
+              <thead>
+                <tr>
+                  <th>시간</th>
+                  <th>종목</th>
+                  <th>방향</th>
+                  <th>전략</th>
+                  <th>수익률</th>
+                  <th>사유</th>
+                </tr>
+              </thead>
+              <tbody>
+                {trades.map((t, i) => (
+                  <tr key={i}>
+                    <td style={{ fontSize: 11 }}>{formatDateTime(t.timestamp).replace(/\d{4}\. /, "")}</td>
+                    <td style={{ fontWeight: 600 }}>{t.coin?.replace("KRW-", "")}</td>
+                    <td>
+                      <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10 }}>
+                        {t.side === "buy" ? "매수" : "매도"}
+                      </span>
+                    </td>
+                    <td style={{ fontSize: 11 }}>{t.strategy}</td>
+                    <td className={t.profit_pct != null ? (t.profit_pct >= 0 ? "positive" : "negative") : ""} style={{ fontWeight: 600 }}>
+                      {t.profit_pct != null ? formatPercent(t.profit_pct) : "-"}
+                    </td>
+                    <td style={{ fontSize: 10, color: "var(--text-muted)", maxWidth: 150, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {t.trigger_reason || "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="empty-state">매매 내역 없음</div>
+        )}
+      </div>
+
+      {/* 뉴스 */}
+      {news.length > 0 && (
+        <div className="card" style={{ marginTop: 24 }}>
+          <div className="card-title">최근 뉴스</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {news.map((n: any, i: number) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", padding: "6px 0", borderBottom: i < news.length - 1 ? "1px solid var(--border)" : "none" }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", gap: 6, marginBottom: 2 }}>
+                    <span className={`badge ${n.sentiment_keyword === "positive" ? "badge-green" : n.sentiment_keyword === "negative" ? "badge-red" : "badge-yellow"}`} style={{ fontSize: 9 }}>
+                      {n.sentiment_keyword === "positive" ? "긍정" : n.sentiment_keyword === "negative" ? "부정" : "중립"}
+                    </span>
+                    <span style={{ fontSize: 10, color: "var(--text-muted)" }}>{n.source}</span>
+                  </div>
+                  <a href={n.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "var(--text-primary)", textDecoration: "none", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "block" }}>
+                    {n.title}
+                  </a>
+                </div>
+                <span style={{ fontSize: 10, color: "var(--text-muted)", whiteSpace: "nowrap", marginLeft: 8 }}>
+                  {formatDateTime(n.published_at).replace(/\d{4}\. /, "")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/cryptobot/api/main.py
+++ b/src/cryptobot/api/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, signals, strategies, trades
+from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, public, signals, strategies, trades
 from cryptobot.logging_config import setup_logging
 
 setup_logging("api", "INFO")
@@ -58,7 +58,8 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-XSS-Protection"] = "1; mode=block"
     return response
 
-# 라우트 등록 — NestJS의 imports: [AuthModule, TradeModule, ...]
+# 라우트 등록
+app.include_router(public.router)  # 공개 API (인증 불필요)
 app.include_router(auth.router)
 app.include_router(trades.router)
 app.include_router(balance.router)

--- a/src/cryptobot/api/routes/public.py
+++ b/src/cryptobot/api/routes/public.py
@@ -1,0 +1,223 @@
+"""공개 API — 인증 불필요, 비율 기반 데이터만 반환.
+
+절대값(원, 수량)은 반환하지 않음. 비율(%)만 제공.
+"""
+
+import time
+from collections import defaultdict
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
+
+from cryptobot.api.deps import get_db
+
+router = APIRouter(prefix="/api/public", tags=["public"])
+
+# Rate limit (IP당 30회/분)
+_rate_limits: dict[str, list[float]] = defaultdict(list)
+RATE_LIMIT = 30
+RATE_WINDOW = 60
+
+
+def _check_rate_limit(request: Request) -> bool:
+    """rate limit 체크. 초과 시 False."""
+    ip = request.client.host if request.client else "unknown"
+    now = time.time()
+    _rate_limits[ip] = [t for t in _rate_limits[ip] if now - t < RATE_WINDOW]
+    if len(_rate_limits[ip]) >= RATE_LIMIT:
+        return False
+    _rate_limits[ip].append(now)
+    return True
+
+
+@router.get("/summary")
+def get_public_summary(request: Request):
+    """수익률 요약 — 승률, 수익률, 거래 수."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+
+    # 전체 성과
+    row = db.execute(
+        """
+        SELECT
+            COUNT(*) as total_sells,
+            SUM(CASE WHEN profit_krw > 0 THEN 1 ELSE 0 END) as wins,
+            ROUND(AVG(profit_pct), 2) as avg_profit_pct
+        FROM trades WHERE side = 'sell'
+        """
+    ).fetchone()
+    r = dict(row) if row else {}
+    total = r.get("total_sells", 0) or 0
+    wins = r.get("wins", 0) or 0
+
+    # 오늘 성과
+    today_row = db.execute(
+        """
+        SELECT
+            COUNT(*) as sells,
+            SUM(CASE WHEN profit_krw > 0 THEN 1 ELSE 0 END) as wins,
+            ROUND(AVG(profit_pct), 2) as avg_pct
+        FROM trades WHERE side = 'sell' AND DATE(timestamp) = DATE('now')
+        """
+    ).fetchone()
+    t = dict(today_row) if today_row else {}
+    today_sells = t.get("sells", 0) or 0
+    today_wins = t.get("wins", 0) or 0
+
+    return {
+        "total_trades": total,
+        "win_rate": round(wins / total * 100, 1) if total > 0 else 0,
+        "avg_profit_pct": r.get("avg_profit_pct", 0) or 0,
+        "today_trades": today_sells,
+        "today_win_rate": round(today_wins / today_sells * 100, 1) if today_sells > 0 else 0,
+        "today_avg_pct": t.get("avg_pct", 0) or 0,
+    }
+
+
+@router.get("/trades")
+def get_public_trades(request: Request, limit: int = Query(20, ge=1, le=50)):
+    """최근 매매 — 금액 제거, 비중(%)만."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+    rows = db.execute(
+        """
+        SELECT coin, side, strategy, trigger_reason, profit_pct,
+            timestamp, hold_duration_minutes
+        FROM trades
+        ORDER BY id DESC LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+
+    return [
+        {
+            "coin": dict(r)["coin"],
+            "side": dict(r)["side"],
+            "strategy": dict(r)["strategy"],
+            "trigger_reason": dict(r)["trigger_reason"],
+            "profit_pct": dict(r)["profit_pct"] if dict(r)["side"] == "sell" else None,
+            "timestamp": dict(r)["timestamp"],
+            "hold_minutes": dict(r)["hold_duration_minutes"],
+        }
+        for r in rows
+    ]
+
+
+@router.get("/portfolio")
+def get_public_portfolio(request: Request):
+    """보유 코인 비중 (%) — 절대값 없음."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+    rows = db.execute(
+        """
+        SELECT coin, total_krw FROM trades t
+        WHERE side = 'buy'
+        AND NOT EXISTS (
+            SELECT 1 FROM trades s WHERE s.buy_trade_id = t.id AND s.side = 'sell'
+        )
+        """
+    ).fetchall()
+
+    if not rows:
+        return {"positions": [], "total_coins": 0}
+
+    total = sum(dict(r)["total_krw"] for r in rows)
+    positions = []
+    for r in rows:
+        d = dict(r)
+        pct = round(d["total_krw"] / total * 100, 1) if total > 0 else 0
+        positions.append({"coin": d["coin"], "weight_pct": pct})
+
+    return {"positions": positions, "total_coins": len(positions)}
+
+
+@router.get("/analysis")
+def get_public_analysis(request: Request, limit: int = Query(3, ge=1, le=10)):
+    """LLM 분석 요약 — 프롬프트/비용 제외."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+    rows = db.execute(
+        """
+        SELECT output_market_state, output_aggression, output_reasoning, timestamp
+        FROM llm_decisions ORDER BY id DESC LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+
+    results = []
+    for r in rows:
+        d = dict(r)
+        reasoning = d["output_reasoning"] or ""
+        # 첫 문단만 (상세 근거는 비공개)
+        summary = reasoning.split("\n\n")[0] if reasoning else ""
+        results.append({
+            "market_state": d["output_market_state"],
+            "aggression": d["output_aggression"],
+            "summary": summary,
+            "timestamp": d["timestamp"],
+        })
+
+    return results
+
+
+@router.get("/news")
+def get_public_news(request: Request, limit: int = Query(10, ge=1, le=30)):
+    """최근 뉴스 + F&G — 공개 데이터."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+
+    news = db.execute(
+        "SELECT title, source, sentiment_keyword, published_at, url FROM news_articles ORDER BY id DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+
+    fg = db.execute(
+        "SELECT value, classification, timestamp FROM fear_greed_index ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+
+    return {
+        "news": [dict(r) for r in news],
+        "fear_greed": dict(fg) if fg else None,
+    }
+
+
+@router.get("/daily-returns")
+def get_public_daily_returns(request: Request, days: int = Query(30, ge=1, le=90)):
+    """일별 수익률 (%) — 금액 없음."""
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    db = get_db()
+    rows = db.execute(
+        """
+        SELECT
+            DATE(timestamp) as date,
+            ROUND(SUM(CASE WHEN side='sell' THEN profit_pct ELSE 0 END), 2) as daily_pnl_pct,
+            COUNT(*) as total_trades,
+            SUM(CASE WHEN side='sell' AND profit_krw > 0 THEN 1 ELSE 0 END) as wins,
+            SUM(CASE WHEN side='sell' THEN 1 ELSE 0 END) as sells
+        FROM trades
+        WHERE timestamp >= datetime('now', ?)
+        GROUP BY DATE(timestamp) ORDER BY date
+        """,
+        (f"-{days} days",),
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        d = dict(r)
+        sells = d.pop("sells", 0) or 0
+        wins = d.pop("wins", 0) or 0
+        d["win_rate"] = round(wins / sells * 100, 1) if sells > 0 else 0
+        result.append(d)
+    return result


### PR DESCRIPTION
## Summary
- 비로그인 시 공개 대시보드 표시 (수익률%, 매매 내역, AI 분석 요약, 뉴스)
- 절대값(원, 수량) 비공개, 비율(%)만 공개
- `/api/public/` 엔드포인트 6개 (rate limit 30회/분)
- 로그인 시 기존 관리자 기능 전체 사용

Related: #120

## Test plan
- [x] pytest 101 passed
- [x] `npm run build` 성공
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)