### PR TITLE
[P0] 주문/기록 무결성 — API 예외, 즉시 commit, 미존재 전략 처리 (#169)

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -25,6 +25,7 @@ from cryptobot.bot.trader import Trader
 from cryptobot.bot.weekly_reporter import WeeklyReporter
 from cryptobot.data.database import Database
 from cryptobot.data.recorder import DataRecorder
+from cryptobot.exceptions import APIError, InsufficientBalanceError
 from cryptobot.notifier.slack import SlackNotifier
 from cryptobot.strategies.base import BaseStrategy
 
@@ -197,9 +198,27 @@ class CryptoBot:
             return
 
         bal_before = bal  # 잔고 스냅샷
-        order = self._trader.buy_market(coin, amount)
+        # 주문 실행 — APIError가 중간에 나면 주문이 접수됐을 수도 있으니 긴급 알림 필수
+        try:
+            order = self._trader.buy_market(coin, amount)
+        except (APIError, InsufficientBalanceError) as e:
+            logger.error("매수 API 실패: %s %s원 — %s", coin, f"{amount:,.0f}", e)
+            self._notifier.notify_error(
+                f"⚠️ 매수 주문 API 실패: {coin} {amount:,.0f}원 — 접수 후 체결 조회 실패 가능성. "
+                f"Upbit에서 수동 확인 필요.\n{e}"
+            )
+            skip = f"API 예외: {type(e).__name__}"
+            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=skip, snapshot_id=snapshot_id, strategy_params_json=pj)
+            return
         if order.success:
             tid = self._recorder.record_trade(coin=coin, side="buy", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, market_state_at_trade=snapshot.get("market_state"), btc_price_at_trade=price, rsi_at_trade=snapshot.get("rsi_14"), order_uuid=order.order_uuid)
+            # 즉시 commit — 다음 틱이 이 buy를 찾지 못해 중복 매수하는 것을 방지
+            try:
+                self._db.commit()
+            except Exception as ce:
+                logger.critical("매수 trade commit 실패: coin=%s tid=%s — %s", coin, tid, ce)
+                self._notifier.notify_error(f"🚨 DB commit 실패 (매수): {coin} — 수동 확인 필수")
+                raise
             # DB 쓰기 검증
             verify = self._db.execute("SELECT id FROM trades WHERE id = ?", (tid,)).fetchone()
             if not verify:
@@ -212,6 +231,9 @@ class CryptoBot:
             if abs(actual_diff - expected_diff) > expected_diff * 0.05:
                 logger.warning("잔고 불일치: 예상 -%s, 실제 -%s", f"{expected_diff:,.0f}", f"{actual_diff:,.0f}")
             self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, executed=True, trade_id=tid, snapshot_id=snapshot_id, strategy_params_json=pj)
+        else:
+            # 사전 검증 실패 (최소 주문 금액 미달 등) — 기록만
+            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=order.error or "주문 실패", snapshot_id=snapshot_id, strategy_params_json=pj)
 
     def _check_and_sell(self, active_trade, price, snapshot_id, snapshot=None, coin=None):
         """매도 신호 확인 및 실행."""
@@ -246,12 +268,29 @@ class CryptoBot:
             self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=f"수수료 가드: 가격 {pnl_pct:+.2f}% 실질 {net_pnl:+.2f}%", snapshot_id=snapshot_id, strategy_params_json=pj)
             return
 
-        order = self._trader.sell_market(coin)
+        try:
+            order = self._trader.sell_market(coin)
+        except (APIError, InsufficientBalanceError) as e:
+            logger.error("매도 API 실패: %s — %s", coin, e)
+            self._notifier.notify_error(
+                f"⚠️ 매도 주문 API 실패: {coin} — 접수 후 체결 조회 실패 가능성. "
+                f"Upbit에서 수동 확인 필요.\n{e}"
+            )
+            skip = f"API 예외: {type(e).__name__}"
+            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=skip, snapshot_id=snapshot_id, strategy_params_json=pj)
+            return
         if order.success:
             bf = active_trade.get("fee_krw") or 0
             profit_krw = round((order.total_krw - order.fee_krw) - (active_trade["total_krw"] + bf), 2)
             profit_pct = round(profit_krw / (active_trade["total_krw"] + bf) * 100, 2) if (active_trade["total_krw"] + bf) > 0 else 0
             tid = self._recorder.record_trade(coin=coin, side="sell", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, buy_trade_id=active_trade["id"], profit_pct=profit_pct, profit_krw=profit_krw, hold_duration_minutes=s._hold_minutes, order_uuid=order.order_uuid)
