### PR TITLE
fix: api/deps.py에 logging 모듈 import 추가 (#156)

### DIFF
--- a/src/cryptobot/api/deps.py
+++ b/src/cryptobot/api/deps.py
@@ -4,6 +4,7 @@ NestJS의 @Inject() + providers와 동일한 역할.
 DB 커넥션, Repository 등을 라우트에 주입한다.
 """
 
+import logging
 import threading
 from functools import lru_cache
 


### PR DESCRIPTION
## Summary

\`src/cryptobot/api/deps.py\`에 \`import logging\`이 누락되어 \`JWT_SECRET\` 미설정 환경(= 테스트)에서 \`NameError\` 발생. 한 줄 import 추가로 해결.

## 원인

#116에서 \`get_jwt_secret\`에 \`logging.getLogger(__name__).warning(...)\` 라인을 추가하면서 상단 import를 빠뜨림. 프로덕션은 \`.env\`에 \`JWT_SECRET\`이 있어서 해당 분기를 안 타 눈에 안 띄었고, 테스트 suite만 조용히 깨져 있었음.

## 변경

- \`src/cryptobot/api/deps.py\` 상단에 \`import logging\` 1줄 추가

## Test plan

- [x] \`pytest tests/test_api.py -v\` — 11/11 통과 (기존 1 FAILED + 7 ERRORS 전부 해소)
- [x] \`pytest tests/\` — 126/126 통과

Closes #156