### PR TITLE
fix: 자동 마이그레이션 — 재시작만으로 스키마 업데이트

### DIFF
--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -714,6 +714,22 @@ class Database:
                 conn.execute("ALTER TABLE trades ADD COLUMN reconciled_at DATETIME")
                 logger.info("trades 테이블에 정합성 검증 컬럼 추가 완료 (order_uuid, reconciled, reconciled_at)")
 
+            # 마이그레이션: llm_decisions에 before/after 스냅샷 컬럼 추가 (#171)
+            try:
+                conn.execute("SELECT before_snapshot_json FROM llm_decisions LIMIT 1")
+            except sqlite3.OperationalError:
+                conn.execute("ALTER TABLE llm_decisions ADD COLUMN before_snapshot_json TEXT")
+                conn.execute("ALTER TABLE llm_decisions ADD COLUMN after_snapshot_json TEXT")
+                logger.info("llm_decisions 테이블에 before/after 스냅샷 컬럼 추가 완료")
+
+            # 마이그레이션: news_articles에 impact_score/scope 컬럼 추가 (#154)
+            try:
+                conn.execute("SELECT impact_score FROM news_articles LIMIT 1")
+            except sqlite3.OperationalError:
+                conn.execute("ALTER TABLE news_articles ADD COLUMN impact_score INTEGER")
+                conn.execute("ALTER TABLE news_articles ADD COLUMN scope TEXT")
+                logger.info("news_articles 테이블에 impact_score/scope 컬럼 추가 완료")
+
             # 마이그레이션: bot_config에 새 설정 추가 (기존 DB 호환)
             existing = conn.execute("SELECT key FROM bot_config WHERE key = 'strategy_switch_delay_seconds'").fetchone()
             if existing is None:

--- a/tests/test_auto_migration.py
+++ b/tests/test_auto_migration.py
@@ -1,0 +1,86 @@
+"""서버 재시작 시 자동 마이그레이션 검증.
+
+initialize()가 기존 DB(신규 컬럼 없음) 상태에서도 ALTER TABLE로 자동 추가해야 한다.
+이게 없으면 운영자가 매번 SQL 스크립트를 수동으로 돌려야 함.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def legacy_db_path():
+    """신규 컬럼이 없는 옛 스키마 DB 파일 생성."""
+    tmpdir = tempfile.mkdtemp()
+    path = Path(tmpdir) / "legacy.db"
+    conn = sqlite3.connect(str(path))
+    # 옛 스키마 — before/after/impact_score/scope 없음
+    conn.executescript("""
+        CREATE TABLE llm_decisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            model TEXT NOT NULL,
+            input_news_summary TEXT,
+            output_market_state TEXT
+        );
+        CREATE TABLE news_articles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source TEXT NOT NULL,
+            title TEXT NOT NULL,
+            collected_at DATETIME NOT NULL
+        );
+    """)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_initialize_adds_llm_decisions_before_after(legacy_db_path):
+    """initialize()가 llm_decisions에 before_snapshot_json / after_snapshot_json 컬럼 추가."""
+    # 실행 전 검증
+    conn = sqlite3.connect(str(legacy_db_path))
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute("SELECT before_snapshot_json FROM llm_decisions LIMIT 1")
+    conn.close()
+
+    # initialize() 실행 → 자동 마이그레이션 발동
+    db = Database(legacy_db_path)
+    db.initialize()
+    try:
+        # 컬럼 존재 확인 (OperationalError 안 나면 성공)
+        db.execute("SELECT before_snapshot_json, after_snapshot_json FROM llm_decisions LIMIT 1").fetchone()
+    finally:
+        db.close()
+
+
+def test_initialize_adds_news_articles_impact_scope(legacy_db_path):
+    """initialize()가 news_articles에 impact_score / scope 컬럼 추가."""
+    conn = sqlite3.connect(str(legacy_db_path))
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute("SELECT impact_score FROM news_articles LIMIT 1")
+    conn.close()
+
+    db = Database(legacy_db_path)
+    db.initialize()
+    try:
+        db.execute("SELECT impact_score, scope FROM news_articles LIMIT 1").fetchone()
+    finally:
+        db.close()
+
+
+def test_initialize_idempotent(legacy_db_path):
+    """initialize()를 여러 번 호출해도 에러 없이 동작 (중복 ALTER 방지)."""
+    db = Database(legacy_db_path)
+    db.initialize()  # 1회차: 컬럼 추가
+    db.initialize()  # 2회차: 이미 있으므로 스킵
+    db.initialize()  # 3회차
+    try:
+        db.execute("SELECT before_snapshot_json FROM llm_decisions LIMIT 1").fetchone()
+        db.execute("SELECT impact_score FROM news_articles LIMIT 1").fetchone()
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
운영자가 \`scripts/migrate_*.sql\`을 수동으로 돌려야 했던 문제 해소.
기존 \`initialize()\` 패턴(try SELECT → ALTER)을 따라 신규 2건 추가.

## 수정
- llm_decisions: before/after 스냅샷 컬럼 자동 추가 (#171 관련)
- news_articles: impact_score/scope 컬럼 자동 추가 (#154 관련)

## 동작
봇/API/뉴스 프로세스 중 하나라도 재시작 → 자동 반영. Idempotent.

## Test plan
- [x] pytest tests/test_auto_migration.py 3/3
- [x] 전체 205/205
- [x] ruff 깨끗

🤖 Generated with [Claude Code](https://claude.com/claude-code)