### PR TITLE
feat: 백테스트 파라미터 스윕 + LLM 프롬프트 개선 + DB 동시접근 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ build/
 # 임시 문서 파일
 docs/temp/
 
-# 사업 계획 (비공개)
-docs/business/
+# 비공개 계획
+docs/private/
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ logger = logging.getLogger(__name__)
 - 테스트 파일: `tests/` 디렉토리에 `test_*.py`
 - API 호출이 필요한 테스트는 mock 사용 (실제 API 호출 금지)
 - 매매 전략 로직은 반드시 단위 테스트 작성
+- **전략 전환 테스트 필수**: 전략 추가/수정/LLM 프롬프트 변경 시 `pytest tests/test_llm_strategy_switch.py -v` 실행 필수.
+  이 테스트는 DB에서 전략을 동적으로 가져오므로 새 전략 추가 시 자동으로 커버됨.
 
 ### DB
 

--- a/scripts/migrate_add_backtest_results.sql
+++ b/scripts/migrate_add_backtest_results.sql
@@ -1,0 +1,21 @@
+-- 백테스트 결과 저장 테이블
+CREATE TABLE IF NOT EXISTS backtest_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_date DATE NOT NULL,
+    strategy_name TEXT NOT NULL,
+    coin TEXT NOT NULL,
+    period TEXT NOT NULL,
+    num_trades INTEGER NOT NULL,
+    win_rate REAL NOT NULL,
+    total_return_pct REAL NOT NULL,
+    max_drawdown_pct REAL NOT NULL,
+    sharpe_ratio REAL NOT NULL,
+    avg_profit_pct REAL NOT NULL,
+    avg_loss_pct REAL NOT NULL,
+    best_trade_pct REAL NOT NULL,
+    worst_trade_pct REAL NOT NULL,
+    params_json TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_bt_run_date ON backtest_results(run_date, strategy_name, coin);

--- a/scripts/migrate_add_reconciliation.sql
+++ b/scripts/migrate_add_reconciliation.sql
@@ -1,0 +1,6 @@
+-- 거래 정합성 검증 컬럼 추가 마이그레이션
+-- 실행: sqlite3 data/cryptobot.db < scripts/migrate_add_reconciliation.sql
+
+ALTER TABLE trades ADD COLUMN order_uuid TEXT;
+ALTER TABLE trades ADD COLUMN reconciled INTEGER DEFAULT 0;  -- 0: 미검증, 1: 일치, 2: 보정됨
+ALTER TABLE trades ADD COLUMN reconciled_at DATETIME;

--- a/scripts/reconcile_trades.py
+++ b/scripts/reconcile_trades.py
@@ -1,0 +1,73 @@
+"""기존 거래 일괄 보정 스크립트.
+
+order_uuid 없는 기존 거래는 보정 불가 → 현재 오차를 로그로 기록.
+order_uuid 있는 거래는 업비트 API로 실체결가 확인 후 보정.
+
+사용법:
+    python -m scripts.reconcile_trades
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# 프로젝트 루트를 경로에 추가
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from cryptobot.bot.config import config
+from cryptobot.bot.health_checker import HealthChecker
+from cryptobot.bot.trader import Trader
+from cryptobot.data.database import Database
+from cryptobot.logging_config import setup_logging
+
+setup_logging("reconcile", "INFO")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """기존 거래 정합성 보정 실행."""
+    db = Database(config.bot.db_path)
+    db.initialize()
+
+    # 전체 거래 통계
+    total = db.execute("SELECT COUNT(*) FROM trades").fetchone()[0]
+    with_uuid = db.execute("SELECT COUNT(*) FROM trades WHERE order_uuid IS NOT NULL").fetchone()[0]
+    without_uuid = db.execute("SELECT COUNT(*) FROM trades WHERE order_uuid IS NULL").fetchone()[0]
+    already_reconciled = db.execute("SELECT COUNT(*) FROM trades WHERE reconciled > 0").fetchone()[0]
+
+    logger.info("=== 거래 정합성 보정 시작 ===")
+    logger.info("전체 거래: %d건", total)
+    logger.info("  - order_uuid 있음: %d건 (보정 가능)", with_uuid)
+    logger.info("  - order_uuid 없음: %d건 (보정 불가)", without_uuid)
+    logger.info("  - 이미 검증됨: %d건", already_reconciled)
+
+    if without_uuid > 0:
+        # 보정 불가 거래의 오차 추정
+        row = db.execute(
+            """
+            SELECT
+                SUM(CASE WHEN side = 'sell' THEN profit_krw ELSE 0 END) as total_profit
+            FROM trades
+            WHERE order_uuid IS NULL AND side = 'sell' AND profit_krw IS NOT NULL
+            """
+        ).fetchone()
+        estimated_profit = row[0] if row and row[0] else 0
+        logger.info("보정 불가 거래의 DB 기록 기준 누적 수익: %.0f원 (실제와 차이 있을 수 있음)", estimated_profit)
+
+    # order_uuid가 있는 미검증 거래 보정
+    trader = Trader()
+    if not trader.is_ready:
+        logger.error("업비트 API Key 미설정 — 보정 불가")
+        db.close()
+        return
+
+    checker = HealthChecker(db, trader)
+    result = checker.reconcile_trades()
+    logger.info("보정 결과: %s", result)
+
+    db.close()
+    logger.info("=== 거래 정합성 보정 완료 ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""백테스트 CLI 러너.
+
+단일 실행:
+    python scripts/run_backtest.py --strategy volatility_breakout --coin KRW-BTC
+
+파라미터 스윕:
+    python scripts/run_backtest.py --strategy rsi_mean_reversion --coin KRW-BTC \\
+        --sweep "stop_loss_pct=-3,-5,-7 trailing_stop_pct=-2,-3,-5"
+"""
+
+import argparse
+import itertools
+import logging
+import sys
+from pathlib import Path
+
+# 프로젝트 루트를 sys.path에 추가
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from cryptobot.backtest.engine import BacktestEngine  # noqa: E402
+from cryptobot.backtest.result import BacktestResult  # noqa: E402
+from cryptobot.bot.strategy_selector import STRATEGY_CLASSES  # noqa: E402
+from cryptobot.strategies.base import BaseStrategy, StrategyParams  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = str(PROJECT_ROOT / "data" / "cryptobot.db")
+
+
+def parse_sweep(sweep_str: str) -> dict[str, list[float]]:
+    """스윕 문자열을 파싱한다.
+
+    Args:
+        sweep_str: "stop_loss_pct=-3,-5,-7 trailing_stop_pct=-2,-3,-5"
+
+    Returns:
+        {"stop_loss_pct": [-3.0, -5.0, -7.0], "trailing_stop_pct": [-2.0, -3.0, -5.0]}
+    """
+    result: dict[str, list[float]] = {}
+    for token in sweep_str.split():
+        key, values = token.split("=")
+        result[key] = [float(v) for v in values.split(",")]
+    return result
+
+
+def create_strategy(strategy_name: str, params_override: dict | None = None) -> BaseStrategy:
+    """전략 인스턴스를 생성한다.
+
+    Args:
+        strategy_name: 전략 식별자
+        params_override: 오버라이드할 파라미터 dict
+
+    Returns:
+        전략 인스턴스
+    """
+    cls = STRATEGY_CLASSES.get(strategy_name)
+    if cls is None:
+        available = ", ".join(sorted(STRATEGY_CLASSES.keys()))
+        raise ValueError(f"알 수 없는 전략: {strategy_name} (가능: {available})")
+
+    params = StrategyParams()
+    if params_override:
+        for key, value in params_override.items():
+            if hasattr(params, key):
+                setattr(params, key, value)
+            else:
+                params.extra[key] = value
+
+    return cls(params)
+
+
+def format_result_table(results: list[BacktestResult]) -> str:
+    """결과를 정렬된 테이블 문자열로 변환한다."""
+    if not results:
+        return "결과 없음"
+
+    # total_return 내림차순 정렬
+    results.sort(key=lambda r: r.total_return_pct, reverse=True)
+
+    cols = ["stop_loss", "trail_stop", "trades", "win_rate", "return%", "max_dd%", "sharpe"]
+    header = f"{cols[0]:>10}  {cols[1]:>10}  {cols[2]:>6}  {cols[3]:>8}  {cols[4]:>8}  {cols[5]:>8}  {cols[6]:>7}"
+    sep = "-" * len(header)
+    lines = [header, sep]
+
+    for r in results:
+        stop_loss = r.params.get("stop_loss_pct", "N/A")
+        trail_stop = r.params.get("trailing_stop_pct", "N/A")
+        lines.append(
+            f"{stop_loss:>10}  {trail_stop:>10}  {r.num_trades:>6}  {r.win_rate:>7.1f}%  "
+            f"{r.total_return_pct:>+7.1f}%  {r.max_drawdown_pct:>7.1f}%  {r.sharpe_ratio:>7.2f}"
+        )
+
+    return "\n".join(lines)
+
+
+def run_single(strategy_name: str, coin: str, db_path: str) -> BacktestResult:
+    """단일 백테스트 실행."""
+    strategy = create_strategy(strategy_name)
+    engine = BacktestEngine.from_db(db_path, coin, strategy)
+    return engine.run()
+
+
+def run_sweep(
+    strategy_name: str, coin: str, db_path: str, sweep_str: str,
+) -> list[BacktestResult]:
+    """파라미터 스윕 실행."""
+    sweep_params = parse_sweep(sweep_str)
+    keys = list(sweep_params.keys())
+    value_lists = [sweep_params[k] for k in keys]
+
+    results: list[BacktestResult] = []
+    combos = list(itertools.product(*value_lists))
+    logger.info("스윕 조합 %d개 실행", len(combos))
+
+    for combo in combos:
+        override = dict(zip(keys, combo))
+        strategy = create_strategy(strategy_name, override)
+        engine = BacktestEngine.from_db(db_path, coin, strategy)
+        result = engine.run()
+        results.append(result)
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="백테스트 CLI 러너")
+    parser.add_argument("--strategy", required=True, help="전략 이름")
+    parser.add_argument("--coin", default="KRW-BTC", help="종목 코드 (기본: KRW-BTC)")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH, help="DB 경로")
+    parser.add_argument(
+        "--sweep", default=None,
+        help='파라미터 스윕 (예: "stop_loss_pct=-3,-5,-7 trailing_stop_pct=-2,-3,-5")',
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="상세 로그 출력")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.sweep:
+        results = run_sweep(args.strategy, args.coin, args.db, args.sweep)
+    else:
+        result = run_single(args.strategy, args.coin, args.db)
+        results = [result]
+
+    # 결과 출력
+    r0 = results[0]
+    print(f"\n=== {r0.strategy_name} / {r0.coin} ({r0.period}) ===\n")
+    print(format_result_table(results))
+
+    # 단일 실행 시 거래 상세
+    if len(results) == 1 and results[0].num_trades > 0:
+        print(f"\n--- 거래 상세 ({results[0].num_trades}건) ---")
+        for i, t in enumerate(results[0].trades, 1):
+            print(
+                f"  {i:>2}. {t.entry_date} → {t.exit_date}  "
+                f"{t.entry_price:>12,.0f} → {t.exit_price:>12,.0f}  "
+                f"net {t.net_pnl_pct:>+6.2f}%  ({t.hold_days}일)  "
+                f"[{t.entry_reason} → {t.exit_reason}]"
+            )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cryptobot/backtest/__init__.py
+++ b/src/cryptobot/backtest/__init__.py
@@ -1,0 +1,6 @@
+"""백테스트 엔진 패키지."""
+
+from cryptobot.backtest.engine import BacktestEngine
+from cryptobot.backtest.result import BacktestResult, Trade
+
+__all__ = ["BacktestEngine", "BacktestResult", "Trade"]

