### PR TITLE
improve: LLM 호출 빈도 조정 — 활발 30분→60분

### DIFF
--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -248,9 +248,9 @@ class LLMAnalyzer:
     # Haiku 4.5 가격 (2026-04 기준)
     PRICE_INPUT_PER_M = 0.80  # $0.80 / 1M 입력 토큰
     PRICE_OUTPUT_PER_M = 4.00  # $4.00 / 1M 출력 토큰
-    MAX_DAILY_CALLS = 60  # 하드 리밋 (동적 주기 목표 ~30회, 긴급 분석 여유)
+    MAX_DAILY_CALLS = 36  # 하드 리밋 (활발 시 24회 + 긴급 여유)
     # 동적 주기 (시장 활동량에 따라)
-    INTERVAL_ACTIVE_MIN = 30  # 활발: 30분
+    INTERVAL_ACTIVE_MIN = 60  # 활발: 1시간 (30분은 파라미터 진동만 유발)
     INTERVAL_NORMAL_MIN = 120  # 보통: 2시간
     INTERVAL_QUIET_MIN = 240  # 한산: 4시간
 


### PR DESCRIPTION
## Summary
- `INTERVAL_ACTIVE_MIN` 30분 → 60분: 30분 간격에서 파라미터 진동만 발생 (rsi_oversold 38→42→38 반복, 수렴 안 함)
- `MAX_DAILY_CALLS` 60 → 36: 1시간 간격 기준 하루 최대 24회 + 긴급 여유
- 100만원 모수 기준 LLM 비용($3/월) 대비 충분한 ROI이므로 NORMAL/QUIET은 유지

## Test plan
- [x] `pytest tests/ -x -q` — 126건 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)