### PR TITLE
chore: 프로젝트 린트 에러 일괄 정리 — 66건 → 0건 (#162)

### DIFF
--- a/src/cryptobot/api/main.py
+++ b/src/cryptobot/api/main.py
@@ -6,12 +6,20 @@ NestJS의 main.ts (bootstrap) + AppModule과 동일.
     uvicorn cryptobot.api.main:app --reload --port 8000
 """
 
+import logging as _logging
 import os
+import time as _time
+from collections import defaultdict as _defaultdict
 
+from fastapi import Depends as _Depends
 from fastapi import FastAPI, Request
+from fastapi import Query as _Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel as _BaseModel
 
+from cryptobot.api.auth import UserResponse, get_current_user
+from cryptobot.api.deps import get_db as _get_db
 from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, public, signals, strategies, trades
 from cryptobot.logging_config import setup_logging
 
@@ -58,6 +66,7 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-XSS-Protection"] = "1; mode=block"
     return response
 
+
 # 라우트 등록
 app.include_router(public.router)  # 공개 API (인증 불필요)
 app.include_router(auth.router)
@@ -71,15 +80,11 @@ app.include_router(news.router)
 app.include_router(coin_strategy.router)
 
 
-from cryptobot.api.auth import UserResponse, get_current_user
-from cryptobot.api.deps import get_db as _get_db
-from fastapi import Query as _Query, Depends as _Depends
-
-
 @app.get("/api/llm/hard-limits", tags=["llm"])
 def get_hard_limits(_: UserResponse = _Depends(get_current_user)):
     """LLM 하드 리밋 조회 (읽기 전용)."""
     from cryptobot.llm.analyzer import HARD_LIMITS
+
     return {k: {"min": v[0], "max": v[1]} for k, v in HARD_LIMITS.items()}
 
 
@@ -95,7 +100,9 @@ def get_llm_decisions(limit: int = _Query(4, ge=1, le=50), _: UserResponse = _De
 def get_llm_prompts(_: UserResponse = _Depends(get_current_user)):
     """프롬프트 버전 목록."""
     db = _get_db()
-    rows = db.execute("SELECT id, version, description, is_active, created_at, activated_at FROM prompt_versions ORDER BY id DESC").fetchall()
+    rows = db.execute(
+        "SELECT id, version, description, is_active, created_at, activated_at FROM prompt_versions ORDER BY id DESC"
+    ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -115,12 +122,7 @@ def health_check():
     return {"status": "ok", "service": "cryptobot-api"}
 
 
-import logging as _logging
-
 _web_logger = _logging.getLogger("web")
-
-
-from pydantic import BaseModel as _BaseModel
 
 
 class _WebErrorReport(_BaseModel):
@@ -130,9 +132,6 @@ class _WebErrorReport(_BaseModel):
     url: str | None = None
     user_agent: str | None = None
 
-
-import time as _time
-from collections import defaultdict as _defaultdict
 
 _error_report_attempts: dict[str, list[float]] = _defaultdict(list)
 

--- a/src/cryptobot/api/routes/balance.py
+++ b/src/cryptobot/api/routes/balance.py
@@ -1,12 +1,13 @@
-import logging
-logger = logging.getLogger(__name__)
 """잔고 + 포지션 라우트."""
+
+import logging
 
 from fastapi import APIRouter, Depends, Query
 
 from cryptobot.api.auth import UserResponse, get_current_user
-from cryptobot.api.deps import get_db, get_recorder
+from cryptobot.api.deps import get_db
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/balance", tags=["balance"])
 
 
@@ -37,7 +38,6 @@ def get_balance(_: UserResponse = Depends(get_current_user)):
 @router.get("/positions")
 def get_positions(_: UserResponse = Depends(get_current_user)):
     """현재 보유 포지션 전체 (멀티코인 대응)."""
-    from cryptobot.bot.trader import Trader
 
     db = get_db()
     # 미매도 매수 건 전체 조회
@@ -53,14 +53,14 @@ def get_positions(_: UserResponse = Depends(get_current_user)):
     if not rows:
         return {"has_position": False, "positions": []}
 
-    trader = Trader()
     positions = []
     # 배치 가격 조회 (N개 코인 → 1 API)
     import pyupbit
+
     coins = list(set(dict(r)["coin"] for r in rows))
     try:
         prices = pyupbit.get_current_price(coins) if len(coins) > 1 else {coins[0]: pyupbit.get_current_price(coins[0])}
-    except Exception as e:
+    except Exception:
         prices = {}
 
     for row in rows:
@@ -74,12 +74,14 @@ def get_positions(_: UserResponse = Depends(get_current_user)):
             unrealized_pnl_pct = 0
             unrealized_pnl_krw = 0
 
-        positions.append({
-            **trade,
-            "current_price": current_price,
-            "unrealized_pnl_pct": round(unrealized_pnl_pct, 2),
-            "unrealized_pnl_krw": round(unrealized_pnl_krw, 0),
-        })
+        positions.append(
+            {
+                **trade,
+                "current_price": current_price,
+                "unrealized_pnl_pct": round(unrealized_pnl_pct, 2),
+                "unrealized_pnl_krw": round(unrealized_pnl_krw, 0),
+            }
+        )
 
     return {
         "has_position": True,

--- a/src/cryptobot/api/routes/coin_strategy.py
+++ b/src/cryptobot/api/routes/coin_strategy.py
@@ -56,9 +56,15 @@ def update_coin_strategy(
         SET strategy_name = ?, stop_loss_pct = ?, trailing_stop_pct = ?,
             position_size_pct = ?, strategy_params_json = ?, updated_at = ?
         WHERE category = ?""",
-        (body.strategy_name, body.stop_loss_pct, body.trailing_stop_pct,
-         body.position_size_pct, body.strategy_params_json,
-         datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"), category),
+        (
+            body.strategy_name,
+            body.stop_loss_pct,
+            body.trailing_stop_pct,
+            body.position_size_pct,
+            body.strategy_params_json,
+            datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            category,
+        ),
     )
     db.commit()
 

--- a/src/cryptobot/api/routes/market.py
+++ b/src/cryptobot/api/routes/market.py
@@ -13,9 +13,7 @@ router = APIRouter(prefix="/api/market", tags=["market"])
 def get_current_market(_: UserResponse = Depends(get_current_user)):
     """현재 시장 상태 (BTC 기준 최근 스냅샷)."""
     db = get_db()
-    row = db.execute(
-        "SELECT * FROM market_snapshots WHERE coin = 'KRW-BTC' ORDER BY id DESC LIMIT 1"
-    ).fetchone()
+    row = db.execute("SELECT * FROM market_snapshots WHERE coin = 'KRW-BTC' ORDER BY id DESC LIMIT 1").fetchone()
 
     if row is None:
         # BTC 없으면 아무거나
@@ -31,19 +29,6 @@ def get_current_market(_: UserResponse = Depends(get_current_user)):
 def get_monitored_coins(_: UserResponse = Depends(get_current_user)):
     """현재 모니터링 중인 코인별 최신 데이터."""
     db = get_db()
-
-    # 모니터링 중인 코인 = 최근 1시간 내 스냅샷이 있는 코인들
-    rows = db.execute(
-        """
-        SELECT coin, MAX(id) as latest_id
-        FROM (
-            SELECT 'KRW-BTC' as coin, id, price, market_state, rsi_14 as rsi, change_pct_24h as change_pct
-            FROM market_snapshots
-            WHERE timestamp >= datetime('now', '-1 hour')
-        )
-        GROUP BY coin
-        """
-    ).fetchall()
 
     # 전체 코인의 최신 스냅샷 (각 코인별)
     # market_snapshots는 현재 BTC만 저장하므로, trade_signals에서 코인 목록을 가져옴
@@ -91,9 +76,11 @@ def get_monitored_coins(_: UserResponse = Depends(get_current_user)):
                 entry["buy_price"] = held["buy_price"]
                 entry["buy_total_krw"] = held["total_krw"]
                 entry["buy_time"] = held["buy_time"]
-                entry["unrealized_pnl_pct"] = round(
-                    (entry["current_price"] - held["buy_price"]) / held["buy_price"] * 100, 2
-                ) if entry["current_price"] and held["buy_price"] else 0
+                entry["unrealized_pnl_pct"] = (
+                    round((entry["current_price"] - held["buy_price"]) / held["buy_price"] * 100, 2)
+                    if entry["current_price"] and held["buy_price"]
+                    else 0
+                )
             else:
                 entry["holding"] = False
 
@@ -202,14 +189,16 @@ def get_coin_strategies(_: UserResponse = Depends(get_current_user)):
             (coin,),
         ).fetchone()
 
-        result.append({
-            "coin": coin,
-            "strategy": r["strategy"],
-            "market_state": r["market_state"],
-            "current_price": r["current_price"],
-            "signal_type": r["signal_type"],
-            "confidence": r["confidence"],
-            "holding": held is not None,
-        })
+        result.append(
+            {
+                "coin": coin,
+                "strategy": r["strategy"],
+                "market_state": r["market_state"],
+                "current_price": r["current_price"],
+                "signal_type": r["signal_type"],
+                "confidence": r["confidence"],
+                "holding": held is not None,
+            }
+        )
 
     return result

--- a/src/cryptobot/api/routes/public.py
+++ b/src/cryptobot/api/routes/public.py
@@ -141,6 +141,7 @@ def get_public_portfolio(request: Request):
     krw = 0
     try:
         from cryptobot.bot.trader import Trader
+
         trader = Trader()
         if trader.is_ready:
             krw = trader.get_balance_krw()
@@ -186,12 +187,14 @@ def get_public_analysis(request: Request, limit: int = Query(3, ge=1, le=10)):
         reasoning = d["output_reasoning"] or ""
         # 첫 문단만 (상세 근거는 비공개)
         summary = reasoning.split("\n\n")[0] if reasoning else ""
-        results.append({
-            "market_state": d["output_market_state"],
-            "aggression": d["output_aggression"],
-            "summary": summary,
-            "timestamp": d["timestamp"],
-        })
+        results.append(
+            {
+                "market_state": d["output_market_state"],
+                "aggression": d["output_aggression"],
+                "summary": summary,
+                "timestamp": d["timestamp"],
+            }
+        )
 
     return results
 
@@ -209,9 +212,7 @@ def get_public_news(request: Request, limit: int = Query(20, ge=1, le=50)):
         (limit,),
     ).fetchall()
 