--- a/src/cryptobot/backtest/engine.py
+++ b/src/cryptobot/backtest/engine.py
@@ -1,0 +1,182 @@
+"""백테스트 시뮬레이션 엔진.
+
+전략 인스턴스의 check_buy/check_sell을 직접 호출하여
+라이브 봇과 동일한 로직으로 시뮬레이션한다.
+"""
+
+import logging
+import sqlite3
+
+import pandas as pd
+
+from cryptobot.backtest.result import BacktestResult, Trade
+from cryptobot.strategies.base import BaseStrategy
+
+logger = logging.getLogger(__name__)
+
+# 업비트 매수/매도 수수료 (편도)
+DEFAULT_FEE_RATE = 0.0005
+
+# 지표 계산용 최소 데이터 행 수
+MIN_WARMUP_ROWS = 20
+
+
+class BacktestEngine:
+    """OHLCV 일봉 데이터로 전략을 시뮬레이션한다.
+
+    Args:
+        strategy: 매매 전략 인스턴스
+        df: OHLCV DataFrame (date, open, high, low, close, volume)
+        coin: 종목 코드 (예: "KRW-BTC")
+        fee_rate: 편도 수수료율 (기본 0.05%)
+    """
+
+    def __init__(
+        self,
+        strategy: BaseStrategy,
+        df: pd.DataFrame,
+        coin: str,
+        fee_rate: float = DEFAULT_FEE_RATE,
+    ) -> None:
+        self.strategy = strategy
+        self.df = df.reset_index(drop=True)
+        self.coin = coin
+        self.fee_rate = fee_rate
+        self.round_trip_fee_pct = fee_rate * 2 * 100  # 왕복 수수료 %
+
+    @classmethod
+    def from_db(
+        cls,
+        db_path: str,
+        coin: str,
+        strategy: BaseStrategy,
+        fee_rate: float = DEFAULT_FEE_RATE,
+    ) -> "BacktestEngine":
+        """SQLite DB에서 OHLCV 데이터를 로드하여 엔진 생성.
+
+        Args:
+            db_path: SQLite 파일 경로
+            coin: 종목 코드
+            strategy: 전략 인스턴스
+            fee_rate: 편도 수수료율
+
+        Returns:
+            BacktestEngine 인스턴스
+        """
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        df = pd.read_sql_query(
+            "SELECT date, open, high, low, close, volume FROM ohlcv_daily "
+            "WHERE coin = ? ORDER BY date ASC",
+            conn,
+            params=(coin,),
+        )
+        conn.close()
+
+        if df.empty:
+            raise ValueError(f"DB에 {coin}의 ohlcv_daily 데이터가 없습니다: {db_path}")
+
+        logger.info("DB에서 %s 일봉 %d건 로드 (%s ~ %s)", coin, len(df), df["date"].iloc[0], df["date"].iloc[-1])
+        return cls(strategy=strategy, df=df, coin=coin, fee_rate=fee_rate)
+
+    def run(self) -> BacktestResult:
+        """시뮬레이션 실행.
+
+        Returns:
+            BacktestResult 통계 및 거래 목록
+        """
+        trades: list[Trade] = []
+        df = self.df
+        n = len(df)
+
+        # 포지션 상태
+        in_position = False
+        entry_price = 0.0
+        entry_date = ""
+        entry_reason = ""
+
+        for i in range(MIN_WARMUP_ROWS, n):
+            current_price = df.iloc[i]["close"]
+            current_date = str(df.iloc[i]["date"])
+            window = df.iloc[: i + 1]
+
+            if not in_position:
+                signal = self.strategy.check_buy(window, current_price)
+                if signal.signal_type == "buy":
+                    in_position = True
+                    entry_price = current_price
+                    entry_date = current_date
+                    entry_reason = signal.reason
+                    self.strategy._highest_price = current_price
+            else:
+                # 보유 일수 → 분 변환 후 전략에 설정
+                days_held = i - self._entry_index
+                self.strategy._hold_minutes = days_held * 1440
+
+                signal = self.strategy.check_sell(window, current_price, entry_price)
+                if signal.signal_type == "sell":
+                    trade = self._make_trade(
+                        entry_date, current_date, entry_price, current_price,
+                        days_held, entry_reason, signal.reason,
+                    )
+                    trades.append(trade)
+                    self.strategy.reset()
+                    in_position = False
+
+            # entry_index 기록 (포지션 진입 시점)
+            if in_position and entry_date == current_date:
+                self._entry_index = i
+
+        # 미청산 포지션 강제 청산
+        if in_position:
+            last_price = df.iloc[-1]["close"]
+            last_date = str(df.iloc[-1]["date"])
+            days_held = (n - 1) - self._entry_index
+            trade = self._make_trade(
+                entry_date, last_date, entry_price, last_price,
+                days_held, entry_reason, "백테스트 종료 (강제 청산)",
+            )
+            trades.append(trade)
+            self.strategy.reset()
+
+        period = f"{df['date'].iloc[0]} ~ {df['date'].iloc[-1]}"
+        params_dict = {
+            "stop_loss_pct": self.strategy.params.stop_loss_pct,
+            "trailing_stop_pct": self.strategy.params.trailing_stop_pct,
+            **self.strategy.params.extra,
+        }
+
+        return BacktestResult(
+            strategy_name=self.strategy.info().name,
+            coin=self.coin,
+            params=params_dict,
+            period=period,
+            trades=trades,
+        )
+
+    def _make_trade(
+        self,
+        entry_date: str,
+        exit_date: str,
+        entry_price: float,
+        exit_price: float,
+        hold_days: int,
+        entry_reason: str,
+        exit_reason: str,
+    ) -> Trade:
+        """Trade 데이터클래스 생성."""
+        pnl_pct = (exit_price - entry_price) / entry_price * 100
+        net_pnl_pct = pnl_pct - self.round_trip_fee_pct
+
+        return Trade(
+            coin=self.coin,
+            entry_date=entry_date,
+            exit_date=exit_date,
+            entry_price=round(entry_price, 2),
+            exit_price=round(exit_price, 2),
+            pnl_pct=round(pnl_pct, 2),
+            net_pnl_pct=round(net_pnl_pct, 2),
+            hold_days=hold_days,
+            entry_reason=entry_reason,
+            exit_reason=exit_reason,
+        )

