### PR TITLE
fix: LLM 비용 계산 + 연속 손실 서킷 + 매매신호 UI (#163 #164 #165)

### DIFF
--- a/admin/src/api/signals.ts
+++ b/admin/src/api/signals.ts
@@ -49,6 +49,8 @@ export async function getSignals(params: {
   limit?: number;
   signal_type?: string;
   strategy?: string;
+  exclude_hold?: boolean;
+  min_confidence?: number;
 }): Promise<SignalListResponse> {
   const { data } = await client.get<SignalListResponse>("/signals", { params });
   return data;

--- a/admin/src/pages/SignalsPage.tsx
+++ b/admin/src/pages/SignalsPage.tsx
@@ -7,11 +7,14 @@ import { formatKRW, formatDateTime, formatNumber } from "../utils/format";
 import { getParamDesc } from "../utils/paramDescriptions";
 import { getIndicatorDesc, getMarketStateKR, MARKET_STATE_KR } from "../utils/indicatorDescriptions";
 
+// 기본 뷰는 "매매만" (hold 제외). HOLD는 조건 미충족 기록이라 confidence=0이 정상이라
+// 대시보드에 섞이면 buy/sell 신호가 묻히고 "신뢰도가 다 0%"처럼 보여 오해를 유발함.
 const SIGNAL_FILTERS = [
-  { label: "전체", value: "" },
+  { label: "매매만", value: "trades" }, // buy + sell (exclude_hold=true)
   { label: "매수", value: "buy" },
   { label: "매도", value: "sell" },
   { label: "HOLD", value: "hold" },
+  { label: "전체", value: "" },
 ] as const;
 
 const STAT_PERIODS = [
@@ -28,14 +31,26 @@ export default function SignalsPage() {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [total, setTotal] = useState(0);
-  const [filter, setFilter] = useState("");
+  const [filter, setFilter] = useState<string>("trades"); // 기본: 매매만
+  const [excludeZeroConfidence, setExcludeZeroConfidence] = useState(true);
   const [statPeriod, setStatPeriod] = useState(1);
   const [selected, setSelected] = useState<SignalItem | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
+      const queryParams: Parameters<typeof getSignals>[0] = { page, limit: 30 };
+      if (filter === "trades") {
+        queryParams.exclude_hold = true;
+      } else if (filter) {
+        queryParams.signal_type = filter;
+      }
+      if (excludeZeroConfidence) {
+        // 0.001은 0%로 표시되지만 실제 0은 아닌 값까지 포함 — 0 초과만 남김
+        queryParams.min_confidence = 0.001;
+      }
+
       const [signalRes, statsRes] = await Promise.all([
-        getSignals({ page, limit: 30, signal_type: filter || undefined }),
+        getSignals(queryParams),
         getSignalStats(statPeriod),
       ]);
       setSignals(signalRes.items);
@@ -47,7 +62,7 @@ export default function SignalsPage() {
     } finally {
       setLoading(false);
     }
-  }, [page, filter, statPeriod]);
+  }, [page, filter, excludeZeroConfidence, statPeriod]);
 
   useEffect(() => {
     fetchData();
@@ -112,8 +127,8 @@ export default function SignalsPage() {
 
       {/* Filter */}
       <div className="card" style={{ marginBottom: 16 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <div style={{ display: "flex", gap: 6 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
             {SIGNAL_FILTERS.map((f) => (
               <button
                 key={f.value}
@@ -132,8 +147,22 @@ export default function SignalsPage() {
               </button>
             ))}
           </div>
-          <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
-            총 {formatNumber(total)}건
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <label
+              style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}
+              title="HOLD 신호는 조건 미충족 기록이라 confidence=0이 정상. 끄면 포함됨."
+            >
+              <input
+                type="checkbox"
+                checked={excludeZeroConfidence}
+                onChange={(e) => { setExcludeZeroConfidence(e.target.checked); setPage(1); }}
+                style={{ cursor: "pointer" }}
+              />
+              신뢰도 0% 제외
+            </label>
+            <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              총 {formatNumber(total)}건
+            </div>
           </div>
         </div>
       </div>

--- a/src/cryptobot/api/routes/signals.py
+++ b/src/cryptobot/api/routes/signals.py
@@ -14,9 +14,15 @@ def get_signals(
     limit: int = Query(50, ge=1, le=200),
     signal_type: str | None = Query(None),
     strategy: str | None = Query(None),
+    exclude_hold: bool = Query(False, description="hold 신호 제외"),
+    min_confidence: float | None = Query(None, ge=0.0, le=1.0, description="신뢰도 최소값 (0.0~1.0)"),
     _: UserResponse = Depends(get_current_user),
 ):
-    """매매 신호 목록 조회 (최신순)."""
+    """매매 신호 목록 조회 (최신순).
+
+    hold 신호는 조건 미충족 기록용이라 confidence=0인 것이 정상이므로,
+    대시보드 기본 뷰에서는 exclude_hold=true 권장.
+    """
     db = get_db()
 
     where_clauses = []
@@ -25,6 +31,11 @@ def get_signals(
     if signal_type:
         where_clauses.append("signal_type = ?")
         params.append(signal_type)
+    if exclude_hold:
+        where_clauses.append("signal_type != 'hold'")
+    if min_confidence is not None:
+        where_clauses.append("confidence >= ?")
+        params.append(min_confidence)
     if strategy:
         where_clauses.append("strategy = ?")
         params.append(strategy)

--- a/src/cryptobot/bot/risk.py
+++ b/src/cryptobot/bot/risk.py
@@ -20,7 +20,8 @@ class RiskLimits:
     max_daily_loss_pct: float = -10.0  # 일일 최대 손실률 (%)
     max_position_size_krw: float = 1_000_000  # 최대 1회 매수 금액 (원)
     min_balance_krw: float = 5_000  # 최소 유지 잔고 (업비트 최소 주문금액)
-    max_consecutive_losses: int = 3  # 연속 손실 시 매매 중단
+    max_consecutive_losses: int = 5  # 연속 손실 시 매매 중단 (최근 1일 윈도우)
+    consecutive_loss_window_hours: int = 24  # 연속 손실 판정 윈도우
     min_order_krw: float = 5_000  # 업비트 최소 주문 금액 (원)
 
 
@@ -30,7 +31,6 @@ class RiskManager:
     매매 전에 check_*() 메서드로 리스크를 점검한다.
     NestJS의 Guard처럼, 조건 미충족 시 매매를 차단한다.
     """
-
 
     def __init__(self, db: Database, limits: RiskLimits | None = None) -> None:
         self._db = db
@@ -127,14 +127,21 @@ class RiskManager:
         return float(row[0]) if row else 0.0
 
     def _get_consecutive_losses(self, coin: str) -> int:
-        """최근 연속 손실 횟수."""
+        """최근 consecutive_loss_window_hours 내 연속 손실 횟수.
+
+        시간 윈도우를 두지 않으면 한 번 연속 손실이 발생한 코인이 영구 차단된다
+        (다음 수익 거래가 나올 때까지 재매수 금지). 매매가 아예 중단된 코인에는
+        이 서킷브레이커가 의미 없으므로 최근 윈도우로 제한한다.
+        """
+        window_hours = self.limits.consecutive_loss_window_hours
         rows = self._db.execute(
             """
             SELECT profit_pct FROM trades
             WHERE coin = ? AND side = 'sell' AND profit_pct IS NOT NULL
+              AND timestamp >= datetime('now', ?)
             ORDER BY id DESC LIMIT ?
             """,
-            (coin, self.limits.max_consecutive_losses),
+            (coin, f"-{window_hours} hours", self.limits.max_consecutive_losses),
         ).fetchall()
 
         count = 0
@@ -144,4 +151,3 @@ class RiskManager:
             else:
                 break
         return count
-

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -260,9 +260,9 @@ class LLMAnalyzer:
     def is_configured(self) -> bool:
         return bool(self._api_key)
 
-    # Haiku 4.5 가격 (2026-04 기준)
-    PRICE_INPUT_PER_M = 0.80  # $0.80 / 1M 입력 토큰
-    PRICE_OUTPUT_PER_M = 4.00  # $4.00 / 1M 출력 토큰
+    # Haiku 4.5 공식가 (platform.claude.com/docs/en/docs/about-claude/pricing)
+    PRICE_INPUT_PER_M = 1.00  # $1.00 / 1M 입력 토큰
+    PRICE_OUTPUT_PER_M = 5.00  # $5.00 / 1M 출력 토큰
     MAX_DAILY_CALLS = 36  # 하드 리밋 (활발 시 24회 + 긴급 여유)
     # 동적 주기 (시장 활동량에 따라)
     INTERVAL_ACTIVE_MIN = 60  # 활발: 1시간 (30분은 파라미터 진동만 유발)

--- a/tests/test_llm_dynamic_interval.py
+++ b/tests/test_llm_dynamic_interval.py
@@ -83,3 +83,22 @@ def test_normal_when_one_open_position():
     # buy만 존재 — trades 테이블에 1건 있으므로 trade_count=1, position_count=1
     # trade_count(1) < 2 이고 position_count(1) < 3 이므로 NORMAL
     assert analyzer._get_dynamic_interval_minutes() == analyzer.INTERVAL_NORMAL_MIN
+
+
+def test_haiku_pricing_matches_official():
+    """Haiku 4.5 가격 상수는 공식가와 일치해야 한다.
+
+    공식: input $1.00/MTok, output $5.00/MTok
+    (platform.claude.com/docs/en/docs/about-claude/pricing)
+    """
+    analyzer, db = _make_analyzer()
+    assert analyzer.PRICE_INPUT_PER_M == 1.00, "Haiku 4.5 공식 input 가격: $1/MTok"
+    assert analyzer.PRICE_OUTPUT_PER_M == 5.00, "Haiku 4.5 공식 output 가격: $5/MTok"
+
+
+def test_cost_calculation_example():
+    """실측 데이터 예시: in=25083 + out=911 → 공식가 $0.02963."""
+    analyzer, db = _make_analyzer()
+    cost = analyzer._calc_cost(25083, 911)
+    # 25083/1M * 1 + 911/1M * 5 = 0.025083 + 0.004555 = 0.029638
+    assert abs(cost - 0.029638) < 1e-5

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -203,3 +203,122 @@ def test_sell_always_allowed():
         assert can is True
     finally:
         db.close()
+
+
+def test_consecutive_losses_outside_window_ignored():
+    """시간 윈도우 밖의 과거 손실은 현재 매매를 차단하지 않는다.
+
+    과거 이슈: 한번 연속 3회 손실난 코인이 수익 거래가 나올 때까지 영구 차단됐음.
+    """
+    limits = RiskLimits(max_consecutive_losses=3, consecutive_loss_window_hours=24)
+    rm, recorder, db = _make_risk_manager(limits)
+    try:
+        # 2일 전 매도 3건 — 전부 손실
+        for _ in range(3):
+            buy_id = recorder.record_trade(
+                coin="KRW-BTC",
+                side="buy",
+                price=50000000,
+                amount=0.001,
+                total_krw=50000,
+                fee_krw=25,
+                strategy="test",
+                trigger_reason="test",
+            )
+            recorder.record_trade(
+                coin="KRW-BTC",
+                side="sell",
+                price=48000000,
+                amount=0.001,
+                total_krw=48000,
+                fee_krw=24,
+                strategy="test",
+                trigger_reason="손절",
+                buy_trade_id=buy_id,
+                profit_pct=-4.0,
+                profit_krw=-2000,
+            )
+        # 모든 레코드를 윈도우 밖으로 이동 (2일 전)
+        db.execute("UPDATE trades SET timestamp = datetime('now', '-2 days')")
+        db.commit()
+
+        can, _ = rm.check_can_buy("KRW-BTC", 50_000, 500_000)
+        assert can is True, "24시간 윈도우 밖 손실은 차단해선 안 됨"
+    finally:
+        db.close()
+
+
+def test_consecutive_losses_within_window_blocks():
+    """시간 윈도우 안 연속 손실은 차단한다."""
+    limits = RiskLimits(max_consecutive_losses=3, consecutive_loss_window_hours=24, max_daily_loss_pct=-100.0)
+    rm, recorder, db = _make_risk_manager(limits)
+    try:
+        for _ in range(3):
+            buy_id = recorder.record_trade(
+                coin="KRW-BTC",
+                side="buy",
+                price=50000000,
+                amount=0.001,
+                total_krw=50000,
+                fee_krw=25,
+                strategy="test",
+                trigger_reason="test",
+            )
+            recorder.record_trade(
+                coin="KRW-BTC",
+                side="sell",
+                price=49950000,
+                amount=0.001,
+                total_krw=49950,
+                fee_krw=25,
+                strategy="test",
+                trigger_reason="손절",
+                buy_trade_id=buy_id,
+                profit_pct=-0.1,
+                profit_krw=-50,
+            )
+
+        can, reason = rm.check_can_buy("KRW-BTC", 50_000, 500_000)
+        assert can is False
+        assert "연속" in reason
+    finally:
+        db.close()
+
+
+def test_default_consecutive_losses_allows_4_losses():
+    """기본 max_consecutive_losses=5 — 4회 연속 손실까지는 이 가드에서 차단 안 함.
+
+    다른 가드(일일 손실률 등)는 분리 테스트. 여기선 연속 손실 카운트만 검증.
+    """
+    limits = RiskLimits(max_consecutive_losses=5, max_daily_loss_pct=-100.0)
+    rm, recorder, db = _make_risk_manager(limits)
+    try:
+        for _ in range(4):
+            buy_id = recorder.record_trade(
+                coin="KRW-BTC",
+                side="buy",
+                price=50000000,
+                amount=0.001,
+                total_krw=50000,
+                fee_krw=25,
+                strategy="test",
+                trigger_reason="test",
+            )
+            recorder.record_trade(
+                coin="KRW-BTC",
+                side="sell",
+                price=49950000,
+                amount=0.001,
+                total_krw=49950,
+                fee_krw=25,
+                strategy="test",
+                trigger_reason="손절",
+                buy_trade_id=buy_id,
+                profit_pct=-0.1,
+                profit_krw=-50,
+            )
+
+        can, _ = rm.check_can_buy("KRW-BTC", 50_000, 500_000)
+        assert can is True, "4회 연속 손실은 5회 미만이라 허용돼야 함"
+    finally:
+        db.close()


### PR DESCRIPTION
오늘 발견된 3가지 이슈 통합 수정.

## #163 — LLM 비용 계산 가격 상수 오류 (fix)
Haiku 4.5 공식가와 코드 상수 불일치 (약 20% 저평가).

| 항목 | 수정 전 | 수정 후 |
|---|---:|---:|
| PRICE_INPUT_PER_M | \$0.80 | **\$1.00** |
| PRICE_OUTPUT_PER_M | \$4.00 | **\$5.00** |

- 공식가: https://platform.claude.com/docs/en/docs/about-claude/pricing
- 322건 누적 재계산: DB \$3.92 → \$4.91 (실제 청구 \$5.83)
- 잔차 \$0.92는 재시도 실패 시 DB 미기록 이슈 — 별도 추적 예정

## #164 — 연속 손실 서킷브레이커 영구 차단 (fix)
\`_get_consecutive_losses()\`가 시간 제한 없이 DB 전체에서 최근 3건을 봤음.
→ 한번 3회 연속 손실난 코인이 **다음 수익 거래까지 영구 차단**.

- \`max_consecutive_losses\`: 3 → **5**
- \`consecutive_loss_window_hours\` 신설: **24시간 윈도우**
- 실측: WLFI가 9일 전 손실 때문에 오늘 0건 매매의 원인. HBAR/QTUM/RENDER도 동일

## #165 — 매매 신호 UI (improve)
### 표면 현상
최근 24h 신호 분포: buy 191, sell 2, **hold 25,978** — hold가 대시보드를 독점해 "신뢰도가 다 0%"로 오인.

### 코어 검증 (추가) ✅
사용자 지적으로 "최근 12시간 confidence 전부 0%" 원인을 DB로 재검증:
- 최근 12h 신호: **hold 11,015건, buy/sell 0건**
- hold는 \`confidence=0\`이 **정상 동작** (조건 미충족 기록용)
- WLFI 현재 상태: RSI=18.6 (과매도) + 가격=123 > bb_lower=107.43 → 하단 미이탈 → hold 정당
- \`bb_rsi_combined\` AND 조건(RSI+BB 모두)을 충족하는 코인이 12h+ 없음 → **버그 아님**

### UI 수정
- 대시보드 기본 필터: "매매만" (hold 제외)
- "신뢰도 0% 제외" 체크박스 (기본 켜짐)
- API: \`exclude_hold\`, \`min_confidence\` 파라미터 신설

### 근본 문제는 별도
12h+ 매매 기회 0건 자체는 실질적 문제 — 전략 엄격함이 원인. **#167에서 추적** (bb_rsi_combined 완화 / 복수 전략 병행 / LLM 강화).

## Test plan
- [x] pytest tests/ 통과 (150/150)
- [x] \`npm run build\` 성공
- [x] ruff check/format 깨끗
- [x] DB 실측으로 buy/sell 0건, hold만 존재 재검증
- [ ] 배포 후 비용/차단 상태 모니터링

Related: #163, #164, #165
Ref: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)