-    fg = db.execute(
-        "SELECT value, classification, timestamp FROM fear_greed_index ORDER BY id DESC LIMIT 1"
-    ).fetchone()
+    fg = db.execute("SELECT value, classification, timestamp FROM fear_greed_index ORDER BY id DESC LIMIT 1").fetchone()
 
     return {
         "news": [dict(r) for r in news],
@@ -324,9 +325,7 @@ def get_public_strategy_stats(request: Request):
         {
             "strategy": dict(r)["strategy"],
             "trades": dict(r)["trades"],
-            "win_rate": round(
-                (dict(r)["wins"] or 0) / dict(r)["trades"] * 100, 1
-            ) if dict(r)["trades"] > 0 else 0,
+            "win_rate": round((dict(r)["wins"] or 0) / dict(r)["trades"] * 100, 1) if dict(r)["trades"] > 0 else 0,
             "avg_pct": dict(r)["avg_pct"] or 0,
         }
         for r in rows

--- a/src/cryptobot/api/routes/strategies.py
+++ b/src/cryptobot/api/routes/strategies.py
@@ -142,7 +142,6 @@ def simulate_strategy(name: str, body: SimulateRequest, _: UserResponse = Depend
         snapshot = dict(snapshot)
         ma_20 = snapshot.get("ma_20")
         bb_upper = snapshot.get("bb_upper")
-        bb_lower = snapshot.get("bb_lower")
         current_price = snapshot.get("price", 0)
         yesterday_high = snapshot.get("high_24h", 0)
         yesterday_low = snapshot.get("low_24h", 0)
@@ -168,8 +167,12 @@ def simulate_strategy(name: str, body: SimulateRequest, _: UserResponse = Depend
                     "new_band_width": round(one_std * new_bb_std * 2),
                     "current_distance_to_lower": round(current_price - (ma_20 - one_std * current_bb_std)),
                     "new_distance_to_lower": round(current_price - (ma_20 - one_std * new_bb_std)),
-                    "current_distance_to_lower_pct": round((current_price - (ma_20 - one_std * current_bb_std)) / current_price * 100, 2),
-                    "new_distance_to_lower_pct": round((current_price - (ma_20 - one_std * new_bb_std)) / current_price * 100, 2),
+                    "current_distance_to_lower_pct": round(
+                        (current_price - (ma_20 - one_std * current_bb_std)) / current_price * 100, 2
+                    ),
+                    "new_distance_to_lower_pct": round(
+                        (current_price - (ma_20 - one_std * new_bb_std)) / current_price * 100, 2
+                    ),
                 }
 
         if name == "volatility_breakout":

--- a/src/cryptobot/api/routes/trades.py
+++ b/src/cryptobot/api/routes/trades.py
@@ -1,15 +1,16 @@
-import logging
-logger = logging.getLogger(__name__)
 """매매 내역 라우트.
 
 NestJS의 TradeController와 동일.
 """
+
+import logging
 
 from fastapi import APIRouter, Depends, Query
 
 from cryptobot.api.auth import UserResponse, get_current_user
 from cryptobot.api.deps import get_db
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/trades", tags=["trades"])
 
 
@@ -49,9 +50,7 @@ def get_trades(
     offset = (page - 1) * limit
 
     # 총 개수
-    total = db.execute(
-        f"SELECT COUNT(*) FROM trades t {where}", tuple(params)
-    ).fetchone()[0]
+    total = db.execute(f"SELECT COUNT(*) FROM trades t {where}", tuple(params)).fetchone()[0]
 
     # 데이터 (trade_signals에서 confidence JOIN)
     rows = db.execute(
@@ -114,10 +113,13 @@ def get_trade_stats(
 
     if held:
         import pyupbit
+
         # 배치 API 호출 (N개 → 1개)
         coins = list(set(h["coin"] for h in held))
         try:
-            prices = pyupbit.get_current_price(coins) if len(coins) > 1 else {coins[0]: pyupbit.get_current_price(coins[0])}
+            prices = (
+                pyupbit.get_current_price(coins) if len(coins) > 1 else {coins[0]: pyupbit.get_current_price(coins[0])}
+            )
         except Exception as e:
             logger.warning("코인 가격 조회 실패: %s", e)
             prices = {}

--- a/src/cryptobot/backtest/engine.py
+++ b/src/cryptobot/backtest/engine.py
@@ -66,8 +66,7 @@ class BacktestEngine:
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         df = pd.read_sql_query(
-            "SELECT date, open, high, low, close, volume FROM ohlcv_daily "
-            "WHERE coin = ? ORDER BY date ASC",
+            "SELECT date, open, high, low, close, volume FROM ohlcv_daily WHERE coin = ? ORDER BY date ASC",
             conn,
             params=(coin,),
         )
@@ -116,8 +115,13 @@ class BacktestEngine:
                 signal = self.strategy.check_sell(window, current_price, entry_price)
                 if signal.signal_type == "sell":
                     trade = self._make_trade(
-                        entry_date, current_date, entry_price, current_price,
-                        days_held, entry_reason, signal.reason,
+                        entry_date,
+                        current_date,
+                        entry_price,
+                        current_price,
+                        days_held,
+                        entry_reason,
+                        signal.reason,
                     )
                     trades.append(trade)
                     self.strategy.reset()
@@ -133,8 +137,13 @@ class BacktestEngine:
             last_date = str(df.iloc[-1]["date"])
             days_held = (n - 1) - self._entry_index
             trade = self._make_trade(
-                entry_date, last_date, entry_price, last_price,
-                days_held, entry_reason, "백테스트 종료 (강제 청산)",
+                entry_date,
+                last_date,
+                entry_price,
+                last_price,
+                days_held,
+                entry_reason,
+                "백테스트 종료 (강제 청산)",
             )
             trades.append(trade)
             self.strategy.reset()

--- a/src/cryptobot/backtest/reporter.py
+++ b/src/cryptobot/backtest/reporter.py
@@ -79,7 +79,11 @@ class BacktestReporter:
                         param_str = self._format_key_params(result.params, name)
                         logger.info(
                             "백테스트 완료: %s × %s%s → %d건, %.1f%%",
-                            coin, name, param_str, result.num_trades, result.total_return_pct,
+                            coin,
+                            name,
+                            param_str,
+                            result.num_trades,
+                            result.total_return_pct,
                         )
                     except Exception as e:
                         logger.warning("백테스트 스킵: %s × %s — %s", coin, name, e)
@@ -216,6 +220,7 @@ class BacktestReporter:
             try:
                 dates = period.split(" ~ ")
                 from datetime import datetime
+
                 d1 = datetime.strptime(dates[0], "%Y-%m-%d")
                 d2 = datetime.strptime(dates[1], "%Y-%m-%d")
                 days = (d2 - d1).days

--- a/src/cryptobot/bot/coin_manager.py
+++ b/src/cryptobot/bot/coin_manager.py
@@ -48,6 +48,7 @@ class CoinManager:
 
         try:
             from cryptobot.bot.scanner import CoinScanner
+
             scanner = CoinScanner(
                 min_volume_krw=float(self._config.get("min_volume_krw", "1000000000")),
                 min_price_krw=float(self._config.get("min_price_krw", "1000")),
@@ -69,10 +70,7 @@ class CoinManager:
 
                 # LLM 제거 추천 (보유 중 코인만 제외 불가)
                 held_coins = self._get_held_coins()
-                new_coins = [
-                    c for c in new_coins
-                    if c not in llm_remove or c in held_coins
-                ]
+                new_coins = [c for c in new_coins if c not in llm_remove or c in held_coins]
 
                 # 보유 중 코인 보장
                 for held in held_coins:

--- a/src/cryptobot/bot/health_checker.py
+++ b/src/cryptobot/bot/health_checker.py
@@ -82,7 +82,8 @@ class HealthChecker:
                 if db_only or upbit_only:
                     logger.warning(
                         "매매 정합성 불일치: DB에만=%s, 업비트에만=%s",
-                        db_only, upbit_only,
+                        db_only,
+                        upbit_only,
                     )
                     return {
                         "status": "warning",
@@ -132,7 +133,6 @@ class HealthChecker:
         try:
             if not self._trader or not self._trader.is_ready:
                 return {"status": "ok", "message": "API 미설정 — 스킵"}
-
 
             # 활성 코인 목록
             coins = self._db.execute(
@@ -238,6 +238,7 @@ class HealthChecker:
         """LLM 추천 vs DB 저장 vs 실제 신호 적용 — 3중 검증."""
         try:
             import json
+
             issues = []
 
             # 1. 활성 전략 확인
@@ -271,7 +272,6 @@ class HealthChecker:
             if llm_row and dict(llm_row)["input_news_summary"]:
                 try:
                     ba = json.loads(dict(llm_row)["input_news_summary"])
-                    llm_after = ba.get("after", {})
                     llm_strategy = ba.get("strategy")
 
                     # 전략 불일치
@@ -377,7 +377,12 @@ class HealthChecker:
                     corrected += 1
                     logger.info(
                         "거래 보정: id=%d %s 가격 %.0f→%.0f 금액 %.0f→%.0f",
-                        trade["id"], trade["side"], db_price, actual_price, db_total, actual_total,
+                        trade["id"],
+                        trade["side"],
+                        db_price,
+                        actual_price,
+                        db_total,
+                        actual_total,
                     )
 
                     # 매도 거래의 profit 재계산
@@ -408,12 +413,8 @@ class HealthChecker:
     def _recalculate_profit(self, sell_trade_id: int, buy_trade_id: int) -> None:
         """보정된 매수/매도 값 기준으로 profit_krw, profit_pct를 재계산한다."""
         try:
-            buy = self._db.execute(
-                "SELECT total_krw, fee_krw FROM trades WHERE id = ?", (buy_trade_id,)
-            ).fetchone()
-            sell = self._db.execute(
-                "SELECT total_krw, fee_krw FROM trades WHERE id = ?", (sell_trade_id,)
-            ).fetchone()
+            buy = self._db.execute("SELECT total_krw, fee_krw FROM trades WHERE id = ?", (buy_trade_id,)).fetchone()
+            sell = self._db.execute("SELECT total_krw, fee_krw FROM trades WHERE id = ?", (sell_trade_id,)).fetchone()
 
             if not buy or not sell:
                 return
@@ -447,6 +448,7 @@ class HealthChecker:
             actual_krw = self._trader.get_balance_krw()
 
             import pyupbit
+
             active_rows = self._db.execute(
                 """
                 SELECT coin, amount FROM trades t
@@ -475,7 +477,9 @@ class HealthChecker:
             if diff_pct > 2.0:
                 logger.warning(
                     "잔고 차이 %.1f%%: 실제=%.0f, DB 역산=%.0f → 미검증 거래 즉시 재보정",
-                    diff_pct, total_actual, db_total,
+                    diff_pct,
+                    total_actual,
+                    db_total,
                 )
                 # 자동 복구: 미검증 거래 재보정
                 recon_result = self.reconcile_trades()
@@ -487,7 +491,9 @@ class HealthChecker:
                     diff_pct_after = abs(total_actual - db_total_after) / total_actual * 100
                     logger.info(
                         "재보정 후 잔고 차이: %.1f%% → %.1f%% (%d건 보정)",
-                        diff_pct, diff_pct_after, corrected,
+                        diff_pct,
+                        diff_pct_after,
+                        corrected,
                     )
 
                     if diff_pct_after > 2.0:

--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -58,7 +58,11 @@ class CryptoBot:
         logger.info("종목: %s (%d개)", ", ".join(self._coin_mgr.active_coins), len(self._coin_mgr.active_coins))
         logger.info("활성 전략: %s", self._strategy_sel.current_strategy_name)
         logger.info("등록 전략: %s", ", ".join(self._strategy_sel.registry.list_names()))
-        logger.info("API Key: %s | Slack: %s", "O" if self._trader.is_ready else "X", "O" if self._notifier.is_configured else "X")
+        logger.info(
+            "API Key: %s | Slack: %s",
+            "O" if self._trader.is_ready else "X",
+            "O" if self._notifier.is_configured else "X",
+        )
 
         self._notifier.notify_bot_status("시작됨")
         self._safety_check()
@@ -69,7 +73,12 @@ class CryptoBot:
         self._scheduler.add_job(self._hourly_reconciliation, "interval", hours=1, id="hourly_reconciliation")
         self._scheduler.add_job(self._weekly_report, "cron", day_of_week="sun", hour=3, minute=0, id="weekly_report")
         self._scheduler.add_job(
-            self._weekly_backtest, "cron", day_of_week="sun", hour=2, minute=0, id="weekly_backtest",
+            self._weekly_backtest,
+            "cron",
+            day_of_week="sun",
+            hour=2,
+            minute=0,
+            id="weekly_backtest",
         )
         self._scheduler.add_job(self._monthly_audit, "cron", day=1, hour=4, minute=0, id="monthly_audit")
         self._scheduler.add_job(self._llm_analyze, "interval", minutes=10, id="llm_analyze")
@@ -173,10 +182,32 @@ class CryptoBot:
         pj = self._config_mgr.get_strategy_params_json(sn)
 
         if sig.signal_type != "buy":
-            self._recorder.record_signal(coin=coin, signal_type=sig.signal_type, strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=sig.reason, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type=sig.signal_type,
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=sig.reason,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
         if not self._trader.is_ready:
-            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason="api_key_not_configured", snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason="api_key_not_configured",
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
 
         bal = self._trader.get_balance_krw()
@@ -189,7 +220,18 @@ class CryptoBot:
 
         ok, reason = self._risk.check_can_buy(coin, amount, bal)
         if not ok:
-            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=reason, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=reason,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
 
         # 중복 매수 방지 — 매수 직전 재확인
@@ -208,10 +250,38 @@ class CryptoBot:
                 f"Upbit에서 수동 확인 필요.\n{e}"
             )
             skip = f"API 예외: {type(e).__name__}"
-            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=skip, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=skip,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
         if order.success:
-            tid = self._recorder.record_trade(coin=coin, side="buy", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, market_state_at_trade=snapshot.get("market_state"), btc_price_at_trade=price, rsi_at_trade=snapshot.get("rsi_14"), order_uuid=order.order_uuid)
+            tid = self._recorder.record_trade(
+                coin=coin,
+                side="buy",
+                price=order.price,
+                amount=order.amount,
+                total_krw=order.total_krw,
+                fee_krw=order.fee_krw,
+                strategy=sn,
+                trigger_reason=sig.reason,
+                trigger_value=sig.trigger_value,
+                param_k_value=s.params.extra.get("k_value"),
+                param_stop_loss=s.params.stop_loss_pct,
+                param_trailing_stop=s.params.trailing_stop_pct,
+                market_state_at_trade=snapshot.get("market_state"),
+                btc_price_at_trade=price,
+                rsi_at_trade=snapshot.get("rsi_14"),
+                order_uuid=order.order_uuid,
+            )
             # 즉시 commit — 다음 틱이 이 buy를 찾지 못해 중복 매수하는 것을 방지
             try:
                 self._db.commit()
@@ -230,10 +300,33 @@ class CryptoBot:
             actual_diff = bal_before - bal_after
             if abs(actual_diff - expected_diff) > expected_diff * 0.05:
                 logger.warning("잔고 불일치: 예상 -%s, 실제 -%s", f"{expected_diff:,.0f}", f"{actual_diff:,.0f}")
-            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, executed=True, trade_id=tid, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                executed=True,
+                trade_id=tid,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
         else:
             # 사전 검증 실패 (최소 주문 금액 미달 등) — 기록만
-            self._recorder.record_signal(coin=coin, signal_type="buy", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=order.error or "주문 실패", snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=order.error or "주문 실패",
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
 
     def _check_and_sell(self, active_trade, price, snapshot_id, snapshot=None, coin=None):
         """매도 신호 확인 및 실행."""
@@ -255,7 +348,18 @@ class CryptoBot:
         pj = self._config_mgr.get_strategy_params_json(sn)
 
         if sig.signal_type != "sell":
-            self._recorder.record_signal(coin=coin, signal_type=sig.signal_type, strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=sig.reason, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type=sig.signal_type,
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=sig.reason,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
         if not self._trader.is_ready:
             return
@@ -266,7 +370,18 @@ class CryptoBot:
         # 익절 신호(ROI/트레일링/중간선 등)만 수수료로 인한 실질 음수 시 차단.
         # 손절/전략 판단(RSI 정상복귀, 데드크로스 등)은 통과.
         if sig.is_profit_taking and net_pnl <= 0:
-            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=f"수수료 가드: 가격 {pnl_pct:+.2f}% 실질 {net_pnl:+.2f}%", snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="sell",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=f"수수료 가드: 가격 {pnl_pct:+.2f}% 실질 {net_pnl:+.2f}%",
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
 
         try:
@@ -274,17 +389,49 @@ class CryptoBot:
         except (APIError, InsufficientBalanceError) as e:
             logger.error("매도 API 실패: %s — %s", coin, e)
             self._notifier.notify_error(
-                f"⚠️ 매도 주문 API 실패: {coin} — 접수 후 체결 조회 실패 가능성. "
-                f"Upbit에서 수동 확인 필요.\n{e}"
+                f"⚠️ 매도 주문 API 실패: {coin} — 접수 후 체결 조회 실패 가능성. Upbit에서 수동 확인 필요.\n{e}"
             )
             skip = f"API 예외: {type(e).__name__}"
-            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=skip, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="sell",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=skip,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             return
         if order.success:
             bf = active_trade.get("fee_krw") or 0
             profit_krw = round((order.total_krw - order.fee_krw) - (active_trade["total_krw"] + bf), 2)
-            profit_pct = round(profit_krw / (active_trade["total_krw"] + bf) * 100, 2) if (active_trade["total_krw"] + bf) > 0 else 0
-            tid = self._recorder.record_trade(coin=coin, side="sell", price=order.price, amount=order.amount, total_krw=order.total_krw, fee_krw=order.fee_krw, strategy=sn, trigger_reason=sig.reason, trigger_value=sig.trigger_value, param_k_value=s.params.extra.get("k_value"), param_stop_loss=s.params.stop_loss_pct, param_trailing_stop=s.params.trailing_stop_pct, buy_trade_id=active_trade["id"], profit_pct=profit_pct, profit_krw=profit_krw, hold_duration_minutes=s._hold_minutes, order_uuid=order.order_uuid)
+            profit_pct = (
+                round(profit_krw / (active_trade["total_krw"] + bf) * 100, 2)
+                if (active_trade["total_krw"] + bf) > 0
+                else 0
+            )
+            tid = self._recorder.record_trade(
+                coin=coin,
+                side="sell",
+                price=order.price,
+                amount=order.amount,
+                total_krw=order.total_krw,
+                fee_krw=order.fee_krw,
+                strategy=sn,
+                trigger_reason=sig.reason,
+                trigger_value=sig.trigger_value,
+                param_k_value=s.params.extra.get("k_value"),
+                param_stop_loss=s.params.stop_loss_pct,
+                param_trailing_stop=s.params.trailing_stop_pct,
+                buy_trade_id=active_trade["id"],
+                profit_pct=profit_pct,
+                profit_krw=profit_krw,
+                hold_duration_minutes=s._hold_minutes,
+                order_uuid=order.order_uuid,
+            )
             # 즉시 commit — 미커밋으로 다음 틱이 이 매도를 놓치면 이중 매도 위험
             try:
                 self._db.commit()
@@ -297,14 +444,38 @@ class CryptoBot:
             if not verify:
                 logger.error("DB 쓰기 검증 실패: trade_id=%s", tid)
                 self._notifier.notify_error(f"DB 쓰기 검증 실패: {coin} 매도 기록 누락")
-            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, executed=True, trade_id=tid, snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="sell",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                executed=True,
+                trade_id=tid,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
             s.reset()
         else:
-            self._recorder.record_signal(coin=coin, signal_type="sell", strategy=sn, confidence=sig.confidence, trigger_reason=sig.reason, current_price=price, trigger_value=sig.trigger_value, skip_reason=order.error or "주문 실패", snapshot_id=snapshot_id, strategy_params_json=pj)
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="sell",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=order.error or "주문 실패",
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
 
     def _llm_analyze(self):
         try:
             from cryptobot.llm.analyzer import LLMAnalyzer
+
             a = LLMAnalyzer(self._db)
             if not a.is_configured:
                 return
@@ -319,7 +490,8 @@ class CryptoBot:
                 if recommended and recommended != self._strategy_sel.current_strategy_name:
                     logger.warning(
                         "전략 불일치: LLM 추천=%s, 실제=%s",
-                        recommended, self._strategy_sel.current_strategy_name,
+                        recommended,
+                        self._strategy_sel.current_strategy_name,
                     )
                     self._notifier.notify_error(
                         f"전략 불일치: 추천={recommended}, 실제={self._strategy_sel.current_strategy_name}"
@@ -356,14 +528,8 @@ class CryptoBot:
             realized = sum(t.get("profit_krw", 0) or 0 for t in sells)
             total_fees = sum(t.get("fee_krw", 0) or 0 for t in trades)
 
-            avg_profit = (
-                sum(t.get("profit_pct", 0) or 0 for t in wins) / len(wins)
-                if wins else 0
-            )
-            avg_loss = (
-                sum(t.get("profit_pct", 0) or 0 for t in losses) / len(losses)
-                if losses else 0
-            )
+            avg_profit = sum(t.get("profit_pct", 0) or 0 for t in wins) / len(wins) if wins else 0
+            avg_loss = sum(t.get("profit_pct", 0) or 0 for t in losses) / len(losses) if losses else 0
 
             self._recorder.save_daily_report(
                 report_date=today,
@@ -388,9 +554,7 @@ class CryptoBot:
             if self._config_mgr.get_bool("slack_daily_report", True):
                 self._notifier.notify_daily_report(
                     date_str=today.isoformat(),
-                    daily_return_pct=sum(
-                        t.get("profit_pct", 0) or 0 for t in sells
-                    ),
+                    daily_return_pct=sum(t.get("profit_pct", 0) or 0 for t in sells),
                     total_trades=len(trades),
                     win_rate=wr,
                     balance_krw=total_asset,
@@ -458,6 +622,7 @@ class CryptoBot:
 
 def main():
     from cryptobot.logging_config import setup_logging
+
     setup_logging("bot", config.bot.log_level)
     CryptoBot().start()
 

--- a/src/cryptobot/bot/monthly_audit.py
+++ b/src/cryptobot/bot/monthly_audit.py
@@ -221,25 +221,17 @@ class MonthlyAudit:
             emoji = "📈" if (s.get("total_pnl", 0) or 0) >= 0 else "📉"
             lines.append(f"{emoji} *전월 실적*")
             lines.append(
-                f"  총 {s.get('total_trades', 0)}건 거래, "
-                f"매도 {s.get('sells', 0)}건, "
-                f"승률 {s.get('win_rate', 0)}%"
+                f"  총 {s.get('total_trades', 0)}건 거래, 매도 {s.get('sells', 0)}건, 승률 {s.get('win_rate', 0)}%"
             )
             lines.append(f"  총 손익: {s.get('total_pnl', 0):+,.0f}원")
             lines.append(f"  총 수수료: {s.get('total_fees', 0):,.0f}원")
-            lines.append(
-                f"  최고: {s.get('best_trade', 0):+,.0f}원 / "
-                f"최악: {s.get('worst_trade', 0):+,.0f}원"
-            )
+            lines.append(f"  최고: {s.get('best_trade', 0):+,.0f}원 / 최악: {s.get('worst_trade', 0):+,.0f}원")
 
             strategies = s.get("strategies", [])
             if strategies:
                 lines.append("  전략별:")
                 for st in strategies:
-                    lines.append(
-                        f"    {st['strategy']}: {st['trades']}건, "
-                        f"{st['pnl']:+,.0f}원"
-                    )
+                    lines.append(f"    {st['strategy']}: {st['trades']}건, {st['pnl']:+,.0f}원")
 
         # LLM 비용
         llm = results.get("llm_cost", {})

--- a/src/cryptobot/bot/risk.py
+++ b/src/cryptobot/bot/risk.py
@@ -113,8 +113,7 @@ class RiskManager:
         UTC 기준 DATE로 하면 KST 00시~09시 구간이 전날로 오판됨.
         """
         row = self._db.execute(
-            "SELECT COUNT(*) FROM trades WHERE coin = ? "
-            "AND DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')",
+            "SELECT COUNT(*) FROM trades WHERE coin = ? AND DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')",
             (coin,),
         ).fetchone()
         return row[0] if row else 0

--- a/src/cryptobot/bot/scanner.py
+++ b/src/cryptobot/bot/scanner.py
@@ -21,8 +21,12 @@ class CoinScanner:
 
     # 스테이블코인 + 매매 부적합 종목 제외
     EXCLUDED_COINS = {
-        "KRW-USDT", "KRW-USDC", "KRW-DAI", "KRW-BUSD",
-        "KRW-TUSD", "KRW-PAXG",
+        "KRW-USDT",
+        "KRW-USDC",
+        "KRW-DAI",
+        "KRW-BUSD",
+        "KRW-TUSD",
+        "KRW-PAXG",
     }
 
     def __init__(
@@ -69,8 +73,7 @@ class CoinScanner:
 
             # 1차 필터: 제외 코인 + 최소 가격
             candidates = [
-                t for t in tickers
-                if t not in self.EXCLUDED_COINS and all_prices.get(t, 0) >= self._min_price_krw
+                t for t in tickers if t not in self.EXCLUDED_COINS and all_prices.get(t, 0) >= self._min_price_krw
             ]
 
             # 상위 50개 OHLCV 조회 (30개 모니터링 커버)
@@ -78,6 +81,7 @@ class CoinScanner:
 
             results = []
             import time as _time
+
             for idx, ticker in enumerate(candidates):
                 price = all_prices.get(ticker, 0)
 
@@ -130,7 +134,7 @@ class CoinScanner:
                 if len(df) >= 14:
                     deltas = df["close"].diff().dropna()
                     gains = deltas.where(deltas > 0, 0)
-                    losses = (-deltas.where(deltas < 0, 0))
+                    losses = -deltas.where(deltas < 0, 0)
                     avg_gain = gains.rolling(14).mean().iloc[-1]
                     avg_loss = losses.rolling(14).mean().iloc[-1]
                     if avg_loss > 0:

--- a/src/cryptobot/bot/strategy_selector.py
+++ b/src/cryptobot/bot/strategy_selector.py
@@ -89,6 +89,7 @@ class StrategySelector:
     def refresh(self, notifier=None) -> None:
         """전략 변경 감지 + 파라미터 실시간 반영 (전략 재생성)."""
         from cryptobot.data.strategy_repository import StrategyRepository
+
         repo = StrategyRepository(self._db)
         repo.complete_shutdown()
 
@@ -137,9 +138,7 @@ class StrategySelector:
             return self.current_strategy, self.current_strategy_name
 
         # 카테고리별 리스크 파라미터 (공유 인스턴스 보호 — 매 틱 후 복원)
-        row = self._db.execute(
-            "SELECT * FROM coin_strategy_config WHERE category = ?", (coin_category,)
-        ).fetchone()
+        row = self._db.execute("SELECT * FROM coin_strategy_config WHERE category = ?", (coin_category,)).fetchone()
         if row:
             # 원본 저장 → _tick_coin의 finally에서 복원됨
             strategy._orig_stop_loss = strategy.params.stop_loss_pct

--- a/src/cryptobot/bot/weekly_reporter.py
+++ b/src/cryptobot/bot/weekly_reporter.py
@@ -55,16 +55,16 @@ class WeeklyReporter:
             strategies = []
             for r in rows:
                 r = dict(r)
-                win_rate = round(
-                    (r["wins"] or 0) / r["trades"] * 100, 1
-                ) if r["trades"] > 0 else 0
-                strategies.append({
-                    "strategy": r["strategy"],
-                    "trades": r["trades"],
-                    "win_rate": win_rate,
-                    "avg_pct": r["avg_pct"] or 0,
-                    "total_pnl": r["total_pnl"] or 0,
-                })
+                win_rate = round((r["wins"] or 0) / r["trades"] * 100, 1) if r["trades"] > 0 else 0
+                strategies.append(
+                    {
+                        "strategy": r["strategy"],
+                        "trades": r["trades"],
+                        "win_rate": win_rate,
+                        "avg_pct": r["avg_pct"] or 0,
+                        "total_pnl": r["total_pnl"] or 0,
+                    }
+                )
 
             return {"status": "ok", "strategies": strategies}
         except Exception as e:
@@ -89,6 +89,7 @@ class WeeklyReporter:
                 if r["input_news_summary"]:
                     try:
                         import json
+
                         ba = json.loads(r["input_news_summary"])
                         before = ba.get("before", {})
                         after = ba.get("after", {})
@@ -98,10 +99,12 @@ class WeeklyReporter:
                             if str(before.get(k, "?")) != str(v)
                         }
                         if diff:
-                            changes.append({
-                                "timestamp": r["kst"],
-                                "changes": diff,
-                            })
+                            changes.append(
+                                {
+                                    "timestamp": r["kst"],
+                                    "changes": diff,
+                                }
+                            )
                     except Exception:
                         pass
 
@@ -130,8 +133,12 @@ class WeeklyReporter:
             # 테이블별 행 수
             tables = {}
             for table in [
-                "trades", "trade_signals", "market_snapshots",
-                "news_articles", "llm_decisions", "daily_reports",
+                "trades",
+                "trade_signals",
+                "market_snapshots",
+                "news_articles",
+                "llm_decisions",
+                "daily_reports",
             ]:
                 r = self._db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 tables[table] = r[0] if r else 0
@@ -150,9 +157,7 @@ class WeeklyReporter:
         """90일 이상 된 데이터 정리."""
         try:
             # market_snapshots 정리 (90일+)
-            cursor = self._db.execute(
-                "DELETE FROM market_snapshots WHERE timestamp < datetime('now', '-90 days')"
-            )
+            cursor = self._db.execute("DELETE FROM market_snapshots WHERE timestamp < datetime('now', '-90 days')")
             snapshots_deleted = cursor.rowcount
 
             # 미실행 신호 정리 (90일+)
@@ -169,7 +174,8 @@ class WeeklyReporter:
             if snapshots_deleted > 0 or signals_deleted > 0:
                 logger.info(
                     "데이터 정리: 스냅샷 %d건, 미실행 신호 %d건 삭제",
-                    snapshots_deleted, signals_deleted,
+                    snapshots_deleted,
+                    signals_deleted,
                 )
 
             return {

--- a/src/cryptobot/data/collector.py
+++ b/src/cryptobot/data/collector.py
@@ -7,6 +7,7 @@ OHLCV 일봉 데이터는 ohlcv_daily 테이블에 별도 저장 (백테스팅/L
 
 import logging
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 import pyupbit
 
@@ -14,6 +15,9 @@ from cryptobot.bot.indicators import calculate_all
 from cryptobot.bot.strategy import determine_market_state
 from cryptobot.data.database import Database
 from cryptobot.exceptions import APIError
+
+if TYPE_CHECKING:
+    import pandas as pd  # noqa: F401 — type-hint only
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +69,7 @@ class DataCollector:
     def _collect_market_data(self) -> dict | None:
         """업비트 API로 시장 데이터 수집."""
         import time as _time
+
         try:
             # OHLCV 데이터 조회 — 1시간 캐시 (일봉은 자주 안 바뀜)
             now = _time.time()
@@ -84,7 +89,9 @@ class DataCollector:
             if self._last_price and self._last_price > 0:
                 change_pct = abs(current_price - self._last_price) / self._last_price * 100
                 if change_pct > 20:
-                    logger.warning("가격 급변: %s %.1f%% (%s → %s)", self._coin, change_pct, self._last_price, current_price)
+                    logger.warning(
+                        "가격 급변: %s %.1f%% (%s → %s)", self._coin, change_pct, self._last_price, current_price
+                    )
             self._last_price = current_price
 
             # 기술적 지표 계산
@@ -168,11 +175,18 @@ class DataCollector:
         rows = []
         for idx, row in self._latest_df.iterrows():
             date_str = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
-            rows.append((
-                self._coin, date_str,
-                row["open"], row["high"], row["low"], row["close"], row["volume"],
-                now,
-            ))
+            rows.append(
+                (
+                    self._coin,
+                    date_str,
+                    row["open"],
+                    row["high"],
+                    row["low"],
+                    row["close"],
+                    row["volume"],
+                    now,
+                )
+            )
 
         self._db.executemany(
             """

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -408,7 +408,9 @@ _DEFAULT_STRATEGIES = [
         "market_states": "sideways,bearish",
         "timeframe": "1d",
         "difficulty": "medium",
-        "default_params_json": '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}',
+        "default_params_json": (
+            '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}'
+        ),
         "is_active": False,
     },
 ]
@@ -647,7 +649,9 @@ class Database:
 
             # 마이그레이션: market_snapshots AUTOINCREMENT 확인
             try:
-                idx = conn.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='market_snapshots'").fetchone()
+                idx = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='market_snapshots'"
+                ).fetchone()
                 if idx and "AUTOINCREMENT" not in (idx[0] or ""):
                     # 컬럼을 명시적으로 매핑하여 재생성 (SELECT * 사용 금지 — 컬럼 밀림 방지)
                     conn.executescript("""
@@ -711,8 +715,17 @@ class Database:
             existing = conn.execute("SELECT key FROM bot_config WHERE key = 'strategy_switch_delay_seconds'").fetchone()
             if existing is None:
                 conn.execute(
-                    "INSERT OR IGNORE INTO bot_config (key, value, value_type, category, display_name, description) VALUES (?, ?, ?, ?, ?, ?)",
-                    ("strategy_switch_delay_seconds", "30", "int", "bot", "전략 전환 대기 시간 (초)", "새 전략 활성화 시 기존 전략이 종료되기까지 대기하는 시간"),
+                    "INSERT OR IGNORE INTO bot_config "
+                    "(key, value, value_type, category, display_name, description) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "strategy_switch_delay_seconds",
+                        "30",
+                        "int",
+                        "bot",
+                        "전략 전환 대기 시간 (초)",
+                        "새 전략 활성화 시 기존 전략이 종료되기까지 대기하는 시간",
+                    ),
                 )
                 logger.info("bot_config에 strategy_switch_delay_seconds 추가")
 
@@ -722,8 +735,17 @@ class Database:
                 for cfg in _DEFAULT_BOT_CONFIG:
                     if cfg["category"] == "coin":
                         conn.execute(
-                            "INSERT OR IGNORE INTO bot_config (key, value, value_type, category, display_name, description) VALUES (?, ?, ?, ?, ?, ?)",
-                            (cfg["key"], cfg["value"], cfg["value_type"], cfg["category"], cfg["display_name"], cfg["description"]),
+                            "INSERT OR IGNORE INTO bot_config "
+                            "(key, value, value_type, category, display_name, description) "
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            (
+                                cfg["key"],
+                                cfg["value"],
+                                cfg["value_type"],
+                                cfg["category"],
+                                cfg["display_name"],
+                                cfg["description"],
+                            ),
                         )
                 logger.info("bot_config에 멀티코인 설정 추가")
 
@@ -732,12 +754,19 @@ class Database:
             if row[0] == 0:
                 for cat_cfg in _DEFAULT_COIN_STRATEGY:
                     conn.execute(
-                        """INSERT INTO coin_strategy_config
-                        (category, strategy_name, stop_loss_pct, trailing_stop_pct, position_size_pct, strategy_params_json, description)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                        (cat_cfg["category"], cat_cfg["strategy_name"], cat_cfg["stop_loss_pct"],
-                         cat_cfg["trailing_stop_pct"], cat_cfg["position_size_pct"],
-                         cat_cfg["strategy_params_json"], cat_cfg["description"]),
+                        """INSERT INTO coin_strategy_config (
+                            category, strategy_name, stop_loss_pct, trailing_stop_pct,
+                            position_size_pct, strategy_params_json, description
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                        (
+                            cat_cfg["category"],
+                            cat_cfg["strategy_name"],
+                            cat_cfg["stop_loss_pct"],
+                            cat_cfg["trailing_stop_pct"],
+                            cat_cfg["position_size_pct"],
+                            cat_cfg["strategy_params_json"],
+                            cat_cfg["description"],
+                        ),
                     )
                 logger.info("코인 카테고리별 전략 기본값 삽입 완료")
 
@@ -778,13 +807,22 @@ class Database:
             bb_rsi = conn.execute("SELECT 1 FROM strategies WHERE name = 'bb_rsi_combined'").fetchone()
             if bb_rsi is None:
                 conn.execute(
-                    """INSERT INTO strategies (name, display_name, description, category, market_states, timeframe, difficulty, default_params_json, is_active, status)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    ("bb_rsi_combined", "볼린저+RSI 복합",
-                     "RSI 과매도 + 볼린저 하단 이탈 동시 충족 시 매수. 거짓 신호 감소로 60%+ 승률.",
-                     "mean_reversion", "sideways,bearish", "1d", "medium",
-                     '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}',
-                     False, "inactive"),
+                    """INSERT INTO strategies (
+                        name, display_name, description, category, market_states,
+                        timeframe, difficulty, default_params_json, is_active, status
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        "bb_rsi_combined",
+                        "볼린저+RSI 복합",
+                        "RSI 과매도 + 볼린저 하단 이탈 동시 충족 시 매수. 거짓 신호 감소로 60%+ 승률.",
+                        "mean_reversion",
+                        "sideways,bearish",
+                        "1d",
+                        "medium",
+                        '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}',
+                        False,
+                        "inactive",
+                    ),
                 )
                 logger.info("bb_rsi_combined 전략 추가")
 
@@ -797,7 +835,14 @@ class Database:
                         INSERT INTO bot_config (key, value, value_type, category, display_name, description)
                         VALUES (?, ?, ?, ?, ?, ?)
                         """,
-                        (cfg["key"], cfg["value"], cfg["value_type"], cfg["category"], cfg["display_name"], cfg["description"]),
+                        (
+                            cfg["key"],
+                            cfg["value"],
+                            cfg["value_type"],
+                            cfg["category"],
+                            cfg["display_name"],
+                            cfg["description"],
+                        ),
                     )
                 logger.info("봇 설정 기본값 삽입 완료 (%d개)", len(_DEFAULT_BOT_CONFIG))
 

--- a/src/cryptobot/data/recorder.py
+++ b/src/cryptobot/data/recorder.py
@@ -173,9 +173,7 @@ class DataRecorder:
                 (coin,),
             ).fetchall()
         else:
-            rows = self._db.execute(
-                "SELECT * FROM trades WHERE DATE(timestamp) = DATE('now') ORDER BY id"
-            ).fetchall()
+            rows = self._db.execute("SELECT * FROM trades WHERE DATE(timestamp) = DATE('now') ORDER BY id").fetchall()
         return [dict(r) for r in rows]
 
     def save_daily_report(

--- a/src/cryptobot/data/strategy_repository.py
+++ b/src/cryptobot/data/strategy_repository.py
@@ -74,9 +74,7 @@ class StrategyRepository:
             return True  # 이미 활성화됨
 
         # 전환 중인 전략이 있으면 차단
-        switching = self._db.execute(
-            "SELECT name FROM strategies WHERE status = 'shutting_down'"
-        ).fetchone()
+        switching = self._db.execute("SELECT name FROM strategies WHERE status = 'shutting_down'").fetchone()
         if switching:
             logger.warning("전략 '%s' 종료 중 — 전환 대기 필요", switching["name"])
             return False
@@ -114,9 +112,7 @@ class StrategyRepository:
         Returns:
             종료 완료된 전략 이름 목록
         """
-        rows = self._db.execute(
-            "SELECT name FROM strategies WHERE status = 'shutting_down'"
-        ).fetchall()
+        rows = self._db.execute("SELECT name FROM strategies WHERE status = 'shutting_down'").fetchall()
 
         completed = []
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -262,7 +262,11 @@ class LLMAnalyzer:
                     if not (mn <= value <= mx):
                         logger.warning(
                             "bot_config.%s 값 %s가 HARD_LIMITS 범위 [%s, %s] 밖 — 기본값 %s 사용",
-                            key, value, mn, mx, default,
+                            key,
+                            value,
+                            mn,
+                            mx,
+                            default,
                         )
                         return default
                 return value
@@ -323,8 +327,7 @@ class LLMAnalyzer:
         # KST 기준 23시~익일 0시 구간에서 새 날짜로 잘못 인식되는 문제.
         daily_count = (
             self._db.execute(
-                "SELECT COUNT(*) FROM llm_decisions "
-                "WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
+                "SELECT COUNT(*) FROM llm_decisions WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
             ).fetchone()[0]
             or 0
         )
@@ -519,9 +522,7 @@ class LLMAnalyzer:
                 new_val = max(mn, min(mx, original))
                 if new_val != original:
                     logger.warning("하드 리밋 클리핑: aggression = %s → %s (범위 %s~%s)", original, new_val, mn, mx)
-                    clipped.append(
-                        {"field": "aggression", "original": original, "clipped": new_val, "range": [mn, mx]}
-                    )
+                    clipped.append({"field": "aggression", "original": original, "clipped": new_val, "range": [mn, mx]})
                 result["aggression"] = new_val
             except (ValueError, TypeError):
                 pass
@@ -1407,14 +1408,19 @@ class LLMAnalyzer:
                 ) VALUES (datetime('now'), ?, ?, ?, ?, 'FAILED', ?)
                 """,
                 (
-                    self._model, input_tokens, output_tokens, cost,
+                    self._model,
+                    input_tokens,
+                    output_tokens,
+                    cost,
                     f"MAX_RETRIES {attempts}회 전부 실패 — 토큰만 집계",
                 ),
             )
             self._db.commit()
             logger.warning(
                 "실패 호출 토큰 기록: in=%d out=%d cost=$%.4f",
-                input_tokens, output_tokens, cost,
+                input_tokens,
+                output_tokens,
+                cost,
             )
         except Exception as e:
             logger.error("실패 호출 DB 기록 실패: %s", e)
@@ -1636,9 +1642,7 @@ class LLMAnalyzer:
                 # LLM이 존재하지 않는 전략 이름을 반환한 경우
                 # — 다음 호출의 이전 피드백에 반영하기 위해 결과 딕셔너리에 마킹
                 logger.warning("전략 활성화 실패: %s — 기존 전략 유지, 다음 프롬프트에 반영", strategy)
-                available = self._db.execute(
-                    "SELECT name FROM strategies WHERE is_available = TRUE"
-                ).fetchall()
+                available = self._db.execute("SELECT name FROM strategies WHERE is_available = TRUE").fetchall()
                 names = ", ".join(dict(r)["name"] for r in available) or "(없음)"
                 result["_rejected_strategy"] = strategy
                 result["_rejected_strategy_reason"] = f"'{strategy}'은 존재하지 않음. 사용 가능: {names}"

--- a/src/cryptobot/logging_config.py
+++ b/src/cryptobot/logging_config.py
@@ -6,7 +6,6 @@
 """
 
 import logging
-import os
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -88,10 +87,9 @@ def setup_logging(service: str, log_level: str = "INFO") -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     error_fmt = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d)\n"
-        "  %(message)s\n"
-        "  %(exc_text)s" if False else
-        "%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d): %(message)s",
+        "%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d)\n  %(message)s\n  %(exc_text)s"
+        if False
+        else "%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d): %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
@@ -113,4 +111,6 @@ def setup_logging(service: str, log_level: str = "INFO") -> None:
     warn_handler.setFormatter(fmt)
     root_logger.addHandler(warn_handler)
 
-    logging.getLogger(service).info("로깅 초기화: %s (콘솔=%s, 에러파일=error/<date>/%s.log)", service, log_level, service)
+    logging.getLogger(service).info(
+        "로깅 초기화: %s (콘솔=%s, 에러파일=error/<date>/%s.log)", service, log_level, service
+    )

--- a/src/cryptobot/strategies/base.py
+++ b/src/cryptobot/strategies/base.py
@@ -49,12 +49,14 @@ class StrategyParams:
 
     # 시간 기반 ROI 테이블: {보유 분: 최소 수익%}
     # 보유 시간이 길어질수록 목표 수익을 낮춤
-    roi_table: dict = field(default_factory=lambda: {
-        10: 3.0,    # 10분 내 +3% 이상이면 매도
-        30: 2.0,    # 30분 내 +2%
-        60: 1.0,    # 60분 내 +1%
-        120: 0.1,   # 120분 내 실질 +0.1% 이상이면 탈출
-    })
+    roi_table: dict = field(
+        default_factory=lambda: {
+            10: 3.0,  # 10분 내 +3% 이상이면 매도
+            30: 2.0,  # 30분 내 +2%
+            60: 1.0,  # 60분 내 +1%
+            120: 0.1,  # 120분 내 실질 +0.1% 이상이면 탈출
+        }
+    )
 
 
 class BaseStrategy(ABC):
@@ -106,8 +108,11 @@ class BaseStrategy(ABC):
         return pnl_pct - self.ROUND_TRIP_FEE_PCT
 
     def check_trailing_stop(
-        self, current_price: float, buy_price: float,
-        hold_minutes: int | None = None, current_rsi: float | None = None,
+        self,
+        current_price: float,
+        buy_price: float,
+        hold_minutes: int | None = None,
+        current_rsi: float | None = None,
     ) -> Signal | None:
         """공통 트레일링 스탑 + 손절 + ROI + 수수료 반영."""
         # 최고가 갱신
@@ -137,14 +142,16 @@ class BaseStrategy(ABC):
                         strong_roi = abs(self.params.stop_loss_pct) * 0.5
                         if net_pnl >= strong_roi:
                             return Signal(
-                                "sell", 0.9,
+                                "sell",
+                                0.9,
                                 f"ROI 강제 (RSI={current_rsi:.0f} 과매도이나 실질 +{net_pnl:.2f}% 충분)",
                                 trigger_value=round(net_pnl, 2),
                                 is_profit_taking=True,
                             )
                         return None  # RSI 과매도 + ROI 약함 → 매도 보류
                     return Signal(
-                        "sell", 0.9,
+                        "sell",
+                        0.9,
                         f"ROI 도달 ({hold_minutes}분 보유, 실질 +{net_pnl:.2f}% >= {min_roi}%)",
                         trigger_value=round(net_pnl, 2),
                         is_profit_taking=True,
@@ -155,7 +162,8 @@ class BaseStrategy(ABC):
         if drop_pct <= self.params.trailing_stop_pct:
             if net_pnl > 0:
                 return Signal(
-                    "sell", 0.8,
+                    "sell",
+                    0.8,
                     f"트레일링 스탑 (실질 {net_pnl:+.2f}%)",
                     trigger_value=round(drop_pct, 2),
                     is_profit_taking=True,

--- a/src/cryptobot/strategies/bb_rsi_combined.py
+++ b/src/cryptobot/strategies/bb_rsi_combined.py
@@ -39,7 +39,7 @@ class BBRSICombined(BaseStrategy):
             return None
         deltas = df["close"].diff().dropna()
         gains = deltas.where(deltas > 0, 0)
-        losses = (-deltas.where(deltas < 0, 0))
+        losses = -deltas.where(deltas < 0, 0)
         avg_gain = gains.rolling(self._rsi_period).mean().iloc[-1]
         avg_loss = losses.rolling(self._rsi_period).mean().iloc[-1]
         if avg_loss == 0:
@@ -114,7 +114,8 @@ class BBRSICombined(BaseStrategy):
         # RSI 정상 복귀 → 전략적 매도 (수수료 무관, 알고리즘 판단 존중)
         if rsi >= self._rsi_overbought:
             return Signal(
-                "sell", 0.7,
+                "sell",
+                0.7,
                 f"RSI({rsi:.0f}) 정상 복귀 (실질 {net_pnl:+.1f}%)",
                 trigger_value=round(rsi, 1),
             )
@@ -122,7 +123,8 @@ class BBRSICombined(BaseStrategy):
         # 볼린저 중간선 도달 → 익절 (실질 수익 있을 때만)
         if current_price >= ma and net_pnl > 0:
             return Signal(
-                "sell", 0.6,
+                "sell",
+                0.6,
                 f"볼린저 중간선 도달 (실질 +{net_pnl:.1f}%)",
                 trigger_value=round(ma, 2),
                 is_profit_taking=True,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,6 +31,7 @@ def _test_db():
 
     # rate limit 초기화
     from cryptobot.api.routes.auth import _login_attempts
+
     _login_attempts.clear()
 
     yield db

--- a/tests/test_backtest_sweep.py
+++ b/tests/test_backtest_sweep.py
@@ -3,10 +3,8 @@
 import json
 import sqlite3
 
-import pytest
-
 from cryptobot.backtest.reporter import SWEEP_CONFIGS, BacktestReporter
-from cryptobot.llm.analyzer import COMMON_PARAM_KEYS, LLMAnalyzer
+from cryptobot.llm.analyzer import LLMAnalyzer
 
 
 class TestGenerateSweepCombos:
@@ -83,9 +81,7 @@ class TestFormatKeyParams:
 
     def test_bb_rsi_combined(self):
         """BB RSI 복합 전략 파라미터 표시."""
-        result = BacktestReporter._format_key_params(
-            {"rsi_oversold": 35, "bb_std": 1.5}, "bb_rsi_combined"
-        )
+        result = BacktestReporter._format_key_params({"rsi_oversold": 35, "bb_std": 1.5}, "bb_rsi_combined")
         assert "rsi_os=35" in result
         assert "bb=1.5" in result
 
@@ -187,7 +183,11 @@ class TestBacktestTextTopNLimit:
         # 15개 결과 삽입 (Top N만 표시되어야 함)
         for i in range(15):
             _insert_backtest_row(
-                db, "2026-04-13", f"strategy_{i}", "KRW-BTC", 10.0 - i,
+                db,
+                "2026-04-13",
+                f"strategy_{i}",
+                "KRW-BTC",
+                10.0 - i,
                 {"param": i},
             )
         db.commit()

--- a/tests/test_boundary_edge_cases.py
+++ b/tests/test_boundary_edge_cases.py
@@ -43,26 +43,18 @@ def test_llm_daily_count_kst_boundary(db):
     assert kst_today is not None
 
     # 25시간 전 레코드는 KST 기준 확실히 어제
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model) "
-        "VALUES (datetime('now', '-25 hours'), 'test')"
-    )
+    db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now', '-25 hours'), 'test')")
     db.commit()
     daily = db.execute(
-        "SELECT COUNT(*) FROM llm_decisions "
-        "WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
+        "SELECT COUNT(*) FROM llm_decisions WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
     ).fetchone()[0]
     assert daily == 0, "25시간 전 레코드는 KST 기준 오늘에 포함되면 안 됨"
 
     # 1분 전 레코드는 KST 기준 확실히 오늘
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model) "
-        "VALUES (datetime('now', '-1 minute'), 'test')"
-    )
+    db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now', '-1 minute'), 'test')")
     db.commit()
     daily_after = db.execute(
-        "SELECT COUNT(*) FROM llm_decisions "
-        "WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
+        "SELECT COUNT(*) FROM llm_decisions WHERE DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
     ).fetchone()[0]
     assert daily_after == 1
     # UTC 와 KST 일자가 다른 경우에도 쿼리가 올바르게 KST 기준으로 동작
@@ -76,8 +68,14 @@ def test_risk_today_trade_count_uses_kst(db):
     rm = RiskManager(db, RiskLimits())
     # 25시간 전 거래 1건 (KST 기준 어제)
     recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=100, fee_krw=1,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=100,
+        fee_krw=1,
+        strategy="test",
+        trigger_reason="test",
     )
     db.execute("UPDATE trades SET timestamp = datetime('now', '-25 hours')")
     db.commit()
@@ -96,8 +94,7 @@ def test_config_float_rejects_out_of_range(db):
     analyzer = LLMAnalyzer(db)
     # emergency_held_pct의 HARD_LIMITS = (1.0, 10.0)
     db.execute(
-        "INSERT INTO bot_config (key, value, display_name) "
-        "VALUES ('emergency_held_pct', '0.1', 'Emergency Held')"
+        "INSERT INTO bot_config (key, value, display_name) VALUES ('emergency_held_pct', '0.1', 'Emergency Held')"
     )
     db.commit()
     # 0.1은 범위 (1.0, 10.0) 밖 → default 3.0 반환
@@ -109,8 +106,7 @@ def test_config_float_accepts_in_range(db):
     """HARD_LIMITS 범위 내 값은 그대로 반환."""
     analyzer = LLMAnalyzer(db)
     db.execute(
-        "INSERT INTO bot_config (key, value, display_name) "
-        "VALUES ('emergency_held_pct', '5.0', 'Emergency Held')"
+        "INSERT INTO bot_config (key, value, display_name) VALUES ('emergency_held_pct', '5.0', 'Emergency Held')"
     )
     db.commit()
     value = analyzer._get_config_float("emergency_held_pct", 3.0)
@@ -120,10 +116,7 @@ def test_config_float_accepts_in_range(db):
 def test_config_float_no_limits_key_no_validation(db):
     """HARD_LIMITS에 없는 키는 범위 검증 안 함."""
     analyzer = LLMAnalyzer(db)
-    db.execute(
-        "INSERT INTO bot_config (key, value, display_name) "
-        "VALUES ('unrelated_key', '9999.9', 'Unrelated')"
-    )
+    db.execute("INSERT INTO bot_config (key, value, display_name) VALUES ('unrelated_key', '9999.9', 'Unrelated')")
     db.commit()
     value = analyzer._get_config_float("unrelated_key", 1.0)
     assert value == 9999.9
@@ -139,14 +132,8 @@ def test_apply_recommendations_writes_to_new_columns(db):
     analyzer = LLMAnalyzer(db)
     # bb_rsi_combined 활성
     db.execute("UPDATE strategies SET is_active = 0")
-    db.execute(
-        "UPDATE strategies SET is_active = 1, is_available = 1 "
-        "WHERE name = 'bb_rsi_combined'"
-    )
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model) "
-        "VALUES (datetime('now'), 'test')"
-    )
+    db.execute("UPDATE strategies SET is_active = 1, is_available = 1 WHERE name = 'bb_rsi_combined'")
+    db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now'), 'test')")
     db.commit()
 
     result = {

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -52,8 +52,14 @@ def test_order_uuid_persisted_to_trades(db):
     bot._trader.is_ready = True
     bot._trader.get_balance_krw.return_value = 100_000
     bot._trader.buy_market.return_value = OrderResult(
-        success=True, side="buy", coin="KRW-BTC", price=100, amount=1,
-        total_krw=10_000, fee_krw=5, order_uuid="unique-order-abc123",
+        success=True,
+        side="buy",
+        coin="KRW-BTC",
+        price=100,
+        amount=1,
+        total_krw=10_000,
+        fee_krw=5,
+        order_uuid="unique-order-abc123",
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
@@ -77,9 +83,7 @@ def test_order_uuid_persisted_to_trades(db):
 
     bot._check_and_buy({"market_state": "sideways"}, price=100.0, snapshot_id=None, coin="KRW-BTC")
 
-    row = db.execute(
-        "SELECT order_uuid FROM trades WHERE coin = 'KRW-BTC' AND side = 'buy'"
-    ).fetchone()
+    row = db.execute("SELECT order_uuid FROM trades WHERE coin = 'KRW-BTC' AND side = 'buy'").fetchone()
     assert dict(row)["order_uuid"] == "unique-order-abc123"
 
 
@@ -96,8 +100,14 @@ def test_duplicate_buy_blocked_when_active_position_exists(db):
     recorder = DataRecorder(db)
     # 기존 open 포지션
     recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=100, fee_krw=1,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=100,
+        fee_krw=1,
+        strategy="test",
+        trigger_reason="test",
     )
     db.commit()
 
@@ -109,8 +119,14 @@ def test_duplicate_buy_blocked_when_active_position_exists(db):
     bot._trader.is_ready = True
     bot._trader.get_balance_krw.return_value = 100_000
     bot._trader.buy_market.return_value = OrderResult(
-        success=True, side="buy", coin="KRW-BTC", price=100, amount=1,
-        total_krw=10_000, fee_krw=5, order_uuid="new-order",
+        success=True,
+        side="buy",
+        coin="KRW-BTC",
+        price=100,
+        amount=1,
+        total_krw=10_000,
+        fee_krw=5,
+        order_uuid="new-order",
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
@@ -144,15 +160,10 @@ def test_apply_recommendations_updates_bot_config(db):
     """LLM 추천값이 bot_config에 UPDATE로 반영된다."""
     analyzer = LLMAnalyzer(db)
     # 사전 값
-    db.execute(
-        "INSERT OR REPLACE INTO bot_config (key, value, display_name) "
-        "VALUES ('stop_loss_pct', '-5', 'SL')"
-    )
+    db.execute("INSERT OR REPLACE INTO bot_config (key, value, display_name) VALUES ('stop_loss_pct', '-5', 'SL')")
     db.execute("UPDATE strategies SET is_active = 0")
     db.execute("UPDATE strategies SET is_active = 1 WHERE name = 'bb_rsi_combined'")
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now'), 'test')"
-    )
+    db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now'), 'test')")
     db.commit()
 
     result = {
@@ -180,15 +191,14 @@ def test_apply_recommendations_merges_strategy_params(db):
     """LLM 전략별 파라미터가 strategies.default_params_json에 머지된다."""
     analyzer = LLMAnalyzer(db)
     import json as _j
+
     db.execute(
         "UPDATE strategies SET default_params_json = ? WHERE name = 'bb_rsi_combined'",
         (_j.dumps({"rsi_oversold": 30, "bb_std": 2.0, "bb_period": 20}),),
     )
     db.execute("UPDATE strategies SET is_active = 0")
     db.execute("UPDATE strategies SET is_active = 1 WHERE name = 'bb_rsi_combined'")
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now'), 'test')"
-    )
+    db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now'), 'test')")
     db.commit()
 
     result = {
@@ -208,9 +218,7 @@ def test_apply_recommendations_merges_strategy_params(db):
     }
     analyzer._apply_recommendations(result)
 
-    row = db.execute(
-        "SELECT default_params_json FROM strategies WHERE name = 'bb_rsi_combined'"
-    ).fetchone()
+    row = db.execute("SELECT default_params_json FROM strategies WHERE name = 'bb_rsi_combined'").fetchone()
     merged = _j.loads(dict(row)["default_params_json"])
     assert merged["rsi_oversold"] == 25  # 업데이트
     assert merged["bb_std"] == 1.5  # 업데이트
@@ -257,28 +265,30 @@ def test_check_emergency_held_vs_non_held_thresholds(db):
     # 보유 코인 등록
     recorder = DataRecorder(db)
     recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=100, fee_krw=1,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=100,
+        fee_krw=1,
+        strategy="test",
+        trigger_reason="test",
     )
     db.commit()
 
     # market_snapshots 2개 세팅: BTC(보유) +4%, ETH(비보유) +4%
     # held_threshold=3.0, non_held=7.0 → BTC는 트리거, ETH는 트리거 안 됨
     db.execute(
-        "INSERT INTO market_snapshots (coin, timestamp, price) "
-        "VALUES ('KRW-BTC', datetime('now', '-65 minutes'), 100)"
+        "INSERT INTO market_snapshots (coin, timestamp, price) VALUES ('KRW-BTC', datetime('now', '-65 minutes'), 100)"
     )
     db.execute(
-        "INSERT INTO market_snapshots (coin, timestamp, price) "
-        "VALUES ('KRW-BTC', datetime('now'), 104)"  # +4%
+        "INSERT INTO market_snapshots (coin, timestamp, price) VALUES ('KRW-BTC', datetime('now'), 104)"  # +4%
     )
     db.execute(
-        "INSERT INTO market_snapshots (coin, timestamp, price) "
-        "VALUES ('KRW-ETH', datetime('now', '-65 minutes'), 100)"
+        "INSERT INTO market_snapshots (coin, timestamp, price) VALUES ('KRW-ETH', datetime('now', '-65 minutes'), 100)"
     )
     db.execute(
-        "INSERT INTO market_snapshots (coin, timestamp, price) "
-        "VALUES ('KRW-ETH', datetime('now'), 104)"  # +4%
+        "INSERT INTO market_snapshots (coin, timestamp, price) VALUES ('KRW-ETH', datetime('now'), 104)"  # +4%
     )
     db.commit()
 

--- a/tests/test_data_hygiene.py
+++ b/tests/test_data_hygiene.py
@@ -35,16 +35,28 @@ def test_cleanup_removes_old_hold_keeps_buy_sell(db):
     recorder = DataRecorder(db)
     # 오래된 hold + 최근 hold + 오래된 buy
     recorder.record_signal(
-        coin="KRW-BTC", signal_type="hold", strategy="test",
-        confidence=0.0, trigger_reason="old", current_price=100,
+        coin="KRW-BTC",
+        signal_type="hold",
+        strategy="test",
+        confidence=0.0,
+        trigger_reason="old",
+        current_price=100,
     )
     recorder.record_signal(
-        coin="KRW-BTC", signal_type="buy", strategy="test",
-        confidence=0.8, trigger_reason="old buy", current_price=100,
+        coin="KRW-BTC",
+        signal_type="buy",
+        strategy="test",
+        confidence=0.8,
+        trigger_reason="old buy",
+        current_price=100,
     )
     recorder.record_signal(
-        coin="KRW-ETH", signal_type="hold", strategy="test",
-        confidence=0.0, trigger_reason="recent", current_price=100,
+        coin="KRW-ETH",
+        signal_type="hold",
+        strategy="test",
+        confidence=0.0,
+        trigger_reason="recent",
+        current_price=100,
     )
     db.execute("UPDATE trade_signals SET timestamp = datetime('now', '-20 days') WHERE trigger_reason LIKE 'old%'")
     db.commit()
@@ -53,15 +65,10 @@ def test_cleanup_removes_old_hold_keeps_buy_sell(db):
     assert before == 3
 
     # 직접 SQL로 cleanup 시뮬레이션 (스크립트 본체는 config.bot.db_path를 쓰니 단위는 SQL로)
-    db.execute(
-        "DELETE FROM trade_signals "
-        "WHERE signal_type = 'hold' AND timestamp < datetime('now', '-14 days')"
-    )
+    db.execute("DELETE FROM trade_signals WHERE signal_type = 'hold' AND timestamp < datetime('now', '-14 days')")
     db.commit()
 
-    rows = db.execute(
-        "SELECT signal_type, trigger_reason FROM trade_signals ORDER BY id"
-    ).fetchall()
+    rows = db.execute("SELECT signal_type, trigger_reason FROM trade_signals ORDER BY id").fetchall()
     types = [dict(r)["signal_type"] for r in rows]
     # 오래된 hold는 사라짐, 오래된 buy + 최근 hold는 유지
     assert "old buy" in [dict(r)["trigger_reason"] for r in rows]
@@ -79,14 +86,27 @@ def test_record_trade_auto_fills_profit_krw(db):
     recorder = DataRecorder(db)
     # 먼저 buy 생성 (orphan 방지 가드 통과)
     buy_id = recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=10000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="test",
     )
     # profit_pct만 주고 profit_krw 생략
     sell_id = recorder.record_trade(
-        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
-        strategy="test", trigger_reason="익절",
-        buy_trade_id=buy_id, profit_pct=10.0,  # profit_krw 생략
+        coin="KRW-BTC",
+        side="sell",
+        price=110,
+        amount=1,
+        total_krw=11000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="익절",
+        buy_trade_id=buy_id,
+        profit_pct=10.0,  # profit_krw 생략
     )
     row = db.execute("SELECT profit_krw FROM trades WHERE id = ?", (sell_id,)).fetchone()
     # 11000 * 10 / 100 = 1100
@@ -97,13 +117,27 @@ def test_record_trade_respects_explicit_profit_krw(db):
     """명시적 profit_krw가 있으면 덮어쓰지 않음."""
     recorder = DataRecorder(db)
     buy_id = recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=10000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="test",
     )
     sell_id = recorder.record_trade(
-        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
-        strategy="test", trigger_reason="익절",
-        buy_trade_id=buy_id, profit_pct=10.0, profit_krw=999.0,  # 명시적
+        coin="KRW-BTC",
+        side="sell",
+        price=110,
+        amount=1,
+        total_krw=11000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="익절",
+        buy_trade_id=buy_id,
+        profit_pct=10.0,
+        profit_krw=999.0,  # 명시적
     )
     row = db.execute("SELECT profit_krw FROM trades WHERE id = ?", (sell_id,)).fetchone()
     assert dict(row)["profit_krw"] == 999.0
@@ -119,8 +153,14 @@ def test_orphan_sell_raises(db):
     recorder = DataRecorder(db)
     with pytest.raises(ValueError, match="orphan"):
         recorder.record_trade(
-            coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
-            strategy="test", trigger_reason="test",
+            coin="KRW-BTC",
+            side="sell",
+            price=110,
+            amount=1,
+            total_krw=11000,
+            fee_krw=5,
+            strategy="test",
+            trigger_reason="test",
             buy_trade_id=999999,  # 존재 안 함
         )
 
@@ -129,13 +169,25 @@ def test_valid_buy_trade_id_accepted(db):
     """실존 buy_trade_id는 정상 통과."""
     recorder = DataRecorder(db)
     buy_id = recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100, amount=1, total_krw=10000, fee_krw=5,
-        strategy="test", trigger_reason="test",
+        coin="KRW-BTC",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=10000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="test",
     )
     # 예외 없이 성공해야 함
     sell_id = recorder.record_trade(
-        coin="KRW-BTC", side="sell", price=110, amount=1, total_krw=11000, fee_krw=5,
-        strategy="test", trigger_reason="익절",
+        coin="KRW-BTC",
+        side="sell",
+        price=110,
+        amount=1,
+        total_krw=11000,
+        fee_krw=5,
+        strategy="test",
+        trigger_reason="익절",
         buy_trade_id=buy_id,
     )
     assert sell_id > 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@
 운영 중 발견된 버그를 재현하여 재발 방지.
 """
 
-import json
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,14 +12,12 @@ import pytest
 
 from cryptobot.data.database import Database
 from cryptobot.data.recorder import DataRecorder
-from cryptobot.data.collector import DataCollector
-from cryptobot.bot.risk import RiskLimits, RiskManager
-from cryptobot.strategies.base import BaseStrategy, Signal, StrategyParams, StrategyInfo
+from cryptobot.strategies.base import StrategyParams
 from cryptobot.strategies.bollinger_bands import BollingerBands
-from cryptobot.strategies.rsi_mean_reversion import RSIMeanReversion
-from cryptobot.strategies.volatility_breakout import VolatilityBreakout
 from cryptobot.strategies.ma_crossover import MACrossover
 from cryptobot.strategies.registry import StrategyRegistry
+from cryptobot.strategies.rsi_mean_reversion import RSIMeanReversion
+from cryptobot.strategies.volatility_breakout import VolatilityBreakout
 
 
 def _make_db():
@@ -34,13 +31,15 @@ def _make_ohlcv(prices: list[float], days: int = 30) -> pd.DataFrame:
     """테스트용 OHLCV DataFrame 생성."""
     data = []
     for i, p in enumerate(prices):
-        data.append({
-            "open": p * 0.99,
-            "high": p * 1.02,
-            "low": p * 0.98,
-            "close": p,
-            "volume": 1000,
-        })
+        data.append(
+            {
+                "open": p * 0.99,
+                "high": p * 1.02,
+                "low": p * 0.98,
+                "close": p,
+                "volume": 1000,
+            }
+        )
     df = pd.DataFrame(data)
     df.index = pd.date_range(end=datetime.now(), periods=len(prices), freq="D")
     return df
@@ -49,6 +48,7 @@ def _make_ohlcv(prices: list[float], days: int = 30) -> pd.DataFrame:
 # ═══════════════════════════════════════════════════
 # 1. 수수료 가드: 0.1% 이하 수익에서 매도 차단
 # ═══════════════════════════════════════════════════
+
 
 class TestFeeGuard:
     """BSV 반복 매도 버그 재현 — 수수료 이하 수익에서 매도 안 되는지."""
@@ -98,6 +98,7 @@ class TestFeeGuard:
 # 2. 수수료 포함 수익 계산 정확성
 # ═══════════════════════════════════════════════════
 
+
 class TestProfitCalculation:
     """profit_krw, profit_pct가 수수료를 포함하는지."""
 
@@ -130,6 +131,7 @@ class TestProfitCalculation:
 # ═══════════════════════════════════════════════════
 # 3. 멀티코인 스냅샷 분리
 # ═══════════════════════════════════════════════════
+
 
 class TestMultiCoinSnapshot:
     """코인별 get_latest_snapshot이 분리되는지."""
@@ -173,6 +175,7 @@ class TestMultiCoinSnapshot:
 # 4. 시장 상태별 전략 자동 선택
 # ═══════════════════════════════════════════════════
 
+
 class TestMarketStrategySelection:
     """시장 상태에 따라 올바른 전략이 선택되는지."""
 
@@ -205,6 +208,7 @@ class TestMarketStrategySelection:
 # 5. 보유 중 hold 신호 기록
 # ═══════════════════════════════════════════════════
 
+
 class TestHoldSignalRecording:
     """보유 중(매도 대기)일 때 hold 신호가 trade_signals에 기록되는지."""
 
@@ -233,6 +237,7 @@ class TestHoldSignalRecording:
 # ═══════════════════════════════════════════════════
 # 6. FOREIGN KEY 안전 처리
 # ═══════════════════════════════════════════════════
+
 
 class TestForeignKeySafety:
     """snapshot_id가 0이면 None으로 처리되는지."""
@@ -287,6 +292,7 @@ class TestForeignKeySafety:
 # 7. 코인별 포지션 독립 추적
 # ═══════════════════════════════════════════════════
 
+
 class TestMultiCoinPositions:
     """여러 코인의 매수/매도가 독립적으로 추적되는지."""
 
@@ -297,13 +303,25 @@ class TestMultiCoinPositions:
 
             # BTC 매수
             btc_buy = recorder.record_trade(
-                coin="KRW-BTC", side="buy", price=100000000, amount=0.001,
-                total_krw=100000, fee_krw=50, strategy="test", trigger_reason="test",
+                coin="KRW-BTC",
+                side="buy",
+                price=100000000,
+                amount=0.001,
+                total_krw=100000,
+                fee_krw=50,
+                strategy="test",
+                trigger_reason="test",
             )
-            # ETH 매수
-            eth_buy = recorder.record_trade(
-                coin="KRW-ETH", side="buy", price=3000000, amount=0.1,
-                total_krw=300000, fee_krw=150, strategy="test", trigger_reason="test",
+            # ETH 매수 (id 반환값은 쓰지 않지만 DB에 레코드 생성)
+            recorder.record_trade(
+                coin="KRW-ETH",
+                side="buy",
+                price=3000000,
+                amount=0.1,
+                total_krw=300000,
+                fee_krw=150,
+                strategy="test",
+                trigger_reason="test",
             )
 
             # BTC만 활성 매수
@@ -318,9 +336,17 @@ class TestMultiCoinPositions:
 
             # BTC 매도
             recorder.record_trade(
-                coin="KRW-BTC", side="sell", price=101000000, amount=0.001,
-                total_krw=101000, fee_krw=50.5, strategy="test", trigger_reason="test",
-                buy_trade_id=btc_buy, profit_pct=0.95, profit_krw=899.5,
+                coin="KRW-BTC",
+                side="sell",
+                price=101000000,
+                amount=0.001,
+                total_krw=101000,
+                fee_krw=50.5,
+                strategy="test",
+                trigger_reason="test",
+                buy_trade_id=btc_buy,
+                profit_pct=0.95,
+                profit_krw=899.5,
             )
 
             # BTC 포지션 없음
@@ -334,6 +360,7 @@ class TestMultiCoinPositions:
 # ═══════════════════════════════════════════════════
 # 8. naive/aware datetime 호환
 # ═══════════════════════════════════════════════════
+
 
 class TestDatetimeCompatibility:
     """UTC aware와 naive datetime이 섞여도 에러 안 나는지."""
@@ -366,6 +393,7 @@ class TestDatetimeCompatibility:
 # 9. 수수료 가드 — main.py 레벨
 # ═══════════════════════════════════════════════════
 
+
 class TestMainFeeGuard:
     """_check_and_sell의 최종 수수료 가드."""
 
@@ -396,6 +424,7 @@ class TestMainFeeGuard:
 # 10. 코인별 전략 파라미터 독립성
 # ═══════════════════════════════════════════════════
 
+
 class TestStrategyParamsIndependence:
     """전략 파라미터가 코인 간에 오염되지 않는지."""
 
@@ -416,11 +445,13 @@ class TestStrategyParamsIndependence:
 # 11. 스캐너 제외 목록
 # ═══════════════════════════════════════════════════
 
+
 class TestScannerExclusions:
     """스테이블코인이 제외되는지."""
 
     def test_stablecoin_excluded(self):
         from cryptobot.bot.scanner import CoinScanner
+
         excluded = CoinScanner.EXCLUDED_COINS
         assert "KRW-USDT" in excluded
         assert "KRW-USDC" in excluded
@@ -431,6 +462,7 @@ class TestScannerExclusions:
 # ═══════════════════════════════════════════════════
 # 12. DB 마이그레이션 안전성
 # ═══════════════════════════════════════════════════
+
 
 class TestDBMigration:
     """DB 초기화가 멱등(idempotent)하고 마이그레이션이 안전한지."""
@@ -443,9 +475,7 @@ class TestDBMigration:
             db.initialize()
 
             # 테이블 존재 확인
-            tables = [r[0] for r in db.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()]
+            tables = [r[0] for r in db.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
             assert "market_snapshots" in tables
             assert "trade_signals" in tables
             assert "trades" in tables

--- a/tests/test_llm_logic_accuracy.py
+++ b/tests/test_llm_logic_accuracy.py
@@ -180,7 +180,10 @@ def test_fee_guard_blocks_profit_taking_when_negative_net(db):
     strat = MagicMock()
     # 익절성 매도 신호 (ROI 등) — 가격이 buy_price 근처라 실질 수수료 차감 후 음수
     strat.check_sell.return_value = Signal(
-        "sell", 0.9, "ROI 도달", is_profit_taking=True,
+        "sell",
+        0.9,
+        "ROI 도달",
+        is_profit_taking=True,
     )
     strat.params = MagicMock()
     strat.params.extra = {}
@@ -195,7 +198,10 @@ def test_fee_guard_blocks_profit_taking_when_negative_net(db):
     bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
 
     active_trade = {
-        "id": 1, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+        "id": 1,
+        "price": 100.0,
+        "total_krw": 10000,
+        "fee_krw": 5,
         "timestamp": "2026-04-17T00:00:00+00:00",
     }
     # 가격 = 100.05 → pnl 0.05%, 수수료 0.15% → 실질 -0.1%
@@ -216,8 +222,14 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     # 실존 buy 레코드 먼저 생성 — orphan 가드(#173) 대응
     recorder = DataRecorder(db)
     buy_id = recorder.record_trade(
-        coin="KRW-BTC", side="buy", price=100.0, amount=1,
-        total_krw=10000, fee_krw=5, strategy="test_strategy", trigger_reason="seed",
+        coin="KRW-BTC",
+        side="buy",
+        price=100.0,
+        amount=1,
+        total_krw=10000,
+        fee_krw=5,
+        strategy="test_strategy",
+        trigger_reason="seed",
     )
 
     bot = CryptoBot.__new__(CryptoBot)
@@ -227,8 +239,14 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     bot._trader = MagicMock()
     bot._trader.is_ready = True
     bot._trader.sell_market.return_value = OrderResult(
-        success=True, side="sell", coin="KRW-BTC", price=95, amount=1,
-        total_krw=9500, fee_krw=5, order_uuid="sell-uuid",
+        success=True,
+        side="sell",
+        coin="KRW-BTC",
+        price=95,
+        amount=1,
+        total_krw=9500,
+        fee_krw=5,
+        order_uuid="sell-uuid",
     )
     bot._config_mgr = MagicMock()
     bot._config_mgr.get_strategy_params_json.return_value = None
@@ -236,7 +254,10 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     strat = MagicMock()
     # 손절 신호 — is_profit_taking=False
     strat.check_sell.return_value = Signal(
-        "sell", 1.0, "손절", is_profit_taking=False,
+        "sell",
+        1.0,
+        "손절",
+        is_profit_taking=False,
     )
     strat.params = MagicMock()
     strat.params.extra = {}
@@ -251,7 +272,10 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
     bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
 
     active_trade = {
-        "id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+        "id": buy_id,
+        "price": 100.0,
+        "total_krw": 10000,
+        "fee_krw": 5,
         "timestamp": "2026-04-17T00:00:00+00:00",
     }
     # 가격 95 — 손실 상태지만 손절이므로 통과해야 함

--- a/tests/test_llm_strategy_switch.py
+++ b/tests/test_llm_strategy_switch.py
@@ -141,11 +141,14 @@ class TestHardLimitsClipping:
         analyzer, db = _make_analyzer()
         try:
             # 범위 밖 값으로 결과 생성
-            result = _build_llm_result("volatility_breakout", extra_params={
-                "k_value": 99.0,  # 범위: 0.2~0.8
-                "stop_loss_pct": -100.0,  # 범위: -20.0~-5.0
-                "rsi_oversold": 99,  # 범위: 20~45
-            })
+            result = _build_llm_result(
+                "volatility_breakout",
+                extra_params={
+                    "k_value": 99.0,  # 범위: 0.2~0.8
+                    "stop_loss_pct": -100.0,  # 범위: -20.0~-5.0
+                    "rsi_oversold": 99,  # 범위: 20~45
+                },
+            )
             result["aggression"] = 5.0  # 범위: 0.1~1.0
 
             clipped = analyzer._apply_hard_limits(result)
@@ -199,12 +202,15 @@ class TestCommonParamsNotInStrategy:
     def test_common_params_not_in_strategy(self):
         analyzer, db = _make_analyzer()
         try:
-            result = _build_llm_result("bb_rsi_combined", extra_params={
-                "bb_std": 1.5,
-                "rsi_oversold": 35,
-                "bb_period": 20,
-                "rsi_period": 14,
-            })
+            result = _build_llm_result(
+                "bb_rsi_combined",
+                extra_params={
+                    "bb_std": 1.5,
+                    "rsi_oversold": 35,
+                    "bb_period": 20,
+                    "rsi_period": 14,
+                },
+            )
 
             repo = StrategyRepository(db)
             repo.complete_shutdown()

--- a/tests/test_order_record_integrity.py
+++ b/tests/test_order_record_integrity.py
@@ -51,7 +51,10 @@ def test_check_and_buy_api_error_notifies_and_records_signal(db):
 
     strat = MagicMock()
     strat.check_buy.return_value = MagicMock(
-        signal_type="buy", confidence=0.8, reason="RSI+BB", trigger_value=100.0,
+        signal_type="buy",
+        confidence=0.8,
+        reason="RSI+BB",
+        trigger_value=100.0,
     )
     strat.params = MagicMock(position_size_pct=100)
     bot._strategy_sel = MagicMock()
@@ -88,7 +91,10 @@ def test_check_and_sell_api_error_notifies_and_records_signal(db):
 
     strat = MagicMock()
     strat.check_sell.return_value = MagicMock(
-        signal_type="sell", confidence=0.7, reason="RSI 정상 복귀", trigger_value=70.0,
+        signal_type="sell",
+        confidence=0.7,
+        reason="RSI 정상 복귀",
+        trigger_value=70.0,
     )
     strat.params = MagicMock()
     strat.params.extra = {}
@@ -104,7 +110,10 @@ def test_check_and_sell_api_error_notifies_and_records_signal(db):
     bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
 
     active_trade = {
-        "id": 1, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+        "id": 1,
+        "price": 100.0,
+        "total_krw": 10000,
+        "fee_krw": 5,
         "timestamp": "2026-04-17T00:00:00+00:00",
     }
     bot._check_and_sell(active_trade, price=110.0, snapshot_id=None, coin="KRW-BTC")
@@ -124,9 +133,11 @@ def test_check_and_buy_commits_immediately_after_record(db):
     # commit을 명시적으로 spy
     commit_calls = []
     orig_commit = db.commit
+
     def spy_commit():
         commit_calls.append(1)
         orig_commit()
+
     bot._db.commit = spy_commit
     # 실제 쿼리는 실제 DB로
     bot._db.execute = db.execute
@@ -136,8 +147,14 @@ def test_check_and_buy_commits_immediately_after_record(db):
     bot._trader.is_ready = True
     bot._trader.get_balance_krw.return_value = 100_000
     bot._trader.buy_market.return_value = OrderResult(
-        success=True, side="buy", coin="KRW-BTC", price=100, amount=1,
-        total_krw=10_000, fee_krw=5, order_uuid="test-uuid",
+        success=True,
+        side="buy",
+        coin="KRW-BTC",
+        price=100,
+        amount=1,
+        total_krw=10_000,
+        fee_krw=5,
+        order_uuid="test-uuid",
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
@@ -148,7 +165,10 @@ def test_check_and_buy_commits_immediately_after_record(db):
 
     strat = MagicMock()
     strat.check_buy.return_value = MagicMock(
-        signal_type="buy", confidence=0.8, reason="test", trigger_value=100.0,
+        signal_type="buy",
+        confidence=0.8,
+        reason="test",
+        trigger_value=100.0,
     )
     strat.params = MagicMock(position_size_pct=100)
     strat.params.extra = {"k_value": 0.5}
@@ -172,9 +192,7 @@ def test_rejected_strategy_marks_result_and_preserves_existing(db):
     # initialize()가 기본 전략을 등록하므로 bb_rsi_combined만 활성화로 세팅
     db.execute("UPDATE strategies SET is_active = 0")
     db.execute("UPDATE strategies SET is_active = 1, is_available = 1 WHERE name = 'bb_rsi_combined'")
-    db.execute(
-        "INSERT INTO llm_decisions (timestamp, model, output_raw_json) VALUES (datetime('now'), 'test', '{}')"
-    )
+    db.execute("INSERT INTO llm_decisions (timestamp, model, output_raw_json) VALUES (datetime('now'), 'test', '{}')")
     db.commit()
 
     analyzer = LLMAnalyzer(db)
@@ -198,6 +216,7 @@ def test_rejected_strategy_marks_result_and_preserves_existing(db):
     # llm_decisions에 rejected 정보 저장됐는지
     row = db.execute("SELECT input_news_summary FROM llm_decisions ORDER BY id DESC LIMIT 1").fetchone()
     import json as _j
+
     payload = _j.loads(dict(row)["input_news_summary"])
     assert payload.get("_rejected_strategy") == "NONEXISTENT_STRATEGY"
     assert "사용 가능" in payload.get("_rejected_strategy_reason", "")


### PR DESCRIPTION
## Summary
- ruff check --fix 자동 수정 + 수동 정리로 **66건 → 0건**
- F821(2) / F841(5) / F401(11) / I001(4) / E402(14) / E501(30)

## 주요 변경
- \`data/collector.py\`: \`pd\` 타입 힌트 → \`TYPE_CHECKING\` 패턴
- \`api/main.py\`, \`routes/balance.py\`, \`routes/trades.py\`: import 상단 이동
- \`data/database.py\`: 긴 INSERT SQL 분리 + trailing comma 제거
- ruff format 전체 적용 (34개 파일)

## Test plan
- [x] pytest tests/ 182/182 통과
- [x] ruff check 깨끗
- [x] ruff format --check 깨끗

Related: #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)