--- a/src/cryptobot/backtest/reporter.py
+++ b/src/cryptobot/backtest/reporter.py
@@ -1,0 +1,248 @@
+"""주간 백테스트 리포터.
+
+매주 일요일 02:00에 전 전략 × 전 코인 조합으로 백테스트를 실행하고:
+1. 결과를 backtest_results 테이블에 저장
+2. Slack으로 요약 리포트 전송
+"""
+
+import itertools
+import json
+import logging
+from datetime import date
+
+from cryptobot.backtest.engine import BacktestEngine
+from cryptobot.backtest.result import BacktestResult
+from cryptobot.strategies.base import StrategyParams
+
+logger = logging.getLogger(__name__)
+
+# 전략별 핵심 파라미터 스윕 범위 — 조합 폭발 방지를 위해 핵심 1~2개만
+SWEEP_CONFIGS: dict[str, dict[str, list]] = {
+    "volatility_breakout": {"k_value": [0.3, 0.5, 0.7]},
+    "ma_crossover": {"short_period": [5, 10], "long_period": [20, 40]},
+    "macd": {"fast": [8, 12], "slow": [21, 26]},
+    "supertrend": {"st_multiplier": [2.0, 3.0, 4.0]},
+    "rsi_mean_reversion": {"oversold": [25, 30, 35]},
+    "bollinger_bands": {"bb_std": [1.5, 2.0, 2.5]},
+    "grid_trading": {"grid_count": [5, 10, 15]},
+    "breakout_momentum": {"entry_period": [10, 20, 30]},
+    "bollinger_squeeze": {"bb_std": [1.5, 2.0, 2.5]},
+    "bb_rsi_combined": {"rsi_oversold": [25, 30, 35], "bb_std": [1.5, 2.0]},
+}
+
+
+class BacktestReporter:
+    """전 전략 백테스트 실행 + DB 저장 + Slack 알림."""
+
+    def __init__(self, db, db_path: str, notifier=None) -> None:
+        self._db = db
+        self._db_path = db_path
+        self._notifier = notifier
+
+    def run_all(self, coins: list[str] | None = None) -> dict:
+        """모든 전략 × 코인 조합으로 백테스트 실행.
+
+        Args:
+            coins: 대상 코인 목록. None이면 DB의 전 코인.
+
+        Returns:
+            코인별 BacktestResult 목록 dict
+        """
+        from cryptobot.bot.strategy_selector import STRATEGY_CLASSES
+
+        if coins is None:
+            coins = self._get_coins_from_db()
+
+        if not coins:
+            logger.warning("백테스트 대상 코인 없음")
+            return {}
+
+        run_date = date.today()
+        all_results: dict[str, list[BacktestResult]] = {}
+
+        for coin in coins:
+            coin_results: list[BacktestResult] = []
+
+            for name, cls in STRATEGY_CLASSES.items():
+                base_params = self._get_default_params(name)
+                sweep = SWEEP_CONFIGS.get(name, {})
+                combos = self._generate_sweep_combos(base_params, sweep) if sweep else [base_params]
+
+                for params_override in combos:
+                    try:
+                        params = StrategyParams(extra=params_override)
+                        strategy = cls(params)
+                        engine = BacktestEngine.from_db(self._db_path, coin, strategy)
+                        result = engine.run()
+                        coin_results.append(result)
+                        self._save_result(run_date, result)
+                        param_str = self._format_key_params(result.params, name)
+                        logger.info(
+                            "백테스트 완료: %s × %s%s → %d건, %.1f%%",
+                            coin, name, param_str, result.num_trades, result.total_return_pct,
+                        )
+                    except Exception as e:
+                        logger.warning("백테스트 스킵: %s × %s — %s", coin, name, e)
+
+            if coin_results:
+                coin_results.sort(key=lambda r: r.total_return_pct, reverse=True)
+                all_results[coin] = coin_results
+
+        self._db.commit()
+
+        if all_results and self._notifier:
+            self._send_slack(all_results)
+
+        total_count = sum(len(v) for v in all_results.values())
+        logger.info("주간 백테스트 완료: %d개 코인, %d개 결과", len(all_results), total_count)
+        return all_results
+
+    def _get_coins_from_db(self) -> list[str]:
+        """DB에서 OHLCV 데이터가 있는 코인 목록 조회."""
+        rows = self._db.execute("SELECT DISTINCT coin FROM ohlcv_daily").fetchall()
+        return [dict(r)["coin"] for r in rows]
+
+    def _get_default_params(self, strategy_name: str) -> dict:
+        """DB에서 전략 기본 파라미터 조회."""
+        row = self._db.execute(
+            "SELECT default_params_json FROM strategies WHERE name = ?",
+            (strategy_name,),
+        ).fetchone()
+        if row and dict(row)["default_params_json"]:
+            try:
+                return json.loads(dict(row)["default_params_json"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return {}
+
+    @staticmethod
+    def _generate_sweep_combos(base_params: dict, sweep: dict[str, list]) -> list[dict]:
+        """기본 파라미터에 스윕 조합을 머지하여 반환.
+
+        Args:
+            base_params: 전략 기본 파라미터
+            sweep: {파라미터명: [값 리스트]} 형태의 스윕 설정
+
+        Returns:
+            머지된 파라미터 dict 리스트
+        """
+        keys = list(sweep.keys())
+        value_lists = [sweep[k] for k in keys]
+        combos = []
+        for combo in itertools.product(*value_lists):
+            merged = {**base_params, **dict(zip(keys, combo))}
+            combos.append(merged)
+        return combos
+
+    @staticmethod
+    def _format_key_params(params: dict, strategy_name: str) -> str:
+        """스윕 대상 파라미터만 간결하게 표시.
+
+        Args:
+            params: 전략 파라미터 dict
+            strategy_name: 전략 이름
+
+        Returns:
+            "(k=0.7)" 형태 문자열. 스윕 설정이 없으면 빈 문자열.
+        """
+        sweep = SWEEP_CONFIGS.get(strategy_name, {})
+        if not sweep:
+            return ""
+        parts = []
+        # 파라미터명 약축: 긴 이름은 짧게
+        short_names = {
+            "k_value": "k",
+            "short_period": "short",
+            "long_period": "long",
+            "st_multiplier": "st_m",
+            "rsi_oversold": "rsi_os",
+            "bb_std": "bb",
+            "grid_count": "grid",
+            "entry_period": "entry",
+            "oversold": "os",
+        }
+        for key in sweep:
+            if key in params:
+                short = short_names.get(key, key)
+                val = params[key]
+                # 정수면 정수로, 소수면 소수로
+                if isinstance(val, float) and val == int(val):
+                    parts.append(f"{short}={int(val)}")
+                else:
+                    parts.append(f"{short}={val}")
+        return f"({','.join(parts)})" if parts else ""
+
+    def _save_result(self, run_date: date, result: BacktestResult) -> None:
+        """백테스트 결과를 DB에 저장."""
+        self._db.execute(
+            """INSERT INTO backtest_results (
+                run_date, strategy_name, coin, period,
+                num_trades, win_rate, total_return_pct, max_drawdown_pct,
+                sharpe_ratio, avg_profit_pct, avg_loss_pct,
+                best_trade_pct, worst_trade_pct, params_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                run_date.isoformat(),
+                result.strategy_name,
+                result.coin,
+                result.period,
+                result.num_trades,
+                result.win_rate,
+                result.total_return_pct,
+                result.max_drawdown_pct,
+                result.sharpe_ratio,
+                result.avg_profit_pct,
+                result.avg_loss_pct,
+                result.best_trade_pct,
+                result.worst_trade_pct,
+                json.dumps(result.params, ensure_ascii=False),
+            ),
+        )
+
+    def _send_slack(self, all_results: dict[str, list[BacktestResult]]) -> None:
+        """Slack 백테스트 요약 전송."""
+        lines = ["🔬 *주간 백테스트 리포트*\n"]
+
+        # 현재 활성 전략 조회
+        active_row = self._db.execute("SELECT name FROM strategies WHERE is_active = TRUE LIMIT 1").fetchone()
+        active_strategy = dict(active_row)["name"] if active_row else None
+
+        for coin, results in all_results.items():
+            if not results:
+                continue
+
+            period = results[0].period
+            # 기간 일수 계산
+            try:
+                dates = period.split(" ~ ")
+                from datetime import datetime
+                d1 = datetime.strptime(dates[0], "%Y-%m-%d")
+                d2 = datetime.strptime(dates[1], "%Y-%m-%d")
+                days = (d2 - d1).days
+                period_str = f"{dates[0]} ~ {dates[1]}, {days}일"
+            except Exception:
+                period_str = period
+
+            lines.append(f"📊 *{coin}* ({period_str})")
+
+            medals = ["🥇", "🥈", "🥉"]
+            for i, r in enumerate(results):
+                medal = medals[i] if i < len(medals) else "  "
+                param_str = self._format_key_params(r.params, r.strategy_name)
+                entry = f"  {medal} {r.strategy_name}{param_str}: {r.total_return_pct:+.1f}%"
+                entry += f" | {r.num_trades}건 승률{r.win_rate:.0f}%"
+                entry += f" | MDD {r.max_drawdown_pct:.1f}%"
+                if r.sharpe_ratio != 0:
+                    entry += f" | sharpe {r.sharpe_ratio:.2f}"
+                lines.append(entry)
+
+            # 활성 전략 vs 백테스트 1위 비교
+            if active_strategy:
+                top = results[0].strategy_name
+                if active_strategy == top:
+                    lines.append(f"  💡 현재 활성: {active_strategy} → 백테스트 1위 ✅")
+                else:
+                    lines.append(f"  💡 현재 활성: {active_strategy} → 백테스트 1위: {top}")
+            lines.append("")
+
+        self._notifier.send("\n".join(lines))

--- a/src/cryptobot/backtest/result.py
+++ b/src/cryptobot/backtest/result.py
@@ -1,0 +1,126 @@
+"""백테스트 결과 데이터 구조."""
+
+import math
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Trade:
+    """개별 거래 기록."""
+
+    coin: str
+    entry_date: str
+    exit_date: str
+    entry_price: float
+    exit_price: float
+    pnl_pct: float  # 총 가격변동 %
+    net_pnl_pct: float  # 수수료 차감 후
+    hold_days: int
+    entry_reason: str
+    exit_reason: str
+
+
+@dataclass
+class BacktestResult:
+    """백테스트 결과 요약.
+
+    Args:
+        strategy_name: 전략 식별자
+        coin: 종목 코드
+        params: 전략 파라미터 dict
+        period: 테스트 기간 문자열
+        trades: 거래 목록
+    """
+
+    strategy_name: str
+    coin: str
+    params: dict
+    period: str
+    trades: list[Trade]
+
+    # __post_init__에서 계산되는 통계
+    total_return_pct: float = field(init=False)
+    win_rate: float = field(init=False)
+    num_trades: int = field(init=False)
+    avg_profit_pct: float = field(init=False)
+    avg_loss_pct: float = field(init=False)
+    max_drawdown_pct: float = field(init=False)
+    sharpe_ratio: float = field(init=False)
+    best_trade_pct: float = field(init=False)
+    worst_trade_pct: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.num_trades = len(self.trades)
+
+        if self.num_trades == 0:
+            self.total_return_pct = 0.0
+            self.win_rate = 0.0
+            self.avg_profit_pct = 0.0
+            self.avg_loss_pct = 0.0
+            self.max_drawdown_pct = 0.0
+            self.sharpe_ratio = 0.0
+            self.best_trade_pct = 0.0
+            self.worst_trade_pct = 0.0
+            return
+
+        pnls = [t.net_pnl_pct for t in self.trades]
+
+        # 복리 수익률
+        cumulative = 1.0
+        for p in pnls:
+            cumulative *= 1 + p / 100
+        self.total_return_pct = round((cumulative - 1) * 100, 2)
+
+        # 승률
+        wins = [p for p in pnls if p > 0]
+        losses = [p for p in pnls if p <= 0]
+        self.win_rate = round(len(wins) / self.num_trades * 100, 1)
+
+        # 평균 수익/손실
+        self.avg_profit_pct = round(sum(wins) / len(wins), 2) if wins else 0.0
+        self.avg_loss_pct = round(sum(losses) / len(losses), 2) if losses else 0.0
+
+        # 최대 낙폭 (누적 수익 곡선 기준)
+        self.max_drawdown_pct = self._calc_max_drawdown(pnls)
+
+        # 샤프 비율 (일별 수익률 기준)
+        self.sharpe_ratio = self._calc_sharpe(pnls)
+
+        # 최고/최저 거래
+        self.best_trade_pct = round(max(pnls), 2)
+        self.worst_trade_pct = round(min(pnls), 2)
+
+    @staticmethod
+    def _calc_max_drawdown(pnls: list[float]) -> float:
+        """누적 수익 곡선의 고점 대비 최대 하락률 계산."""
+        cumulative = 1.0
+        peak = 1.0
+        max_dd = 0.0
+
+        for p in pnls:
+            cumulative *= 1 + p / 100
+            if cumulative > peak:
+                peak = cumulative
+            dd = (cumulative - peak) / peak * 100
+            if dd < max_dd:
+                max_dd = dd
+
+        return round(max_dd, 2)
+
+    @staticmethod
+    def _calc_sharpe(pnls: list[float]) -> float:
+        """샤프 비율 계산 (연율화).
+
+        거래별 수익률을 일별 수익률로 간주하여 계산.
+        """
+        if len(pnls) < 2:
+            return 0.0
+
+        mean_r = sum(pnls) / len(pnls)
+        variance = sum((p - mean_r) ** 2 for p in pnls) / (len(pnls) - 1)
+        std_r = math.sqrt(variance)
+
+        if std_r == 0:
+            return 0.0
+
+        return round(mean_r / std_r * math.sqrt(365), 2)

--- a/src/cryptobot/bot/health_checker.py
+++ b/src/cryptobot/bot/health_checker.py
@@ -27,6 +27,8 @@ class HealthChecker:
         results = {}
 
         results["trade_integrity"] = self._check_trade_integrity()
+        results["trade_reconciliation"] = self.reconcile_trades()
+        results["balance_check"] = self._check_balance_consistency()
         results["news_collector"] = self._check_news_collector()
         results["pending_orders"] = self._check_pending_orders()
         results["llm_cost"] = self._check_llm_cost()
@@ -309,6 +311,257 @@ class HealthChecker:
         except Exception as e:
             logger.error("전략 일관성 체크 실패: %s", e)
             return {"status": "warning", "message": str(e)}
+
+    def reconcile_trades(self) -> dict:
+        """미검증 거래의 체결 정합성을 검증하고 보정한다.
+
+        order_uuid가 있는 미검증(reconciled=0) 거래를 업비트 API로 확인하여
+        실체결가와 DB 기록의 차이가 0.1% 이상이면 DB를 보정한다.
+
+        Returns:
+            검증 결과 dict
+        """
+        try:
+            if not self._trader or not self._trader.is_ready:
+                return {"status": "ok", "message": "API 미설정 — 스킵"}
+
+            # 미검증 거래 조회 (최근 7일, order_uuid 있는 건)
+            rows = self._db.execute(
+                """
+                SELECT id, coin, side, price, amount, total_krw, fee_krw, order_uuid, buy_trade_id
+                FROM trades
+                WHERE reconciled = 0
+                  AND order_uuid IS NOT NULL
+                  AND timestamp >= datetime('now', '-7 days')
+                ORDER BY id
+                """
+            ).fetchall()
+
+            if not rows:
+                return {"status": "ok", "checked": 0, "corrected": 0}
+
+            checked = 0
+            corrected = 0
+            now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+            for row in rows:
+                trade = dict(row)
+                detail = self._trader.get_order_detail(trade["order_uuid"])
+                if not detail:
+                    logger.warning("체결 상세 조회 실패 (trade_id=%d)", trade["id"])
+                    continue
+
+                checked += 1
+                db_price = trade["price"]
+                db_total = trade["total_krw"]
+                actual_price = detail["price"]
+                actual_total = detail["funds"]
+                actual_fee = detail["fee"]
+                actual_volume = detail["volume"]
+
+                # 오차율 계산
+                price_diff = abs(db_price - actual_price) / actual_price if actual_price > 0 else 0
+                total_diff = abs(db_total - actual_total) / actual_total if actual_total > 0 else 0
+
+                if price_diff > 0.001 or total_diff > 0.001:
+                    # DB 보정
+                    self._db.execute(
+                        """
+                        UPDATE trades
+                        SET price = ?, amount = ?, total_krw = ?, fee_krw = ?,
+                            reconciled = 2, reconciled_at = ?
+                        WHERE id = ?
+                        """,
+                        (actual_price, actual_volume, actual_total, actual_fee, now_str, trade["id"]),
+                    )
+                    corrected += 1
+                    logger.info(
+                        "거래 보정: id=%d %s 가격 %.0f→%.0f 금액 %.0f→%.0f",
+                        trade["id"], trade["side"], db_price, actual_price, db_total, actual_total,
+                    )
+
+                    # 매도 거래의 profit 재계산
+                    if trade["side"] == "sell" and trade["buy_trade_id"]:
+                        self._recalculate_profit(trade["id"], trade["buy_trade_id"])
+                else:
+                    # 일치 확인
+                    self._db.execute(
+                        "UPDATE trades SET reconciled = 1, reconciled_at = ? WHERE id = ?",
+                        (now_str, trade["id"]),
+                    )
+
+            self._db.commit()
+
+            result = {"status": "ok", "checked": checked, "corrected": corrected}
+            if corrected > 0:
+                result["status"] = "warning"
+                result["message"] = f"{corrected}건 보정됨 (총 {checked}건 검증)"
+                logger.warning("체결 정합성: %d건 보정 / %d건 검증", corrected, checked)
+            else:
+                logger.info("체결 정합성: %d건 검증 완료 — 이상 없음", checked)
+
+            return result
+        except Exception as e:
+            logger.error("체결 정합성 검증 실패: %s", e, exc_info=True)
+            return {"status": "warning", "message": str(e)}
+
+    def _recalculate_profit(self, sell_trade_id: int, buy_trade_id: int) -> None:
+        """보정된 매수/매도 값 기준으로 profit_krw, profit_pct를 재계산한다."""
+        try:
+            buy = self._db.execute(
+                "SELECT total_krw, fee_krw FROM trades WHERE id = ?", (buy_trade_id,)
+            ).fetchone()
+            sell = self._db.execute(
+                "SELECT total_krw, fee_krw FROM trades WHERE id = ?", (sell_trade_id,)
+            ).fetchone()
+
+            if not buy or not sell:
+                return
+
+            buy = dict(buy)
+            sell = dict(sell)
+            buy_cost = buy["total_krw"] + (buy["fee_krw"] or 0)
+            sell_revenue = sell["total_krw"] - (sell["fee_krw"] or 0)
+            profit_krw = round(sell_revenue - buy_cost, 2)
+            profit_pct = round(profit_krw / buy_cost * 100, 2) if buy_cost > 0 else 0
+
+            self._db.execute(
+                "UPDATE trades SET profit_krw = ?, profit_pct = ? WHERE id = ?",
+                (profit_krw, profit_pct, sell_trade_id),
+            )
+            logger.info("수익 재계산: sell_id=%d profit=%.0f원 (%.2f%%)", sell_trade_id, profit_krw, profit_pct)
+        except Exception as e:
+            logger.error("수익 재계산 실패 (sell_id=%d): %s", sell_trade_id, e)
+
+    def _check_balance_consistency(self) -> dict:
+        """DB 역산 잔고 vs 실제 업비트 KRW 잔고 비교.
+
+        차이 > 2%이면 미검증 거래를 즉시 재보정한 후 재확인.
+        재보정 후에도 차이 > 2%이면 Slack 경고.
+        """
+        try:
+            if not self._trader or not self._trader.is_ready:
+                return {"status": "ok", "message": "API 미설정 — 스킵"}
+
+            # 실제 업비트 자산 조회
+            actual_krw = self._trader.get_balance_krw()
+
+            import pyupbit
+            active_rows = self._db.execute(
+                """
+                SELECT coin, amount FROM trades t
+                WHERE side = 'buy'
+                AND NOT EXISTS (SELECT 1 FROM trades s WHERE s.buy_trade_id = t.id AND s.side = 'sell')
+                """
+            ).fetchall()
+            coin_value = 0
+            for ar in active_rows:
+                ad = dict(ar)
+                cp = pyupbit.get_current_price(ad["coin"])
+                if cp:
+                    coin_value += ad["amount"] * cp
+
+            total_actual = actual_krw + coin_value
+            logger.info("잔고 검증: KRW=%.0f 코인=%.0f 합계=%.0f", actual_krw, coin_value, total_actual)
+
+            # DB 기준 총자산 역산
+            db_total = self._calculate_db_total_asset()
+
+            if total_actual <= 0 or db_total <= 0:
+                return {"status": "ok", "krw_balance": actual_krw, "coin_value": coin_value, "total": total_actual}
+
+            diff_pct = abs(total_actual - db_total) / total_actual * 100
+
+            if diff_pct > 2.0:
+                logger.warning(
+                    "잔고 차이 %.1f%%: 실제=%.0f, DB 역산=%.0f → 미검증 거래 즉시 재보정",
+                    diff_pct, total_actual, db_total,
+                )
+                # 자동 복구: 미검증 거래 재보정
+                recon_result = self.reconcile_trades()
+                corrected = recon_result.get("corrected", 0)
+
+                if corrected > 0:
+                    # 재보정 후 재확인
+                    db_total_after = self._calculate_db_total_asset()
+                    diff_pct_after = abs(total_actual - db_total_after) / total_actual * 100
+                    logger.info(
+                        "재보정 후 잔고 차이: %.1f%% → %.1f%% (%d건 보정)",
+                        diff_pct, diff_pct_after, corrected,
+                    )
+
+                    if diff_pct_after > 2.0:
+                        msg = (
+                            f"잔고 차이 {diff_pct_after:.1f}%: "
+                            f"실제={total_actual:,.0f}원, DB={db_total_after:,.0f}원 "
+                            f"({corrected}건 보정 후)"
+                        )
+                        if self._notifier:
+                            self._notifier.send(f"⚠️ *잔고 불일치 경고*\n{msg}")
+                        return {"status": "warning", "message": msg, "diff_pct": diff_pct_after}
+
+                    return {
+                        "status": "ok",
+                        "message": f"자동 보정 완료 ({corrected}건): {diff_pct:.1f}% → {diff_pct_after:.1f}%",
+                        "krw_balance": actual_krw,
+                        "total": total_actual,
+                    }
+                else:
+                    msg = (
+                        f"잔고 차이 {diff_pct:.1f}%: "
+                        f"실제={total_actual:,.0f}원, DB={db_total:,.0f}원 (보정 가능 건 없음)"
+                    )
+                    if self._notifier:
+                        self._notifier.send(f"⚠️ *잔고 불일치 경고*\n{msg}")
+                    return {"status": "warning", "message": msg, "diff_pct": diff_pct}
+
+            return {"status": "ok", "krw_balance": actual_krw, "coin_value": coin_value, "total": total_actual}
+        except Exception as e:
+            logger.error("잔고 일관성 체크 실패: %s", e)
+            return {"status": "warning", "message": str(e)}
+
+    def _calculate_db_total_asset(self) -> float:
+        """DB 기록 기준 총자산을 역산한다."""
+        try:
+            import pyupbit
+
+            # 매도 수익 합산
+            row = self._db.execute(
+                """
+                SELECT
+                    COALESCE(SUM(CASE WHEN side = 'sell' THEN total_krw - fee_krw ELSE 0 END), 0)
+                    - COALESCE(SUM(CASE WHEN side = 'buy' THEN total_krw ELSE 0 END), 0)
+                    AS net_flow
+                FROM trades
+                """
+            ).fetchone()
+            net_flow = row[0] if row else 0
+
+            # 미매도 코인 DB 기록 가치
+            active_rows = self._db.execute(
+                """
+                SELECT coin, amount FROM trades t
+                WHERE side = 'buy'
+                AND NOT EXISTS (SELECT 1 FROM trades s WHERE s.buy_trade_id = t.id AND s.side = 'sell')
+                """
+            ).fetchall()
+            db_coin_value = 0
+            for ar in active_rows:
+                ad = dict(ar)
+                cp = pyupbit.get_current_price(ad["coin"])
+                if cp:
+                    db_coin_value += ad["amount"] * cp
+
+            # 최초 입금액이 없으므로 daily_reports의 starting_balance 참고
+            first_report = self._db.execute(
+                "SELECT starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
+            ).fetchone()
+            initial_balance = dict(first_report)["starting_balance_krw"] if first_report else 0
+
+            return initial_balance + net_flow + db_coin_value
+        except Exception as e:
+            logger.error("DB 총자산 역산 실패: %s", e)
+            return 0
 
     def _send_alert(self, results: dict) -> None:
         """이상 발견 시 Slack 알림."""

--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -65,7 +65,11 @@ class CryptoBot:
         self._scheduler.add_job(self._tick, "interval", seconds=self._tick_interval, id="main_tick")
         self._scheduler.add_job(self._daily_report, "cron", hour=0, minute=0, id="daily_report")
         self._scheduler.add_job(self._daily_health_check, "cron", hour=6, minute=0, id="daily_health")
+        self._scheduler.add_job(self._hourly_reconciliation, "interval", hours=1, id="hourly_reconciliation")
         self._scheduler.add_job(self._weekly_report, "cron", day_of_week="sun", hour=3, minute=0, id="weekly_report")
+        self._scheduler.add_job(
+            self._weekly_backtest, "cron", day_of_week="sun", hour=2, minute=0, id="weekly_backtest",
+        )
         self._scheduler.add_job(self._monthly_audit, "cron", day=1, hour=4, minute=0, id="monthly_audit")
         self._scheduler.add_job(self._llm_analyze, "interval", minutes=10, id="llm_analyze")
 
@@ -195,7 +199,7 @@ class CryptoBot:
         bal_before = bal  # 잔고 스냅샷
         order = self._trader.buy_market(coin, amount)
         if order.success:
-            tid = self._recorder.record_trade(coin=coin, side="buy", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, market_state_at_trade=snapshot.get("market_state"), btc_price_at_trade=price, rsi_at_trade=snapshot.get("rsi_14"))
+            tid = self._recorder.record_trade(coin=coin, side="buy", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, market_state_at_trade=snapshot.get("market_state"), btc_price_at_trade=price, rsi_at_trade=snapshot.get("rsi_14"), order_uuid=order.order_uuid)
             # DB 쓰기 검증
             verify = self._db.execute("SELECT id FROM trades WHERE id = ?", (tid,)).fetchone()
             if not verify:
@@ -247,7 +251,7 @@ class CryptoBot:
             bf = active_trade.get("fee_krw") or 0
             profit_krw = round((order.total_krw - order.fee_krw) - (active_trade["total_krw"] + bf), 2)
             profit_pct = round(profit_krw / (active_trade["total_krw"] + bf) * 100, 2) if (active_trade["total_krw"] + bf) > 0 else 0
-            tid = self._recorder.record_trade(coin=coin, side="sell", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, buy_trade_id=active_trade["id"], profit_pct=profit_pct, profit_krw=profit_krw, hold_duration_minutes=s._hold_minutes)
+            tid = self._recorder.record_trade(coin=coin, side="sell", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, buy_trade_id=active_trade["id"], profit_pct=profit_pct, profit_krw=profit_krw, hold_duration_minutes=s._hold_minutes, order_uuid=order.order_uuid)
             # DB 쓰기 검증
             verify = self._db.execute("SELECT id FROM trades WHERE id = ?", (tid,)).fetchone()
             if not verify:
@@ -360,6 +364,14 @@ class CryptoBot:
         except Exception as e:
             logger.error("헬스체크 에러: %s", e, exc_info=True)
 
+    def _hourly_reconciliation(self):
+        """매시간 체결 정합성 검증."""
+        try:
+            checker = HealthChecker(self._db, self._trader, self._notifier)
+            checker.reconcile_trades()
+        except Exception as e:
+            logger.error("체결 정합성 검증 에러: %s", e, exc_info=True)
+
     def _weekly_report(self):
         """주간 리포트 (일요일 03:00)."""
         try:
@@ -367,6 +379,16 @@ class CryptoBot:
             reporter.run_all()
         except Exception as e:
             logger.error("주간 리포트 에러: %s", e, exc_info=True)
+
+    def _weekly_backtest(self):
+        """주간 백테스트 (일요일 02:00)."""
+        try:
+            from cryptobot.backtest.reporter import BacktestReporter
+
+            reporter = BacktestReporter(self._db, config.bot.db_path, self._notifier)
+            reporter.run_all()
+        except Exception as e:
+            logger.error("주간 백테스트 에러: %s", e, exc_info=True)
 
     def _monthly_audit(self):
         """월간 감사 (매월 1일 04:00)."""

--- a/src/cryptobot/bot/trader.py
+++ b/src/cryptobot/bot/trader.py
@@ -28,6 +28,7 @@ class OrderResult:
     fee_krw: float
     raw_response: dict | None = None
     error: str | None = None
+    order_uuid: str | None = None
 
 
 class Trader:
@@ -115,31 +116,34 @@ class Trader:
             result = self._upbit.buy_market_order(coin, krw_amount)
             logger.info("매수 주문 실행: %s %s원", coin, f"{krw_amount:,.0f}")
 
-            price = self.get_current_price(coin)
-            fee = krw_amount * self.FEE_RATE
-            amount = (krw_amount - fee) / price
+            order_uuid = result.get("uuid") if isinstance(result, dict) else None
 
-            # 체결 검증 — 실제 잔고 확인 (실패해도 주문은 이미 나갔으므로 기록 필수)
-            actual_balance = amount  # 기본값: 계산된 수량
-            try:
-                import time as _time
-                _time.sleep(0.5)
-                actual_balance = self.get_balance_coin(coin)
-                if actual_balance <= 0:
-                    logger.error("매수 체결 검증 실패: %s 잔고=0 (주문 응답: %s)", coin, result)
-                    actual_balance = amount  # 폴백: 계산된 수량으로 기록
-            except Exception as e:
-                logger.warning("매수 체결 검증 에러: %s — 계산량으로 기록", e)
+            # 추정값 (폴백용)
+            est_price = self.get_current_price(coin)
+            est_fee = krw_amount * self.FEE_RATE
+            est_amount = (krw_amount - est_fee) / est_price
+
+            # 실체결가 조회
+            price, amount, total_krw, fee = est_price, est_amount, krw_amount, est_fee
+            if order_uuid:
+                trade_detail = self._fetch_order_detail(order_uuid)
+                if trade_detail:
+                    price = trade_detail["price"]
+                    amount = trade_detail["volume"]
+                    total_krw = trade_detail["funds"]
+                    fee = trade_detail["fee"]
+                    logger.info("매수 실체결가: %s %.0f원 × %.8f개 (수수료 %.0f원)", coin, price, amount, fee)
 
             return OrderResult(
                 success=True,
                 side="buy",
                 coin=coin,
                 price=price,
-                amount=actual_balance,
-                total_krw=krw_amount,
+                amount=amount,
+                total_krw=total_krw,
                 fee_krw=fee,
                 raw_response=result,
+                order_uuid=order_uuid,
             )
         except (InsufficientBalanceError, APIError):
             raise
@@ -174,32 +178,37 @@ class Trader:
                     error="매도 가능한 수량 없음",
                 )
 
-            price = self.get_current_price(coin)
             result = self._upbit.sell_market_order(coin, amount)
             logger.info("매도 주문 실행: %s %.8f개", coin, amount)
 
-            # 체결 검증 — 매도 후 잔고 확인 (실패해도 기록은 유지)
-            try:
-                import time as _time
-                _time.sleep(0.5)
-                remaining = self.get_balance_coin(coin)
-                if remaining > amount * 0.01:
-                    logger.warning("매도 부분 체결: %s 잔여 %.8f개", coin, remaining)
-            except Exception as e:
-                logger.warning("매도 체결 검증 에러: %s", e)
+            order_uuid = result.get("uuid") if isinstance(result, dict) else None
 
-            total_krw = price * amount
-            fee = total_krw * self.FEE_RATE
+            # 추정값 (폴백용)
+            est_price = self.get_current_price(coin)
+            est_total = est_price * amount
+            est_fee = est_total * self.FEE_RATE
+
+            # 실체결가 조회
+            price, sell_amount, total_krw, fee = est_price, amount, est_total, est_fee
+            if order_uuid:
+                trade_detail = self._fetch_order_detail(order_uuid)
+                if trade_detail:
+                    price = trade_detail["price"]
+                    sell_amount = trade_detail["volume"]
+                    total_krw = trade_detail["funds"]
+                    fee = trade_detail["fee"]
+                    logger.info("매도 실체결가: %s %.0f원 × %.8f개 (수수료 %.0f원)", coin, price, sell_amount, fee)
 
             return OrderResult(
                 success=True,
                 side="sell",
                 coin=coin,
                 price=price,
-                amount=amount,
+                amount=sell_amount,
                 total_krw=total_krw,
                 fee_krw=fee,
                 raw_response=result,
+                order_uuid=order_uuid,
             )
         except APIError:
             raise
@@ -226,6 +235,65 @@ class Trader:
             return len(orders)
         except Exception as e:
             raise APIError(f"주문 취소 실패: {e}") from e
+
+    def _fetch_order_detail(self, order_uuid: str, max_retries: int = 3) -> dict | None:
+        """주문 UUID로 실체결 상세를 조회한다.
+
+        Args:
+            order_uuid: 업비트 주문 UUID
+            max_retries: 최대 재시도 횟수
+
+        Returns:
+            {"price": 평균체결가, "volume": 체결수량, "funds": 체결금액, "fee": 수수료} 또는 None
+        """
+        import time as _time
+
+        for attempt in range(max_retries):
+            _time.sleep(0.5 * (attempt + 1))
+            try:
+                detail = self._upbit.get_individual_order(order_uuid)
+                if not isinstance(detail, dict):
+                    continue
+
+                trades = detail.get("trades", [])
+                state = detail.get("state", "")
+
+                if state not in ("done", "cancel") and not trades:
+                    logger.debug("주문 미체결 상태 (attempt %d): %s", attempt + 1, state)
+                    continue
+
+                if not trades:
+                    logger.warning("체결 내역 없음: uuid=%s, state=%s", order_uuid, state)
+                    return None
+
+                total_funds = sum(float(t.get("funds", 0)) for t in trades)
+                total_volume = sum(float(t.get("volume", 0)) for t in trades)
+                paid_fee = float(detail.get("paid_fee", 0))
+                avg_price = total_funds / total_volume if total_volume > 0 else 0
+
+                return {
+                    "price": avg_price,
+                    "volume": total_volume,
+                    "funds": total_funds,
+                    "fee": paid_fee,
+                }
+            except Exception as e:
+                logger.warning("체결 상세 조회 실패 (attempt %d): %s", attempt + 1, e)
+
+        logger.warning("체결 상세 조회 최종 실패: uuid=%s", order_uuid)
+        return None
+
+    def get_order_detail(self, order_uuid: str) -> dict | None:
+        """외부에서 주문 UUID로 체결 상세를 조회한다.
+
+        Args:
+            order_uuid: 업비트 주문 UUID
+
+        Returns:
+            {"price": 평균체결가, "volume": 체결수량, "funds": 체결금액, "fee": 수수료} 또는 None
+        """
+        self._ensure_ready()
+        return self._fetch_order_detail(order_uuid)
 
     def _ensure_ready(self) -> None:
         """API Key 설정 확인."""

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -93,6 +93,9 @@ CREATE TABLE IF NOT EXISTS trades (
     hold_duration_minutes INTEGER,
     strategy_params_json TEXT,
     strategy_selection_reason TEXT,
+    order_uuid TEXT,
+    reconciled INTEGER DEFAULT 0,
+    reconciled_at DATETIME,
     FOREIGN KEY (buy_trade_id) REFERENCES trades(id)
 );
 
@@ -260,6 +263,26 @@ CREATE TABLE IF NOT EXISTS coin_strategy_config (
     description TEXT,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS backtest_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_date DATE NOT NULL,
+    strategy_name TEXT NOT NULL,
+    coin TEXT NOT NULL,
+    period TEXT NOT NULL,
+    num_trades INTEGER NOT NULL,
+    win_rate REAL NOT NULL,
+    total_return_pct REAL NOT NULL,
+    max_drawdown_pct REAL NOT NULL,
+    sharpe_ratio REAL NOT NULL,
+    avg_profit_pct REAL NOT NULL,
+    avg_loss_pct REAL NOT NULL,
+    best_trade_pct REAL NOT NULL,
+    worst_trade_pct REAL NOT NULL,
+    params_json TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_bt_run_date ON backtest_results(run_date, strategy_name, coin);
 """
 
 # 기본 전략 파라미터 (최초 1회 삽입)
@@ -597,9 +620,10 @@ class Database:
         """현재 DB 커넥션을 반환한다. 없으면 생성."""
         if self._conn is None:
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
-            self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=30)
             self._conn.row_factory = sqlite3.Row  # dict처럼 접근 가능
             self._conn.execute("PRAGMA journal_mode=WAL")  # 동시 읽기 성능 향상
+            self._conn.execute("PRAGMA busy_timeout=30000")  # 30초 대기 (동시 시작 대응)
             self._conn.execute("PRAGMA foreign_keys=OFF")
         return self._conn
 
@@ -670,6 +694,15 @@ class Database:
             except sqlite3.OperationalError:
                 conn.execute("ALTER TABLE trade_signals ADD COLUMN strategy_params_json TEXT")
                 logger.info("trade_signals 테이블에 strategy_params_json 컬럼 추가 완료")
+
+            # 마이그레이션: trades 테이블에 정합성 검증 컬럼 추가
+            try:
+                conn.execute("SELECT order_uuid FROM trades LIMIT 1")
+            except sqlite3.OperationalError:
+                conn.execute("ALTER TABLE trades ADD COLUMN order_uuid TEXT")
+                conn.execute("ALTER TABLE trades ADD COLUMN reconciled INTEGER DEFAULT 0")
+                conn.execute("ALTER TABLE trades ADD COLUMN reconciled_at DATETIME")
+                logger.info("trades 테이블에 정합성 검증 컬럼 추가 완료 (order_uuid, reconciled, reconciled_at)")
 
             # 마이그레이션: bot_config에 새 설정 추가 (기존 DB 호환)
             existing = conn.execute("SELECT key FROM bot_config WHERE key = 'strategy_switch_delay_seconds'").fetchone()

--- a/src/cryptobot/data/recorder.py
+++ b/src/cryptobot/data/recorder.py
@@ -90,6 +90,7 @@ class DataRecorder:
         profit_pct: float | None = None,
         profit_krw: float | None = None,
         hold_duration_minutes: int | None = None,
+        order_uuid: str | None = None,
     ) -> int:
         """매매 체결을 기록한다.
 
@@ -103,8 +104,9 @@ class DataRecorder:
                 strategy, trigger_reason, trigger_value,
                 param_k_value, param_stop_loss, param_trailing_stop,
                 market_state_at_trade, btc_price_at_trade, rsi_at_trade,
-                buy_trade_id, profit_pct, profit_krw, hold_duration_minutes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                buy_trade_id, profit_pct, profit_krw, hold_duration_minutes,
+                order_uuid
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 coin,
@@ -126,6 +128,7 @@ class DataRecorder:
                 profit_pct,
                 profit_krw,
                 hold_duration_minutes,
+                order_uuid,
             ),
         )
         self._db.commit()

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -14,6 +14,13 @@ from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
+# 공통 파라미터 키 — 전략별 파라미터가 아닌 bot_config에 직접 적용되는 키
+COMMON_PARAM_KEYS = {
+    "stop_loss_pct", "trailing_stop_pct", "max_position_per_coin_pct",
+    "max_spread_pct", "emergency_held_pct", "emergency_non_held_pct",
+    "roi_10min", "roi_30min", "roi_60min", "roi_120min",
+}
+
 # 하드 리밋 — LLM이 이 범위를 벗어나면 클리핑
 HARD_LIMITS = {
     "stop_loss_pct": (-20.0, -5.0),
@@ -58,22 +65,18 @@ ANALYSIS_PROMPT = """당신은 암호화폐 자동매매 봇의 시장 분석 �
 ## 현재 전략 파라미터 (지금 봇에 적용 중인 값)
 {current_strategy_params}
 
-## 사용 가능한 전략
-- volatility_breakout: 변동성 돌파 (상승장에 적합, k_value 조절)
-- bb_rsi_combined: 볼린저+RSI 복합 (횡보/하락장, 매수조건: RSI ≤ rsi_oversold AND 가격 < 볼린저하단)
-- rsi_mean_reversion: RSI 평균회귀 (횡보장)
-- ma_crossover: 이동평균 교차 (추세 전환)
-- bollinger_bands: 볼린저 밴드 (횡보장)
+## 현재 활성 전략
+{active_strategy_text}
 
-## 파라미터 조절 범위 (하드 리밋)
+## 사용 가능한 전략
+{strategies_text}
+
+## 공통 파라미터 조절 범위 (하드 리밋)
 | 파라미터 | 범위 | 설명 |
 |----------|------|------|
 | stop_loss_pct | -20.0 ~ -5.0 | 손절률 (%) |
 | trailing_stop_pct | -10.0 ~ -1.0 | 트레일링 스탑 (%) |
 | max_position_per_coin_pct | 30 ~ 80 | 종목당 최대 포지션 (%) |
-| k_value | 0.2 ~ 0.8 | 변동성 돌파 계수 |
-| bb_std | 0.8 ~ 2.5 | 볼린저밴드 표준편차 배수 (낮을수록 밴드 좁음→매수 쉬움) |
-| rsi_oversold | 20 ~ 45 | RSI 과매도 기준 (높을수록 매수 조건 완화) |
 | roi_10min | 1.0 ~ 5.0 | 10분 보유 시 목표 수익률 (%) |
 | roi_30min | 0.5 ~ 3.0 | 30분 보유 시 목표 수익률 (%) |
 | roi_60min | 0.3 ~ 2.0 | 60분 보유 시 목표 수익률 (%) |
@@ -82,6 +85,14 @@ ANALYSIS_PROMPT = """당신은 암호화폐 자동매매 봇의 시장 분석 �
 
 ## 과거 전략별 실제 성과
 {param_stats_text}
+
+## 백테스트 시뮬레이션 결과 (파라미터 스윕 포함, 코인당 수익률 Top 10)
+{backtest_text}
+
+위 백테스트는 실제 OHLCV 일봉 데이터로 각 전략의 다양한 파라미터 조합을 시뮬레이션한 결과입니다.
+괄호 안은 해당 결과의 핵심 파라미터입니다.
+현재 파라미터와 비교하여 조정 근거로 활용하세요.
+단, 백테스트는 과거 데이터 기반이므로 맹신하지 말고 참고 자료로만 사용하세요.
 
 ## 중요 규칙
 
@@ -119,6 +130,28 @@ ANALYSIS_PROMPT = """당신은 암호화폐 자동매매 봇의 시장 분석 �
 - 나쁜 전략의 과거 성과 때문에 좋은 전략의 파라미터를 보수적으로 잡지 마세요
 - **건당 평균 수익이 건당 평균 손실의 1/3 이상인지 확인하세요**
 
+### 전략 전환 판단 (매 분석마다 반드시 수행)
+**주의: 이 섹션은 단순 참고가 아니라 매 분석마다 반드시 수행해야 하는 핵심 작업입니다.**
+
+1. **현재 전략 적합성 평가**: 위의 '현재 활성 전략' 정보와 '현재 시장 상태'를 비교하세요.
+   - 현재 전략의 '적합 시장'과 실제 시장 상태가 불일치하면 전략 전환을 적극 검토
+   - 예: 시장이 bullish인데 활성 전략이 bb_rsi_combined(sideways,bearish용)이면 → 전환 검토
+
+2. **전환 판단 시 종합적으로 고려할 요소**:
+   - 시장 상태(bullish/sideways/bearish)와 각 전략의 적합 시장
+   - 현재 코인 보유 현황과 미실현 손익
+   - 백테스트 시뮬레이션 결과(해당 전략의 수익률, 승률, MDD)
+   - 최근 매매 성과(현재 전략의 실전 승률, 손익비)
+   - 공포/탐욕 지수 추이
+
+3. **전환 실행 방법**: 전략을 바꾸기로 결정했다면:
+   - recommended_strategy에 새 전략 이름 설정
+   - recommended_params에 해당 전략의 파라미터 포함
+   - reasoning에 전환 근거 명시
+
+4. **전략 유지도 적극적 판단**: 현재 전략이 시장에 맞다면 유지하되,
+   "관성으로 유지"가 아니라 "검토 후 유지"임을 reasoning에 명시
+
 ### 시장 대응
 - 업비트 현물 거래만 가능 (숏/선물/레버리지 불가)
 - 공포/탐욕 지수 25 이하(극도 공포)는 역사적 매수 적기 (7년 백테스트 1,145% 수익)
@@ -141,16 +174,25 @@ ANALYSIS_PROMPT = """당신은 암호화폐 자동매매 봇의 시장 분석 �
   "alert_message": "",
   "recommended_strategy": "전략 이름",
   "recommended_params": {{
-    "k_value": 0.5,
-    "bb_std": 1.5,
-    "rsi_oversold": 35,
+    // 공통 파라미터 (모든 전략)
     "stop_loss_pct": -5.0,
     "trailing_stop_pct": -3.0,
     "max_position_per_coin_pct": 50,
     "roi_10min": 3.0,
     "roi_30min": 2.0,
     "roi_60min": 1.0,
-    "roi_120min": 0.3
+    "roi_120min": 0.3,
+    // 전략별 파라미터 — recommended_strategy에 해당하는 것만 포함
+    // volatility_breakout: k_value
+    // bb_rsi_combined: bb_std, rsi_oversold, bb_period, rsi_period
+    // rsi_mean_reversion: rsi_period, oversold, overbought
+    // ma_crossover: short_period, long_period
+    // bollinger_bands: bb_period, bb_std
+    // macd: fast, slow, signal_period
+    // supertrend: st_period, st_multiplier
+    // bollinger_squeeze: bb_period, bb_std, squeeze_lookback
+    // breakout_momentum: entry_period, exit_period
+    // grid_trading: grid_count, range_pct
   }},
   "coin_recommendations": {{
     "add": [],
@@ -344,8 +386,12 @@ class LLMAnalyzer:
             previous_feedback = self._get_previous_feedback()
             param_stats_text = self._get_param_stats_text()
             current_strategy_params = self._get_current_strategy_params()
+            backtest_text, _backtest_run_date = self._get_backtest_text()
 
             # 2. 프롬프트 구성
+            strategies_text = self._get_strategies_text()
+            active_strategy_text = self._get_active_strategy_text()
+
             prompt = ANALYSIS_PROMPT.format(
                 news_text=news_text,
                 fear_greed_text=fear_greed_text,
@@ -355,6 +401,9 @@ class LLMAnalyzer:
                 previous_feedback=previous_feedback,
                 param_stats_text=param_stats_text,
                 current_strategy_params=current_strategy_params,
+                backtest_text=backtest_text,
+                strategies_text=strategies_text,
+                active_strategy_text=active_strategy_text,
             )
 
             # 2.5. 프롬프트 버전 저장
@@ -632,6 +681,126 @@ class LLMAnalyzer:
 
         return "\n".join(lines)
 
+    # 코인당 백테스트 결과 표시 수 제한 (토큰 절약)
+    TOP_N_PER_COIN = 10
+
+    def _get_backtest_text(self) -> tuple[str, str]:
+        """최근 2회 백테스트 결과를 텍스트로 반환.
+
+        스윕으로 레코드가 많으므로 코인당 수익률 Top N만 포함.
+        파라미터 정보를 함께 표시하여 LLM이 어떤 설정의 결과인지 파악 가능.
+
+        Returns:
+            (결과 텍스트, 실행일자) 튜플
+        """
+        try:
+            # 최근 2회 실행일 조회
+            date_rows = self._db.execute(
+                "SELECT DISTINCT run_date FROM backtest_results ORDER BY run_date DESC LIMIT 2"
+            ).fetchall()
+            if not date_rows:
+                return "백테스트 데이터 없음", "없음"
+
+            run_dates = [dict(d)["run_date"] for d in date_rows]
+            placeholders = ",".join("?" * len(run_dates))
+
+            rows = self._db.execute(
+                f"""SELECT coin, strategy_name, total_return_pct, num_trades,
+                          win_rate, max_drawdown_pct, sharpe_ratio, period,
+                          params_json, run_date
+                FROM backtest_results
+                WHERE run_date IN ({placeholders})
+                ORDER BY run_date DESC, coin, total_return_pct DESC""",
+                run_dates,
+            ).fetchall()
+
+            if not rows:
+                return "백테스트 데이터 없음", "없음"
+
+            # 실행일별 → 코인별 그룹핑
+            date_groups: dict[str, dict[str, list]] = {}
+            for r in rows:
+                r = dict(r)
+                rd = r["run_date"]
+                date_groups.setdefault(rd, {}).setdefault(r["coin"], []).append(r)
+
+            lines = []
+            for i, rd in enumerate(run_dates):
+                label = "최근 실행" if i == 0 else "이전 실행"
+                lines.append(f"### {label}: {rd}")
+
+                coin_groups = date_groups.get(rd, {})
+                for coin, results in coin_groups.items():
+                    # 코인당 수익률 Top N만
+                    top_results = results[: self.TOP_N_PER_COIN]
+                    period = top_results[0]["period"] if top_results else ""
+                    lines.append(f"[{coin}] ({period})")
+                    for r in top_results:
+                        param_str = self._format_backtest_params(r.get("params_json"), r["strategy_name"])
+                        entry = f"  {r['strategy_name']}{param_str}: {r['total_return_pct']:+.1f}%"
+                        entry += f" | {r['num_trades']}건 승률{r['win_rate']:.0f}%"
+                        entry += f" | MDD {r['max_drawdown_pct']:.1f}%"
+                        if r["sharpe_ratio"] != 0:
+                            entry += f" | sharpe {r['sharpe_ratio']:.2f}"
+                        lines.append(entry)
+                lines.append("")
+
+            return "\n".join(lines), run_dates[0]
+        except Exception as e:
+            logger.debug("백테스트 데이터 조회 실패: %s", e)
+            return "백테스트 데이터 없음", "없음"
+
+    @staticmethod
+    def _format_backtest_params(params_json: str | None, strategy_name: str) -> str:
+        """params_json에서 핵심 파라미터(공통 제외)만 간결하게 표시.
+
+        Args:
+            params_json: JSON 문자열 또는 None
+            strategy_name: 전략 이름
+
+        Returns:
+            "(k=0.7)" 형태 문자열. 파라미터가 없으면 빈 문자열.
+        """
+        if not params_json:
+            return ""
+        try:
+            params = json.loads(params_json) if isinstance(params_json, str) else params_json
+        except (json.JSONDecodeError, TypeError):
+            return ""
+
+        # 공통 파라미터 제외, 전략 고유 파라미터만
+        short_names = {
+            "k_value": "k",
+            "short_period": "short",
+            "long_period": "long",
+            "st_multiplier": "st_m",
+            "rsi_oversold": "rsi_os",
+            "bb_std": "bb",
+            "grid_count": "grid",
+            "entry_period": "entry",
+            "exit_period": "exit",
+            "oversold": "os",
+            "overbought": "ob",
+            "fast": "fast",
+            "slow": "slow",
+            "bb_period": "bb_p",
+            "rsi_period": "rsi_p",
+            "st_period": "st_p",
+            "signal_period": "sig",
+            "squeeze_lookback": "sq_lb",
+            "range_pct": "range",
+        }
+        parts = []
+        for key, value in params.items():
+            if key in COMMON_PARAM_KEYS:
+                continue
+            short = short_names.get(key, key)
+            if isinstance(value, float) and value == int(value):
+                parts.append(f"{short}={int(value)}")
+            else:
+                parts.append(f"{short}={value}")
+        return f"({','.join(parts)})" if parts else ""
+
     def _get_news_text(self) -> str:
         """최신 뉴스 20개 (항상 포함)."""
         rows = self._db.execute(
@@ -853,6 +1022,103 @@ class LLMAnalyzer:
             lines.append(f"  {r['name']}: {r['default_params_json']}")
 
         return "\n".join(lines) if lines else "설정 없음"
+
+    def _get_strategies_text(self) -> str:
+        """DB에서 사용 가능한 전략 목록을 동적으로 생성."""
+        try:
+            rows = self._db.execute(
+                """SELECT name, display_name, description, category, market_states, default_params_json
+                FROM strategies WHERE is_available = TRUE
+                ORDER BY name"""
+            ).fetchall()
+
+            if not rows:
+                return "사용 가능한 전략 없음"
+
+            lines = []
+            for r in rows:
+                r = dict(r)
+                name = r["name"]
+                display = r["display_name"] or name
+                category = r["category"] or "기타"
+                markets = r["market_states"] or "all"
+                desc = r["description"] or ""
+
+                line = f"### {name} ({display}) [{category}]"
+                lines.append(line)
+                if desc:
+                    lines.append(f"- 설명: {desc}")
+                lines.append(f"- 적합 시장: {markets}")
+
+                # 조절 가능한 파라미터 목록 + 하드 리밋 범위
+                if r["default_params_json"]:
+                    try:
+                        params = json.loads(r["default_params_json"])
+                        param_parts = []
+                        for k, v in params.items():
+                            limit = HARD_LIMITS.get(k)
+                            if limit:
+                                param_parts.append(f"{k}={v} ({limit[0]}~{limit[1]})")
+                            else:
+                                param_parts.append(f"{k}={v}")
+                        if param_parts:
+                            lines.append(f"- 조절 파라미터: {', '.join(param_parts)}")
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                lines.append("")  # 빈 줄로 구분
+
+            return "\n".join(lines)
+        except Exception as e:
+            logger.debug("전략 목록 조회 실패: %s", e)
+            return "전략 목록 조회 실패"
+
+    def _get_active_strategy_text(self) -> str:
+        """현재 활성 전략 정보를 텍스트로 생성."""
+        try:
+            row = self._db.execute(
+                """SELECT name, display_name, description, market_states, default_params_json
+                FROM strategies WHERE is_active = TRUE LIMIT 1"""
+            ).fetchone()
+
+            if not row:
+                return "활성 전략 없음 (기본 전략 사용 중)"
+
+            r = dict(row)
+            lines = [
+                f"전략: {r['name']} ({r['display_name'] or r['name']})",
+                f"적합 시장: {r['market_states'] or 'all'}",
+            ]
+
+            if r["default_params_json"]:
+                try:
+                    params = json.loads(r["default_params_json"])
+                    param_str = ", ".join(f"{k}={v}" for k, v in params.items())
+                    lines.append(f"파라미터: {param_str}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            # 최근 성과 요약 (활성 전략 기준)
+            perf = self._db.execute(
+                """SELECT COUNT(*) as cnt,
+                    SUM(CASE WHEN profit_krw > 0 THEN 1 ELSE 0 END) as wins,
+                    AVG(profit_pct) as avg_pct
+                FROM trades WHERE side='sell' AND strategy = ?
+                AND timestamp >= datetime('now', '-7 days')""",
+                (r["name"],),
+            ).fetchone()
+            if perf:
+                p = dict(perf)
+                cnt = p["cnt"] or 0
+                if cnt > 0:
+                    wr = round((p["wins"] or 0) / cnt * 100)
+                    lines.append(f"최근 7일 성과: {cnt}건 매도, 승률 {wr}%, 평균 {p['avg_pct'] or 0:+.2f}%")
+                else:
+                    lines.append("최근 7일 성과: 매매 없음")
+
+            return "\n".join(lines)
+        except Exception as e:
+            logger.debug("활성 전략 조회 실패: %s", e)
+            return "활성 전략 조회 실패"
 
     # 필수 응답 필드
     REQUIRED_FIELDS = ["market_summary_kr", "market_state", "recommended_strategy"]
@@ -1084,18 +1350,18 @@ class LLMAnalyzer:
             row = self._db.execute("SELECT value FROM bot_config WHERE key = ?", (key,)).fetchone()
             if row:
                 before[key] = dict(row)["value"]
-        # 전략 파라미터도 before에 포함
-        strategy = result.get("recommended_strategy")
-        if strategy:
-            row = self._db.execute("SELECT default_params_json FROM strategies WHERE name = ?", (strategy,)).fetchone()
-            if row and dict(row)["default_params_json"]:
-                try:
-                    sp = json.loads(dict(row)["default_params_json"])
-                    for k in ["rsi_oversold", "bb_std"]:
-                        if k in sp:
-                            before[k] = sp[k]
-                except (json.JSONDecodeError, TypeError):
-                    pass
+        # 전략 파라미터도 before에 포함 (활성 전략의 모든 파라미터)
+        active_row = self._db.execute(
+            "SELECT name, default_params_json FROM strategies WHERE is_active = TRUE LIMIT 1"
+        ).fetchone()
+        if active_row and dict(active_row)["default_params_json"]:
+            try:
+                sp = json.loads(dict(active_row)["default_params_json"])
+                for k, v in sp.items():
+                    before[f"strategy:{k}"] = v
+                before["active_strategy"] = dict(active_row)["name"]
+            except (json.JSONDecodeError, TypeError):
+                pass
 
         # 파라미터 적용
         config_map = {
@@ -1137,10 +1403,10 @@ class LLMAnalyzer:
                 json.loads(dict(row)["default_params_json"]) if row and dict(row)["default_params_json"] else {}
             )
 
-            # LLM 추천값으로 머지 (있는 것만 덮어쓰기)
-            for key in ["bb_std", "rsi_oversold", "k_value"]:
-                if key in params:
-                    strategy_params[key] = params[key]
+            # LLM 추천값으로 머지 — 공통 키 제외한 전략별 파라미터 모두 반영
+            for key, value in params.items():
+                if key not in COMMON_PARAM_KEYS:
+                    strategy_params[key] = value
 
             self._db.execute(
                 "UPDATE strategies SET default_params_json = ?, updated_at = ? WHERE name = ?",
@@ -1200,9 +1466,11 @@ class LLMAnalyzer:
         after = {k: str(v) for k, v in config_map.items() if v is not None}
         if result.get("allow_trading") is not None:
             after["allow_trading"] = str(result["allow_trading"]).lower()
-        for k in ["rsi_oversold", "bb_std"]:
-            if k in params:
-                after[k] = params[k]
+        if strategy:
+            after["active_strategy"] = strategy
+        for key, value in params.items():
+            if key not in COMMON_PARAM_KEYS:
+                after[f"strategy:{key}"] = value
 
         # before/after를 최신 llm_decisions에 기록
         self._db.execute(

--- a/tests/test_backtest_sweep.py
+++ b/tests/test_backtest_sweep.py
@@ -1,0 +1,252 @@
+"""백테스트 파라미터 스윕 + LLM 프롬프트 개선 테스트."""
+
+import json
+import sqlite3
+
+import pytest
+
+from cryptobot.backtest.reporter import SWEEP_CONFIGS, BacktestReporter
+from cryptobot.llm.analyzer import COMMON_PARAM_KEYS, LLMAnalyzer
+
+
+class TestGenerateSweepCombos:
+    """_generate_sweep_combos 조합 생성 테스트."""
+
+    def test_single_param_three_values(self):
+        """단일 파라미터 3값 → 3개 조합."""
+        base = {"a": 1, "b": 2}
+        sweep = {"k_value": [0.3, 0.5, 0.7]}
+        combos = BacktestReporter._generate_sweep_combos(base, sweep)
+        assert len(combos) == 3
+        assert combos[0] == {"a": 1, "b": 2, "k_value": 0.3}
+        assert combos[1] == {"a": 1, "b": 2, "k_value": 0.5}
+        assert combos[2] == {"a": 1, "b": 2, "k_value": 0.7}
+
+    def test_two_params_product(self):
+        """2개 파라미터 (3 × 2) → 6개 조합."""
+        base = {"x": 10}
+        sweep = {"rsi_oversold": [25, 30, 35], "bb_std": [1.5, 2.0]}
+        combos = BacktestReporter._generate_sweep_combos(base, sweep)
+        assert len(combos) == 6
+        # 모든 조합이 base 값 유지
+        for c in combos:
+            assert c["x"] == 10
+        # 모든 bb_rsi_combined 조합 확인
+        rsi_values = {c["rsi_oversold"] for c in combos}
+        bb_values = {c["bb_std"] for c in combos}
+        assert rsi_values == {25, 30, 35}
+        assert bb_values == {1.5, 2.0}
+
+    def test_override_base_param(self):
+        """스윕 값이 기본 파라미터를 덮어쓰는지 확인."""
+        base = {"k_value": 0.5, "other": 99}
+        sweep = {"k_value": [0.3, 0.7]}
+        combos = BacktestReporter._generate_sweep_combos(base, sweep)
+        assert len(combos) == 2
+        assert combos[0]["k_value"] == 0.3
+        assert combos[1]["k_value"] == 0.7
+        assert all(c["other"] == 99 for c in combos)
+
+    def test_empty_sweep(self):
+        """빈 스윕 → itertools.product가 1개 빈 튜플 반환."""
+        base = {"a": 1}
+        combos = BacktestReporter._generate_sweep_combos(base, {})
+        assert len(combos) == 1
+        assert combos[0] == {"a": 1}
+
+
+class TestSweepConfigsCoverage:
+    """SWEEP_CONFIGS가 모든 전략을 커버하는지 확인."""
+
+    def test_all_strategies_have_sweep(self):
+        """STRATEGY_CLASSES의 모든 전략이 SWEEP_CONFIGS에 있는지 확인."""
+        from cryptobot.bot.strategy_selector import STRATEGY_CLASSES
+
+        for name in STRATEGY_CLASSES:
+            assert name in SWEEP_CONFIGS, f"전략 '{name}'이 SWEEP_CONFIGS에 없음"
+
+    def test_sweep_values_are_lists(self):
+        """스윕 값이 모두 리스트인지 확인."""
+        for strategy, params in SWEEP_CONFIGS.items():
+            for key, values in params.items():
+                assert isinstance(values, list), f"{strategy}.{key}가 리스트가 아님"
+                assert len(values) >= 2, f"{strategy}.{key}에 값이 2개 미만"
+
+
+class TestFormatKeyParams:
+    """_format_key_params 파라미터 표시 테스트."""
+
+    def test_volatility_breakout(self):
+        """변동성 돌파 전략 파라미터 표시."""
+        result = BacktestReporter._format_key_params({"k_value": 0.7}, "volatility_breakout")
+        assert result == "(k=0.7)"
+
+    def test_bb_rsi_combined(self):
+        """BB RSI 복합 전략 파라미터 표시."""
+        result = BacktestReporter._format_key_params(
+            {"rsi_oversold": 35, "bb_std": 1.5}, "bb_rsi_combined"
+        )
+        assert "rsi_os=35" in result
+        assert "bb=1.5" in result
+
+    def test_no_sweep_config(self):
+        """스윕 설정 없는 전략 → 빈 문자열."""
+        result = BacktestReporter._format_key_params({"k_value": 0.5}, "unknown_strategy")
+        assert result == ""
+
+    def test_integer_display(self):
+        """정수값은 정수로 표시."""
+        result = BacktestReporter._format_key_params({"grid_count": 10.0}, "grid_trading")
+        assert "grid=10" in result
+        assert "10.0" not in result
+
+
+def _create_test_db() -> sqlite3.Connection:
+    """테스트용 인메모리 DB 생성."""
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("""
+        CREATE TABLE backtest_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_date TEXT,
+            strategy_name TEXT,
+            coin TEXT,
+            period TEXT,
+            num_trades INTEGER,
+            win_rate REAL,
+            total_return_pct REAL,
+            max_drawdown_pct REAL,
+            sharpe_ratio REAL,
+            avg_profit_pct REAL,
+            avg_loss_pct REAL,
+            best_trade_pct REAL,
+            worst_trade_pct REAL,
+            params_json TEXT
+        )
+    """)
+    return db
+
+
+def _insert_backtest_row(
+    db: sqlite3.Connection,
+    run_date: str,
+    strategy: str,
+    coin: str,
+    total_return_pct: float,
+    params: dict | None = None,
+) -> None:
+    """백테스트 결과 1건 삽입."""
+    db.execute(
+        """INSERT INTO backtest_results
+           (run_date, strategy_name, coin, period, num_trades, win_rate,
+            total_return_pct, max_drawdown_pct, sharpe_ratio,
+            avg_profit_pct, avg_loss_pct, best_trade_pct, worst_trade_pct, params_json)
+           VALUES (?, ?, ?, '2026-03-01 ~ 2026-04-13', 5, 60.0,
+                   ?, -3.0, 1.5, 2.0, -1.0, 4.0, -2.0, ?)""",
+        (run_date, strategy, coin, total_return_pct, json.dumps(params or {})),
+    )
+
+
+class TestBacktestTextWithParams:
+    """_get_backtest_text 파라미터 표시 테스트."""
+
+    def test_params_in_text(self):
+        """파라미터가 프롬프트 텍스트에 포함되는지 확인."""
+        db = _create_test_db()
+        _insert_backtest_row(db, "2026-04-13", "volatility_breakout", "KRW-BTC", 2.3, {"k_value": 0.7})
+        db.commit()
+
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer._db = db
+
+        text, run_date = analyzer._get_backtest_text()
+        assert "k=0.7" in text
+        assert "volatility_breakout" in text
+        assert "+2.3%" in text
+        assert run_date == "2026-04-13"
+
+    def test_common_params_excluded(self):
+        """공통 파라미터(stop_loss_pct 등)는 표시되지 않는지 확인."""
+        db = _create_test_db()
+        params = {"k_value": 0.5, "stop_loss_pct": -5.0, "trailing_stop_pct": -3.0}
+        _insert_backtest_row(db, "2026-04-13", "volatility_breakout", "KRW-BTC", 1.0, params)
+        db.commit()
+
+        text = LLMAnalyzer._format_backtest_params(json.dumps(params), "volatility_breakout")
+        assert "k=0.5" in text
+        assert "stop_loss" not in text
+        assert "trailing" not in text
+
+
+class TestBacktestTextTopNLimit:
+    """코인당 Top N 제한 테스트."""
+
+    def test_top_n_limit(self):
+        """코인당 TOP_N_PER_COIN개만 표시되는지 확인."""
+        db = _create_test_db()
+        # 15개 결과 삽입 (Top 10만 표시되어야 함)
+        for i in range(15):
+            _insert_backtest_row(
+                db, "2026-04-13", f"strategy_{i}", "KRW-BTC", 10.0 - i,
+                {"param": i},
+            )
+        db.commit()
+
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer._db = db
+
+        text, _ = analyzer._get_backtest_text()
+        # strategy_0 ~ strategy_9 (Top 10) 있어야 함
+        for i in range(10):
+            assert f"strategy_{i}" in text
+        # strategy_10 ~ strategy_14 (하위 5개) 없어야 함
+        for i in range(10, 15):
+            assert f"strategy_{i}" not in text
+
+
+class TestBacktestTextTwoRuns:
+    """2회분 결과 포함 테스트."""
+
+    def test_two_run_dates(self):
+        """최근 2회 실행일의 결과가 모두 포함되는지 확인."""
+        db = _create_test_db()
+        _insert_backtest_row(db, "2026-04-13", "volatility_breakout", "KRW-BTC", 2.3, {"k_value": 0.7})
+        _insert_backtest_row(db, "2026-04-06", "volatility_breakout", "KRW-BTC", 1.1, {"k_value": 0.5})
+        db.commit()
+
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer._db = db
+
+        text, run_date = analyzer._get_backtest_text()
+        assert "최근 실행: 2026-04-13" in text
+        assert "이전 실행: 2026-04-06" in text
+        assert run_date == "2026-04-13"
+
+    def test_single_run_date(self):
+        """1회분만 있으면 '이전 실행' 없이 표시."""
+        db = _create_test_db()
+        _insert_backtest_row(db, "2026-04-13", "macd", "KRW-ETH", 3.5, {"fast": 12, "slow": 26})
+        db.commit()
+
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer._db = db
+
+        text, _ = analyzer._get_backtest_text()
+        assert "최근 실행: 2026-04-13" in text
+        assert "이전 실행" not in text
+
+    def test_three_dates_only_latest_two(self):
+        """3회분 있어도 최근 2회만 표시."""
+        db = _create_test_db()
+        _insert_backtest_row(db, "2026-04-13", "macd", "KRW-BTC", 3.0)
+        _insert_backtest_row(db, "2026-04-06", "macd", "KRW-BTC", 2.0)
+        _insert_backtest_row(db, "2026-03-30", "macd", "KRW-BTC", 1.0)
+        db.commit()
+
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer._db = db
+
+        text, _ = analyzer._get_backtest_text()
+        assert "2026-04-13" in text
+        assert "2026-04-06" in text
+        assert "2026-03-30" not in text

--- a/tests/test_llm_strategy_switch.py
+++ b/tests/test_llm_strategy_switch.py
@@ -1,0 +1,291 @@
+"""LLM 전략 전환 통합 테스트.
+
+DB에서 is_available=TRUE 전략을 동적으로 가져와 테스트하므로
+새 전략 추가 시 자동으로 커버됨.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from cryptobot.data.database import Database
+from cryptobot.data.strategy_repository import StrategyRepository
+from cryptobot.llm.analyzer import COMMON_PARAM_KEYS, HARD_LIMITS, LLMAnalyzer
+
+
+def _make_analyzer():
+    """테스트용 LLMAnalyzer + Database 생성."""
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    return LLMAnalyzer(db), db
+
+
+def _get_available_strategies(db):
+    """DB에서 available 전략 목록 동적 조회."""
+    rows = db.execute("SELECT name, default_params_json FROM strategies WHERE is_available = TRUE").fetchall()
+    return [dict(r) for r in rows]
+
+
+def _build_llm_result(strategy_name, extra_params=None):
+    """LLM 응답 dict 생성."""
+    result = {
+        "market_summary_kr": "테스트 시장 요약",
+        "market_state": "sideways",
+        "confidence": 0.7,
+        "aggression": 0.5,
+        "should_alert_stop": False,
+        "allow_trading": True,
+        "recommended_strategy": strategy_name,
+        "recommended_params": {
+            "stop_loss_pct": -7.0,
+            "trailing_stop_pct": -3.0,
+            "max_position_per_coin_pct": 50,
+            "roi_10min": 3.0,
+            "roi_30min": 2.0,
+            "roi_60min": 1.0,
+            "roi_120min": 0.3,
+            **(extra_params or {}),
+        },
+        "reasoning": "테스트 전략 전환 근거",
+    }
+    return result
+
+
+class TestSwitchToEachStrategy:
+    """test_switch_to_each_strategy — DB의 모든 available 전략 루프, 전환 + 활성화 검증."""
+
+    def test_switch_to_each_strategy(self):
+        analyzer, db = _make_analyzer()
+        try:
+            strategies = _get_available_strategies(db)
+            assert len(strategies) > 0, "available 전략이 0개"
+
+            repo = StrategyRepository(db)
+
+            for strat in strategies:
+                name = strat["name"]
+                # 전략별 기본 파라미터를 extra_params로 전달
+                default_params = json.loads(strat["default_params_json"]) if strat["default_params_json"] else {}
+                result = _build_llm_result(name, extra_params=default_params)
+
+                # shutting_down 전략이 있으면 정리
+                repo.complete_shutdown()
+
+                analyzer._apply_recommendations(result)
+
+                # 활성화 검증 (shutting_down은 아직 is_active=TRUE이므로 status='active'로 필터)
+                row = db.execute(
+                    "SELECT name, is_active, status FROM strategies WHERE is_active = TRUE AND status = 'active'"
+                ).fetchone()
+                assert row is not None, f"전략 {name} 활성화 후 active 전략 없음"
+                assert dict(row)["name"] == name, f"활성 전략 불일치: {dict(row)['name']} != {name}"
+                assert dict(row)["status"] == "active"
+        finally:
+            db.close()
+
+
+class TestStrategyParamsMerged:
+    """test_strategy_params_merged_correctly — 전략별 파라미터 머지, COMMON_PARAM_KEYS 분리."""
+
+    def test_strategy_params_merged_correctly(self):
+        analyzer, db = _make_analyzer()
+        try:
+            strategies = _get_available_strategies(db)
+            repo = StrategyRepository(db)
+
+            for strat in strategies:
+                name = strat["name"]
+                default_params = json.loads(strat["default_params_json"]) if strat["default_params_json"] else {}
+                result = _build_llm_result(name, extra_params=default_params)
+
+                repo.complete_shutdown()
+                analyzer._apply_recommendations(result)
+
+                # DB에서 전략 파라미터 확인
+                row = db.execute("SELECT default_params_json FROM strategies WHERE name = ?", (name,)).fetchone()
+                saved_params = json.loads(dict(row)["default_params_json"])
+
+                # 전략별 파라미터(공통 키 제외)가 저장되었는지 확인
+                for key, value in default_params.items():
+                    if key not in COMMON_PARAM_KEYS:
+                        assert key in saved_params, f"전략 {name}: 파라미터 {key} 누락"
+        finally:
+            db.close()
+
+
+class TestMissingParamsDefense:
+    """test_missing_strategy_params_defense — 필수 필드 누락 시 _fill_param_defaults() 방어."""
+
+    def test_missing_strategy_params_defense(self):
+        analyzer, db = _make_analyzer()
+        try:
+            # 빈 파라미터로 _fill_param_defaults 호출
+            filled = analyzer._fill_param_defaults({})
+
+            # bot_config에서 기본값이 채워져야 함
+            # initialize()에서 stop_loss_pct 등을 bot_config에 넣으므로 값이 존재해야 함
+            config_keys_in_db = ["stop_loss_pct", "trailing_stop_pct", "k_value", "max_position_per_coin_pct"]
+            for key in config_keys_in_db:
+                row = db.execute("SELECT value FROM bot_config WHERE key = ?", (key,)).fetchone()
+                if row:
+                    assert key in filled, f"_fill_param_defaults가 {key}를 채우지 않음"
+        finally:
+            db.close()
+
+
+class TestHardLimitsClipping:
+    """test_hard_limits_clipping — 범위 밖 파라미터 클리핑."""
+
+    def test_hard_limits_clipping(self):
+        analyzer, db = _make_analyzer()
+        try:
+            # 범위 밖 값으로 결과 생성
+            result = _build_llm_result("volatility_breakout", extra_params={
+                "k_value": 99.0,  # 범위: 0.2~0.8
+                "stop_loss_pct": -100.0,  # 범위: -20.0~-5.0
+                "rsi_oversold": 99,  # 범위: 20~45
+            })
+            result["aggression"] = 5.0  # 범위: 0.1~1.0
+
+            clipped = analyzer._apply_hard_limits(result)
+            params = clipped["recommended_params"]
+
+            assert params["k_value"] == HARD_LIMITS["k_value"][1], f"k_value 클리핑 실패: {params['k_value']}"
+            assert params["stop_loss_pct"] == HARD_LIMITS["stop_loss_pct"][0], (
+                f"stop_loss_pct 클리핑 실패: {params['stop_loss_pct']}"
+            )
+            assert params["rsi_oversold"] == HARD_LIMITS["rsi_oversold"][1], (
+                f"rsi_oversold 클리핑 실패: {params['rsi_oversold']}"
+            )
+            assert clipped["aggression"] == HARD_LIMITS["aggression"][1], (
+                f"aggression 클리핑 실패: {clipped['aggression']}"
+            )
+        finally:
+            db.close()
+
+
+class TestBeforeAfterSnapshot:
+    """test_before_after_snapshot — llm_decisions에 before/after 기록."""
+
+    def test_before_after_snapshot(self):
+        analyzer, db = _make_analyzer()
+        try:
+            # 먼저 save_decision으로 레코드 생성
+            result = _build_llm_result("volatility_breakout", extra_params={"k_value": 0.5})
+            result["_input_tokens"] = 100
+            result["_output_tokens"] = 50
+            result["_model"] = "test-model"
+            result["_prompt_version_id"] = None
+
+            analyzer._save_decision(result)
+            analyzer._apply_recommendations(result)
+
+            # llm_decisions의 input_news_summary에 before/after JSON이 기록되었는지
+            row = db.execute("SELECT input_news_summary FROM llm_decisions ORDER BY id DESC LIMIT 1").fetchone()
+            assert row is not None, "llm_decisions 레코드 없음"
+
+            snapshot = json.loads(dict(row)["input_news_summary"])
+            assert "before" in snapshot, "before 스냅샷 없음"
+            assert "after" in snapshot, "after 스냅샷 없음"
+            assert "strategy" in snapshot, "strategy 필드 없음"
+        finally:
+            db.close()
+
+
+class TestCommonParamsNotInStrategy:
+    """test_common_params_not_in_strategy — 공통 파라미터가 strategy params에 안 들어가는지."""
+
+    def test_common_params_not_in_strategy(self):
+        analyzer, db = _make_analyzer()
+        try:
+            result = _build_llm_result("bb_rsi_combined", extra_params={
+                "bb_std": 1.5,
+                "rsi_oversold": 35,
+                "bb_period": 20,
+                "rsi_period": 14,
+            })
+
+            repo = StrategyRepository(db)
+            repo.complete_shutdown()
+            analyzer._apply_recommendations(result)
+
+            # 전략 파라미터에서 공통 키가 없어야 함
+            row = db.execute("SELECT default_params_json FROM strategies WHERE name = 'bb_rsi_combined'").fetchone()
+            saved_params = json.loads(dict(row)["default_params_json"])
+
+            for common_key in COMMON_PARAM_KEYS:
+                assert common_key not in saved_params, (
+                    f"공통 파라미터 {common_key}가 전략 params에 들어감: {saved_params}"
+                )
+        finally:
+            db.close()
+
+
+class TestUnknownStrategyRejected:
+    """test_unknown_strategy_rejected — DB에 없는 전략 graceful 처리."""
+
+    def test_unknown_strategy_rejected(self):
+        analyzer, db = _make_analyzer()
+        try:
+            result = _build_llm_result("nonexistent_strategy_xyz")
+            result["_input_tokens"] = 100
+            result["_output_tokens"] = 50
+            result["_model"] = "test-model"
+            result["_prompt_version_id"] = None
+
+            analyzer._save_decision(result)
+
+            # apply_recommendations는 StrategyRepository.activate()에서 False 반환 → 예외 없이 처리
+            analyzer._apply_recommendations(result)
+
+            # 활성 전략이 변경되지 않아야 함 (기존 전략 유지)
+            active = db.execute("SELECT name FROM strategies WHERE is_active = TRUE AND status = 'active'").fetchone()
+            if active:
+                assert dict(active)["name"] != "nonexistent_strategy_xyz"
+        finally:
+            db.close()
+
+
+class TestGetStrategiesTextDynamic:
+    """test_get_strategies_text_dynamic — 프롬프트 전략 목록 동적 생성 (DB 전략 수 일치)."""
+
+    def test_get_strategies_text_dynamic(self):
+        analyzer, db = _make_analyzer()
+        try:
+            strategies = _get_available_strategies(db)
+            text = analyzer._get_strategies_text()
+
+            # 각 전략 이름이 텍스트에 포함되어야 함
+            for strat in strategies:
+                assert strat["name"] in text, f"전략 {strat['name']}이 프롬프트 텍스트에 없음"
+
+            # "###" 헤더 수가 전략 수와 일치
+            header_count = text.count("### ")
+            assert header_count == len(strategies), (
+                f"프롬프트 전략 수 불일치: 헤더 {header_count}개 vs DB {len(strategies)}개"
+            )
+        finally:
+            db.close()
+
+
+class TestGetActiveStrategyText:
+    """test_get_active_strategy_text — 활성 전략 텍스트 출력."""
+
+    def test_get_active_strategy_text(self):
+        analyzer, db = _make_analyzer()
+        try:
+            # 기본 상태: volatility_breakout이 활성
+            text = analyzer._get_active_strategy_text()
+            assert "volatility_breakout" in text, f"활성 전략 텍스트에 전략 이름 없음: {text}"
+            assert "적합 시장" in text, f"적합 시장 정보 없음: {text}"
+
+            # 다른 전략으로 전환 후 확인
+            repo = StrategyRepository(db)
+            repo.activate("bb_rsi_combined", source="test")
+            repo.complete_shutdown()
+
+            text = analyzer._get_active_strategy_text()
+            assert "bb_rsi_combined" in text, f"전환 후 텍스트에 bb_rsi_combined 없음: {text}"
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary
- **백테스트 파라미터 스윕**: `BacktestReporter.run_all()`에 전략별 핵심 파라미터 조합 스윕 추가 (SWEEP_CONFIGS). 전략당 최대 6조합, 총 ~33조합 × 코인 수
- **LLM 프롬프트 개선**: `_get_backtest_text()`에 파라미터 표시(`k=0.7`), 코인당 Top 10 제한, 최근 2회 실행분 포함으로 추이 파악 가능
- **DB 동시접근 안정화**: SQLite `busy_timeout=30초` + `timeout=30` 설정으로 서버 동시 시작 시 `database is locked` 해결
- 백테스트 모듈 전체 (engine, result, reporter), CLI 러너, 정합성 검증, 헬스체커 포함
- 전략 전환 테스트 9건 + 백테스트 스윕 테스트 16건 추가 (전체 126건 통과)

## Test plan
- [x] `pytest tests/test_backtest_sweep.py -v` — 16건 통과
- [x] `pytest tests/test_llm_strategy_switch.py -v` — 9건 통과
- [x] `pytest tests/ -x -q` — 전체 126건 통과
- [ ] `make start`로 서버 동시 시작 시 database locked 안 나는지 확인
- [ ] Slack 리포트에 파라미터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)