+            # 즉시 commit — 미커밋으로 다음 틱이 이 매도를 놓치면 이중 매도 위험
+            try:
+                self._db.commit()
+            except Exception as ce:
+                logger.critical("매도 trade commit 실패: coin=%s tid=%s — %s", coin, tid, ce)
+                self._notifier.notify_error(f"🚨 DB commit 실패 (매도): {coin} — 수동 확인 필수")
+                raise
             # DB 쓰기 검증
             verify = self._db.execute("SELECT id FROM trades WHERE id = ?", (tid,)).fetchone()
             if not verify:
@@ -259,6 +298,8 @@ class CryptoBot:
                 self._notifier.notify_error(f"DB 쓰기 검증 실패: {coin} 매도 기록 누락")
             self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, executed=True, trade_id=tid, snapshot_id=snapshot_id, strategy_params_json=pj)
             s.reset()
+        else:
+            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=order.error or "주문 실패", snapshot_id=snapshot_id, strategy_params_json=pj)
 
     def _llm_analyze(self):
         try:

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -634,6 +634,10 @@ class LLMAnalyzer:
                     changed = [f"{k}={v}" for k, v in after.items()]
                     if changed:
                         entry += f" | 설정: {', '.join(changed[:5])}"
+                    # LLM이 존재하지 않는 전략 이름을 반환했던 경우 경고 표기
+                    rejected = ba.get("_rejected_strategy")
+                    if rejected:
+                        entry += f" | ⚠️ 거절된 추천: {ba.get('_rejected_strategy_reason', rejected)}"
                 except Exception:
                     pass
 
@@ -1521,7 +1525,16 @@ class LLMAnalyzer:
             repo = StrategyRepository(self._db)
             activated = repo.activate(strategy, source="llm", reason="LLM 분석에서 추천")
             if not activated:
-                logger.warning("전략 활성화 실패: %s — 기존 전략 유지", strategy)
+                # LLM이 존재하지 않는 전략 이름을 반환한 경우
+                # — 다음 호출의 이전 피드백에 반영하기 위해 결과 딕셔너리에 마킹
+                logger.warning("전략 활성화 실패: %s — 기존 전략 유지, 다음 프롬프트에 반영", strategy)
+                available = self._db.execute(
+                    "SELECT name FROM strategies WHERE is_available = TRUE"
+                ).fetchall()
+                names = ", ".join(dict(r)["name"] for r in available) or "(없음)"
+                result["_rejected_strategy"] = strategy
+                result["_rejected_strategy_reason"] = f"'{strategy}'은 존재하지 않음. 사용 가능: {names}"
+                strategy = None  # 이후 파라미터 병합도 스킵
 
             # 기존 파라미터 로드
             row = self._db.execute("SELECT default_params_json FROM strategies WHERE name = ?", (strategy,)).fetchone()
@@ -1594,14 +1607,18 @@ class LLMAnalyzer:
             if key not in COMMON_PARAM_KEYS:
                 after[f"strategy:{key}"] = value
 
-        # before/after를 최신 llm_decisions에 기록
+        # before/after를 최신 llm_decisions에 기록 (거절된 전략 추천이 있으면 함께)
+        payload = {"before": before, "after": after, "strategy": strategy}
+        if result.get("_rejected_strategy"):
+            payload["_rejected_strategy"] = result["_rejected_strategy"]
+            payload["_rejected_strategy_reason"] = result.get("_rejected_strategy_reason", "")
         self._db.execute(
             """
             UPDATE llm_decisions SET
                 input_news_summary = ?
             WHERE id = (SELECT MAX(id) FROM llm_decisions)
             """,
-            (json.dumps({"before": before, "after": after, "strategy": strategy}, ensure_ascii=False),),
+            (json.dumps(payload, ensure_ascii=False),),
         )
 
         self._db.commit()

