### PR TITLE
[P4] 데이터 위생 4건 — signals/NULL/orphan/fallback (#173)

### DIFF
--- a/scripts/cleanup_old_hold_signals.py
+++ b/scripts/cleanup_old_hold_signals.py
@@ -1,0 +1,66 @@
+"""오래된 hold 신호 정리 — DB 부피/조회 성능 개선.
+
+실측: trade_signals가 시간당 수천 건 쌓여 테이블이 거대화됨. buy/sell은 영구 보존해야 하나
+hold는 조건 미충족 기록용이라 14일 이상이면 삭제해도 무방.
+
+사용법:
+    python -m cryptobot.scripts.cleanup_old_hold_signals           # 14일 이전 hold 삭제
+    python -m cryptobot.scripts.cleanup_old_hold_signals --days 7  # 기간 지정
+    python -m cryptobot.scripts.cleanup_old_hold_signals --dry-run # 삭제할 건수만 출력
+
+APScheduler 주간 잡으로도 호출 가능 (main.py에서 scheduler.add_job 참조).
+"""
+
+import argparse
+import logging
+
+from cryptobot.bot.config import config
+from cryptobot.data.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup(days: int = 14, dry_run: bool = False) -> int:
+    """days일 이전의 hold 신호 삭제. 삭제 건수 반환."""
+    db = Database(config.bot.db_path)
+    db.initialize()
+    try:
+        row = db.execute(
+            "SELECT COUNT(*) FROM trade_signals "
+            "WHERE signal_type = 'hold' AND timestamp < datetime('now', ?)",
+            (f"-{days} days",),
+        ).fetchone()
+        count = row[0] if row else 0
+
+        if count == 0:
+            print(f"[cleanup] {days}일 이전 hold 신호 없음")
+            return 0
+
+        if dry_run:
+            print(f"[dry-run] {days}일 이전 hold 신호 {count:,}건 — 실제 삭제 안 함")
+            return count
+
+        db.execute(
+            "DELETE FROM trade_signals "
+            "WHERE signal_type = 'hold' AND timestamp < datetime('now', ?)",
+            (f"-{days} days",),
+        )
+        db.commit()
+        db.execute("VACUUM")
+        print(f"[cleanup] hold 신호 {count:,}건 삭제 + VACUUM 완료")
+        return count
+    finally:
+        db.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", type=int, default=14, help="N일 이전 데이터 삭제 (기본 14)")
+    parser.add_argument("--dry-run", action="store_true", help="삭제하지 않고 건수만 출력")
+    args = parser.parse_args()
+    cleanup(days=args.days, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cryptobot/data/recorder.py
+++ b/src/cryptobot/data/recorder.py
@@ -97,6 +97,23 @@ class DataRecorder:
         Returns:
             생성된 trade의 id
         """
+        # profit_pct만 들어오고 profit_krw 누락된 경우 자동 계산 (#173)
+        # 성과 리포트의 SUM(profit_krw) undercount 방지
+        if profit_pct is not None and profit_krw is None and total_krw > 0:
+            profit_krw = round(total_krw * profit_pct / 100, 2)
+
+        # buy_trade_id가 주어졌으면 실존 매수 레코드인지 검증 (#173)
+        # orphan sell (buy_trade_id가 가리키는 매수가 없는 상태) 방지
+        if buy_trade_id is not None:
+            exists = self._db.execute(
+                "SELECT 1 FROM trades WHERE id = ? AND side = 'buy'",
+                (buy_trade_id,),
+            ).fetchone()
+            if not exists:
+                raise ValueError(
+                    f"record_trade: buy_trade_id={buy_trade_id}에 해당하는 매수 레코드가 없음 (orphan 방지)"
+                )
+
         cursor = self._db.execute(
             """
             INSERT INTO trades (

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -591,13 +591,23 @@ class LLMAnalyzer:
         return result
 
     def _get_balance_text(self) -> str:
-        """현재 잔고 + 포지션 정보."""
+        """현재 잔고 + 포지션 정보.
+
+        API 미설정 시 LLM에 "API 키 미설정"만 주면 잔고 미상 상태로 공격적 권고를
+        받을 수 있음. DB 기반 보수적 폴백으로 대체하여 allow_trading=False 유도.
+        """
         try:
             from cryptobot.bot.trader import Trader
 
             trader = Trader()
             if not trader.is_ready:
-                return "API 키 미설정"
+                # 잔고 조회 불가 — 보수적 경고 텍스트로 대체
+                logger.warning("Trader 미설정 — 잔고 데이터 없이 LLM 호출. 보수 모드 유도")
+                return (
+                    "⚠️ 잔고 데이터 조회 불가 (Upbit API 미설정).\n"
+                    "신규 매수 가능 금액 미상 — 공격적 파라미터 권고 금지.\n"
+                    "권고: allow_trading=false 또는 보수적 aggression(≤0.3) 설정."
+                )
 
             krw = trader.get_balance_krw()
 

--- a/tests/test_data_hygiene.py
+++ b/tests/test_data_hygiene.py
@@ -1,0 +1,162 @@
+"""P4 #173 — 데이터 위생 테스트.
+
+1. 오래된 hold 신호 정리 (cleanup 스크립트)
+2. profit_krw NULL 자동 계산
+3. orphan buy_trade_id 방지
+4. balance_text API 미설정 시 보수적 폴백
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+from cryptobot.data.recorder import DataRecorder
+from cryptobot.llm.analyzer import LLMAnalyzer
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+# ===================================================================
+# 1. cleanup_old_hold_signals
+# ===================================================================
+
+
+def test_cleanup_removes_old_hold_keeps_buy_sell(db):
+    """14일 이상 된 hold는 삭제, buy/sell은 보존."""
+    recorder = DataRecorder(db)
+    # 오래된 hold + 최근 hold + 오래된 buy
+    recorder.record_signal(
+        coin="KRW-BTC", signal_type="hold", strategy="test",
+        confidence=0.0, trigger_reason="old", current_price=100,
+    )
+    recorder.record_signal(
+        coin="KRW-BTC", signal_type="buy", strategy="test",
+        confidence=0.8, trigger_reason="old buy", current_price=100,
+    )
+    recorder.record_signal(
+        coin="KRW-ETH", signal_type="hold", strategy="test",
+        confidence=0.0, trigger_reason="recent", current_price=100,
+    )
+    db.execute("UPDATE trade_signals SET timestamp = datetime('now', '-20 days') WHERE trigger_reason LIKE 'old%'")
+    db.commit()
+
+    before = db.execute("SELECT COUNT(*) FROM trade_signals").fetchone()[0]
+    assert before == 3
+
+    # 직접 SQL로 cleanup 시뮬레이션 (스크립트 본체는 config.bot.db_path를 쓰니 단위는 SQL로)
+    db.execute(
+        "DELETE FROM trade_signals "
+        "WHERE signal_type = 'hold' AND timestamp < datetime('now', '-14 days')"
+    )
+    db.commit()
+
+    rows = db.execute(
+        "SELECT signal_type, trigger_reason FROM trade_signals ORDER BY id"
+    ).fetchall()
+    types = [dict(r)["signal_type"] for r in rows]
+    # 오래된 hold는 사라짐, 오래된 buy + 최근 hold는 유지
+    assert "old buy" in [dict(r)["trigger_reason"] for r in rows]
+    assert types.count("hold") == 1
+    assert types.count("buy") == 1
+
+
+# ===================================================================
+# 2. profit_krw NULL 자동 계산
+# ===================================================================
+
+
+def test_record_trade_auto_fills_profit_krw(db):
+    """profit_pct만 주고 profit_krw 생략 시 total_krw * profit_pct / 100로 자동 계산."""
+    recorder = DataRecorder(db)
+    # 먼저 buy 생성 (orphan 방지 가드 통과)
+    buy_id = recorder.record_trade(
+        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
+        strategy="test", trigger_reason="test",
+    )
+    # profit_pct만 주고 profit_krw 생략
+    sell_id = recorder.record_trade(
+        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
+        strategy="test", trigger_reason="익절",
+        buy_trade_id=buy_id, profit_pct=10.0,  # profit_krw 생략
+    )
+    row = db.execute("SELECT profit_krw FROM trades WHERE id = ?", (sell_id,)).fetchone()
+    # 11000 * 10 / 100 = 1100
+    assert dict(row)["profit_krw"] == 1100.0
+
+
+def test_record_trade_respects_explicit_profit_krw(db):
+    """명시적 profit_krw가 있으면 덮어쓰지 않음."""
+    recorder = DataRecorder(db)
+    buy_id = recorder.record_trade(
+        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
+        strategy="test", trigger_reason="test",
+    )
+    sell_id = recorder.record_trade(
+        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
+        strategy="test", trigger_reason="익절",
+        buy_trade_id=buy_id, profit_pct=10.0, profit_krw=999.0,  # 명시적
+    )
+    row = db.execute("SELECT profit_krw FROM trades WHERE id = ?", (sell_id,)).fetchone()
+    assert dict(row)["profit_krw"] == 999.0
+
+
+# ===================================================================
+# 3. orphan buy_trade_id 방지
+# ===================================================================
+
+
+def test_orphan_sell_raises(db):
+    """존재하지 않는 buy_trade_id로 sell 시도 시 ValueError."""
+    recorder = DataRecorder(db)
+    with pytest.raises(ValueError, match="orphan"):
+        recorder.record_trade(
+            coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
+            strategy="test", trigger_reason="test",
+            buy_trade_id=999999,  # 존재 안 함
+        )
+
+
+def test_valid_buy_trade_id_accepted(db):
+    """실존 buy_trade_id는 정상 통과."""
+    recorder = DataRecorder(db)
+    buy_id = recorder.record_trade(
+        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
+        strategy="test", trigger_reason="test",
+    )
+    # 예외 없이 성공해야 함
+    sell_id = recorder.record_trade(
+        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
+        strategy="test", trigger_reason="익절",
+        buy_trade_id=buy_id,
+    )
+    assert sell_id > 0
+
+
+# ===================================================================
+# 4. balance_text API 미설정 보수적 폴백
+# ===================================================================
+
+
+def test_balance_text_api_not_configured_returns_conservative_warning(db, monkeypatch):
+    """Trader.is_ready=False일 때 LLM에 공격적 권고 금지 경고 포함."""
+    analyzer = LLMAnalyzer(db)
+
+    # Trader를 mock — is_ready False
+    import cryptobot.bot.trader as trader_mod
+
+    class _FakeTrader:
+        is_ready = False
+
+    monkeypatch.setattr(trader_mod, "Trader", _FakeTrader)
+    text = analyzer._get_balance_text()
+    # 더 이상 "API 키 미설정" 단순 메시지가 아니라 경고 포함 길어진 텍스트
+    assert "공격적 파라미터 권고 금지" in text or "allow_trading=false" in text

--- a/tests/test_llm_logic_accuracy.py
+++ b/tests/test_llm_logic_accuracy.py
@@ -213,9 +213,16 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     from cryptobot.bot.main import CryptoBot
     from cryptobot.bot.trader import OrderResult
 
+    # 실존 buy 레코드 먼저 생성 — orphan 가드(#173) 대응
+    recorder = DataRecorder(db)
+    buy_id = recorder.record_trade(
+        coin="KRW-BTC", side="buy", price=100.0, amount=1,
+        total_krw=10000, fee_krw=5, strategy="test_strategy", trigger_reason="seed",
+    )
+
     bot = CryptoBot.__new__(CryptoBot)
     bot._db = db
-    bot._recorder = DataRecorder(db)
+    bot._recorder = recorder
     bot._notifier = MagicMock()
     bot._trader = MagicMock()
     bot._trader.is_ready = True
@@ -244,7 +251,7 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
 
     active_trade = {
-        "id": 1, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+        "id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
         "timestamp": "2026-04-17T00:00:00+00:00",
     }
     # 가격 95 — 손실 상태지만 손절이므로 통과해야 함


### PR DESCRIPTION
마스터 #168의 P4 (마지막).

## 수정
1. **hold signals 정리 스크립트** — 14일 이전 삭제 + VACUUM
2. **profit_krw NULL 자동 계산** — record_trade에서 보정
3. **orphan buy_trade_id 가드** — 실존 buy 검증, 없으면 ValueError
4. **balance_text 보수적 폴백** — API 미설정 시 공격적 권고 금지 경고

## Test plan
- [x] pytest tests/test_data_hygiene.py 6/6 통과
- [x] 전체 182/182 통과 (회귀 1건 보정)
- [x] ruff check 깨끗

Related: #168, #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)