--- a/tests/test_order_record_integrity.py
+++ b/tests/test_order_record_integrity.py
@@ -1,0 +1,203 @@
+"""P0 #169 — 주문/기록 무결성 테스트.
+
+검증 대상:
+1. _check_and_buy/sell에서 APIError 발생 시 긴급 알림 + record_signal(skip_reason)
+2. record_trade 직후 명시적 commit 실행
+3. LLM이 미존재 전략 이름 반환 시 기존 전략 유지 + rejected 마킹
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cryptobot.data.database import Database
+from cryptobot.data.recorder import DataRecorder
+from cryptobot.exceptions import APIError
+from cryptobot.llm.analyzer import LLMAnalyzer
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def test_check_and_buy_api_error_notifies_and_records_signal(db):
+    """매수 중 APIError 발생 시: notify_error + record_signal(skip_reason='API 예외: APIError')."""
+    from cryptobot.bot.main import CryptoBot
+
+    bot = CryptoBot.__new__(CryptoBot)
+    bot._db = db
+    bot._recorder = DataRecorder(db)
+    bot._notifier = MagicMock()
+    bot._trader = MagicMock()
+    bot._trader.is_ready = True
+    bot._trader.get_balance_krw.return_value = 100_000
+    bot._trader.buy_market.side_effect = APIError("Upbit timeout")
+
+    # RiskManager/strategy selector mock
+    bot._risk = MagicMock()
+    bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
+    bot._config_mgr = MagicMock()
+    bot._config_mgr.get.return_value = "50"
+    bot._config_mgr.get_strategy_params_json.return_value = None
+
+    strat = MagicMock()
+    strat.check_buy.return_value = MagicMock(
+        signal_type="buy", confidence=0.8, reason="RSI+BB", trigger_value=100.0,
+    )
+    strat.params = MagicMock(position_size_pct=100)
+    bot._strategy_sel = MagicMock()
+    bot._strategy_sel.current_strategy = strat
+    bot._strategy_sel.current_strategy_name = "bb_rsi_combined"
+
+    coll = MagicMock()
+    coll.latest_df = pd.DataFrame({"close": [100] * 30})
+    bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
+
+    bot._check_and_buy({"market_state": "sideways"}, price=100.0, snapshot_id=None, coin="KRW-BTC")
+
+    bot._notifier.notify_error.assert_called_once()
+    # record_signal 중 skip_reason에 "API 예외" 포함 확인
+    rows = db.execute("SELECT skip_reason FROM trade_signals ORDER BY id DESC LIMIT 1").fetchall()
+    assert len(rows) == 1
+    assert "API 예외" in dict(rows[0])["skip_reason"]
+
+
+def test_check_and_sell_api_error_notifies_and_records_signal(db):
+    """매도 중 APIError 발생 시: notify_error + record_signal(skip_reason='API 예외: APIError')."""
+    from cryptobot.bot.main import CryptoBot
+
+    bot = CryptoBot.__new__(CryptoBot)
+    bot._db = db
+    bot._recorder = DataRecorder(db)
+    bot._notifier = MagicMock()
+    bot._trader = MagicMock()
+    bot._trader.is_ready = True
+    bot._trader.sell_market.side_effect = APIError("Upbit rate limit")
+
+    bot._config_mgr = MagicMock()
+    bot._config_mgr.get_strategy_params_json.return_value = None
+
+    strat = MagicMock()
+    strat.check_sell.return_value = MagicMock(
+        signal_type="sell", confidence=0.7, reason="RSI 정상 복귀", trigger_value=70.0,
+    )
+    strat.params = MagicMock()
+    strat.params.extra = {}
+    strat.params.stop_loss_pct = -5
+    strat.params.trailing_stop_pct = -2
+    strat._hold_minutes = 10
+    bot._strategy_sel = MagicMock()
+    bot._strategy_sel.current_strategy = strat
+    bot._strategy_sel.current_strategy_name = "bb_rsi_combined"
+
+    coll = MagicMock()
+    coll.latest_df = pd.DataFrame({"close": [100] * 30})
+    bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
+
+    active_trade = {
+        "id": 1, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+        "timestamp": "2026-04-17T00:00:00+00:00",
+    }
+    bot._check_and_sell(active_trade, price=110.0, snapshot_id=None, coin="KRW-BTC")
+
+    bot._notifier.notify_error.assert_called_once()
+    rows = db.execute("SELECT skip_reason FROM trade_signals ORDER BY id DESC LIMIT 1").fetchall()
+    assert "API 예외" in dict(rows[0])["skip_reason"]
+
+
+def test_check_and_buy_commits_immediately_after_record(db):
+    """성공 매수 후 명시적 commit이 호출된다 (다음 틱 중복 매수 방지)."""
+    from cryptobot.bot.main import CryptoBot
+    from cryptobot.bot.trader import OrderResult
+
+    bot = CryptoBot.__new__(CryptoBot)
+    bot._db = MagicMock(wraps=db)
+    # commit을 명시적으로 spy
+    commit_calls = []
+    orig_commit = db.commit
+    def spy_commit():
+        commit_calls.append(1)
+        orig_commit()
+    bot._db.commit = spy_commit
+    # 실제 쿼리는 실제 DB로
+    bot._db.execute = db.execute
+    bot._recorder = DataRecorder(db)
+    bot._notifier = MagicMock()
+    bot._trader = MagicMock()
+    bot._trader.is_ready = True
+    bot._trader.get_balance_krw.return_value = 100_000
+    bot._trader.buy_market.return_value = OrderResult(
+        success=True, side="buy", coin="KRW-BTC", price=100, amount=1,
+        total_krw=10_000, fee_krw=5, order_uuid="test-uuid",
+    )
+    bot._risk = MagicMock()
+    bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
+    bot._config_mgr = MagicMock()
+    bot._config_mgr.get.return_value = "50"
+    bot._config_mgr.get_strategy_params_json.return_value = None
+
+    strat = MagicMock()
+    strat.check_buy.return_value = MagicMock(
+        signal_type="buy", confidence=0.8, reason="test", trigger_value=100.0,
+    )
+    strat.params = MagicMock(position_size_pct=100)
+    strat.params.extra = {"k_value": 0.5}
+    strat.params.stop_loss_pct = -5
+    strat.params.trailing_stop_pct = -2
+    bot._strategy_sel = MagicMock()
+    bot._strategy_sel.current_strategy = strat
+    bot._strategy_sel.current_strategy_name = "bb_rsi_combined"
+    coll = MagicMock()
+    coll.latest_df = pd.DataFrame({"close": [100] * 30})
+    bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
+
+    bot._check_and_buy({"market_state": "sideways"}, price=100.0, snapshot_id=None, coin="KRW-BTC")
+
+    assert len(commit_calls) >= 1, "매수 후 최소 1회 commit이 호출돼야 함"
+
+
+def test_rejected_strategy_marks_result_and_preserves_existing(db):
+    """LLM이 존재하지 않는 전략 이름 반환 시 기존 전략 유지 + _rejected_strategy 플래그."""
+    # available 전략 2개 등록
+    # initialize()가 기본 전략을 등록하므로 bb_rsi_combined만 활성화로 세팅
+    db.execute("UPDATE strategies SET is_active = 0")
+    db.execute("UPDATE strategies SET is_active = 1, is_available = 1 WHERE name = 'bb_rsi_combined'")
+    db.execute(
+        "INSERT INTO llm_decisions (timestamp, model, output_raw_json) VALUES (datetime('now'), 'test', '{}')"
+    )
+    db.commit()
+
+    analyzer = LLMAnalyzer(db)
+    result = {
+        "market_summary_kr": "test",
+        "market_state": "sideways",
+        "confidence": 0.7,
+        "aggression": 0.5,
+        "allow_trading": True,
+        "should_alert_stop": False,
+        "recommended_strategy": "NONEXISTENT_STRATEGY",
+        "recommended_params": {},
+        "reasoning": "test",
+    }
+    analyzer._apply_recommendations(result)
+
+    # 기존 활성 전략이 유지됨
+    active = db.execute("SELECT name FROM strategies WHERE is_active = 1").fetchone()
+    assert dict(active)["name"] == "bb_rsi_combined"
+
+    # llm_decisions에 rejected 정보 저장됐는지
+    row = db.execute("SELECT input_news_summary FROM llm_decisions ORDER BY id DESC LIMIT 1").fetchone()
+    import json as _j
+    payload = _j.loads(dict(row)["input_news_summary"])
+    assert payload.get("_rejected_strategy") == "NONEXISTENT_STRATEGY"
+    assert "사용 가능" in payload.get("_rejected_strategy_reason", "")


### PR DESCRIPTION
마스터 #168의 P0. 돈 유실 위험 3건 수정.

## 수정 내용
1. **APIError 예외 포착**: \`_check_and_buy\`/\`_check_and_sell\`에 try/except 추가. Upbit 타임아웃/rate limit 시 긴급 알림 + skip_reason 기록.
2. **record_trade 직후 명시적 commit**: 다음 틱이 미커밋 매매를 놓쳐 재매수/재매도하는 위험 차단.
3. **미존재 전략 사일런트 무시 방지**: LLM이 오타나 비존재 전략명 반환 시 \`_rejected_strategy\` 마킹 → 다음 프롬프트 이전 피드백에 경고 포함.

## Test plan
- [x] tests/test_order_record_integrity.py 4건 통과
- [x] 전체 154건 통과
- [x] ruff check 깨끗 (변경된 라인 기준)
- [ ] 배포 후 실제 예외 케이스 로그 확인

## 한계 / 별도 이슈
- API 예외 후 실제 주문 접수/체결 자동 복구는 미포함 — HealthChecker reconcile 확장 필요 (P3 일부)

Related: #168, #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)