### PR TITLE
fix: #152 #183 리뷰 후속 수정 5건 (#186)

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -161,14 +161,30 @@ class CryptoBot:
             self._coin_highest_prices[coin] = strategy._highest_price
         finally:
             # 카테고리별 파라미터 복원 (공유 인스턴스 보호)
-            if hasattr(strategy, "_orig_stop_loss"):
-                strategy.params.stop_loss_pct = strategy._orig_stop_loss
-                strategy.params.trailing_stop_pct = strategy._orig_trailing
-                strategy.params.position_size_pct = strategy._orig_position
+            # #186: 복원 중 자체에서도 예외 안전하게 — 각 속성별 try/except
+            for attr_restore in (
+                ("_orig_stop_loss", "stop_loss_pct"),
+                ("_orig_trailing", "trailing_stop_pct"),
+                ("_orig_position", "position_size_pct"),
+            ):
+                marker, field = attr_restore
+                if hasattr(strategy, marker):
+                    try:
+                        setattr(strategy.params, field, getattr(strategy, marker))
+                    finally:
+                        try:
+                            delattr(strategy, marker)
+                        except AttributeError:
+                            pass
             # #152: 코인별 assignment_params로 오버라이드한 extra 복원
             if hasattr(strategy, "_orig_extra"):
-                strategy.params.extra = strategy._orig_extra
-                del strategy._orig_extra
+                try:
+                    strategy.params.extra = strategy._orig_extra
+                finally:
+                    try:
+                        delattr(strategy, "_orig_extra")
+                    except AttributeError:
+                        pass
             self._strategy_sel.current_strategy = orig
             self._strategy_sel.current_strategy_name = orig_name
 

--- a/src/cryptobot/bot/strategy_selector.py
+++ b/src/cryptobot/bot/strategy_selector.py
@@ -166,10 +166,12 @@ class StrategySelector:
             return self.current_strategy, self.current_strategy_name
 
         # 코인별 assignment_params 적용 — 전략 파라미터 오버라이드
-        if assignment_params:
+        # #186: 항상 _orig_extra 세팅 (빈 dict여도). finally 복원 일관성 보장.
+        if assignment_params is not None:
             strategy._orig_extra = dict(strategy.params.extra)
-            for k, v in assignment_params.items():
-                strategy.params.extra[k] = v
+            if assignment_params:
+                for k, v in assignment_params.items():
+                    strategy.params.extra[k] = v
 
         # 카테고리별 리스크 파라미터 (공유 인스턴스 보호 — 매 틱 후 복원)
         row = self._db.execute("SELECT * FROM coin_strategy_config WHERE category = ?", (coin_category,)).fetchone()

--- a/src/cryptobot/data/coin_strategy_repository.py
+++ b/src/cryptobot/data/coin_strategy_repository.py
@@ -100,7 +100,8 @@ class CoinStrategyRepository:
                 except (ValueError, TypeError):
                     pass  # 타임스탬프 파싱 실패 시 허용
 
-        params_json = json.dumps(params, ensure_ascii=False) if params else None
+        # #186: None과 빈 dict 구분 — 빈 dict는 명시적 "기본값 사용" 의사 표현
+        params_json = json.dumps(params, ensure_ascii=False) if params is not None else None
         self._db.execute(
             """
             INSERT INTO coin_strategy_assignment (coin, strategy_name, params_json, assigned_by, reason, assigned_at)
@@ -134,6 +135,7 @@ class CoinStrategyRepository:
         coin_strategies: dict[str, dict],
         available_strategies: set[str],
         held_coins: set[str] | None = None,
+        active_coins: set[str] | None = None,
     ) -> dict:
         """LLM이 준 coin_strategies dict 일괄 적용.
 
@@ -141,6 +143,8 @@ class CoinStrategyRepository:
             coin_strategies: {coin: {"strategy": name, "params": {...}}}
             available_strategies: DB에 등록된 유효 전략명 집합
             held_coins: 보유 중인 코인 (전략 변경 금지 대상)
+            active_coins: 현재 모니터링 중인 코인 (#186). 지정 시 외부 코인 배정 거부.
+                None이면 기존 동작(필터 없음) 유지.
 
         Returns:
             {"applied": [...], "rejected": [{coin, strategy, reason}, ...]}
@@ -160,6 +164,10 @@ class CoinStrategyRepository:
                 continue
             if strategy not in available_strategies:
                 rejected.append({"coin": coin_norm, "strategy": strategy, "reason": "unknown strategy"})
+                continue
+            # #186: 모니터링 외 코인 배정 거부 — 사용되지 않는 배정이 DB에 쌓이는 것 방지
+            if active_coins is not None and coin_norm not in active_coins:
+                rejected.append({"coin": coin_norm, "strategy": strategy, "reason": "coin not monitored"})
                 continue
             if coin_norm in held_coins:
                 # 보유 중인 코인은 전략 교체 금지 — 다음 라운드 때 반영

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -165,7 +165,11 @@ SYSTEM_PROMPT = """당신은 암호화폐 자동매매 봇의 시장 분석 전�
     "roi_10min": 3.0,
     "roi_30min": 2.0,
     "roi_60min": 1.0,
-    "roi_120min": 0.3
+    "roi_120min": 0.3,
+    // 전략별 추가 — recommended_strategy가 bb_rsi_combined일 때 예:
+    "rsi_oversold": 30,
+    "bb_std": 2.0
+    // 다른 전략이면 해당 전략의 파라미터만 포함 (아래 표 참조)
   },
   "coin_recommendations": {
     "add": [],
@@ -1426,12 +1430,16 @@ class LLMAnalyzer:
                     messages=[{"role": "user", "content": prompt}],
                 )
 
-                usage = response.usage
-                total_input += getattr(usage, "input_tokens", 0) or 0
-                total_output += getattr(usage, "output_tokens", 0) or 0
-                # 캐시 토큰 — SDK 응답에 있을 때만 집계 (없으면 0)
-                total_cache_creation += getattr(usage, "cache_creation_input_tokens", 0) or 0
-                total_cache_read += getattr(usage, "cache_read_input_tokens", 0) or 0
+                # #186: usage 객체가 없거나 malformed여도 응답 처리는 계속
+                try:
+                    usage = response.usage
+                    total_input += getattr(usage, "input_tokens", 0) or 0
+                    total_output += getattr(usage, "output_tokens", 0) or 0
+                    # 캐시 토큰 — SDK 응답에 있을 때만 집계 (없으면 0)
+                    total_cache_creation += getattr(usage, "cache_creation_input_tokens", 0) or 0
+                    total_cache_read += getattr(usage, "cache_read_input_tokens", 0) or 0
+                except Exception as _usage_e:
+                    logger.warning("usage 파싱 실패 (집계 건너뜀): %s", _usage_e)
 
                 content = response.content[0].text.strip()
 
@@ -1846,7 +1854,19 @@ class LLMAnalyzer:
             ).fetchall()
             held = {dict(r)["coin"] for r in held_rows}
 
-            bulk = coin_repo.apply_bulk(coin_strategies, available, held_coins=held)
+            # #186: 현재 모니터링 중인 코인만 허용 — 최근 1시간 스냅샷 기준
+            # 모니터링 외 코인 배정을 DB에 저장하지 않음 (안 쓰일 배정)
+            active_rows = self._db.execute(
+                "SELECT DISTINCT coin FROM market_snapshots WHERE timestamp >= datetime('now', '-1 hour')"
+            ).fetchall()
+            active_coins = {dict(r)["coin"] for r in active_rows}
+
+            bulk = coin_repo.apply_bulk(
+                coin_strategies,
+                available,
+                held_coins=held,
+                active_coins=active_coins if active_coins else None,
+            )
             logger.info(
                 "coin_strategies 적용: %d건 반영, %d건 거부",
                 len(bulk["applied"]),

--- a/tests/test_review_followup_186.py
+++ b/tests/test_review_followup_186.py
@@ -1,0 +1,221 @@
+"""#186 — #152 #183 리뷰 후속 수정 테스트.
+
+1. _orig_extra 예외 경로 안전 복원
+2. SDK usage 파싱 실패 시 크래시 없음
+3. 모니터링 외 코인 배정 거부
+4. SYSTEM_PROMPT 예시 JSON 전략 파라미터 언급
+5. _orig_extra 빈 assignment_params여도 일관된 동작
+"""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cryptobot.data.coin_strategy_repository import CoinStrategyRepository
+from cryptobot.data.database import Database
+from cryptobot.llm.analyzer import SYSTEM_PROMPT, LLMAnalyzer
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+# ===================================================================
+# 1. _orig_extra 복원 안전성 — main.py finally
+# ===================================================================
+
+
+def test_orig_extra_finally_restores_even_after_exception():
+    """finally 복원 로직 자체 검증 — 공유 인스턴스 강건성.
+
+    main._tick_coin의 finally 로직을 재현:
+    - 예외 발생 상황에서도 _orig_extra가 항상 복원되고 제거된다.
+    """
+
+    # main.py의 finally 블록과 동일한 로직 시뮬레이션
+    class _Params:
+        extra: dict
+
+    class _Strat:
+        params = _Params()
+
+    strat = _Strat()
+    strat.params.extra = {"k_value": 0.99}  # 오버라이드된 상태
+    strat._orig_extra = {"k_value": 0.5}  # 원본
+
+    # finally 코드를 직접 실행 (예외 경로 모사)
+    try:
+        raise RuntimeError("forced exception in tick")
+    except RuntimeError:
+        pass
+    finally:
+        if hasattr(strat, "_orig_extra"):
+            try:
+                strat.params.extra = strat._orig_extra
+            finally:
+                try:
+                    delattr(strat, "_orig_extra")
+                except AttributeError:
+                    pass
+
+    # 복원 + 정리 확인
+    assert not hasattr(strat, "_orig_extra"), "_orig_extra 정리 실패"
+    assert strat.params.extra == {"k_value": 0.5}, "원본 복원 실패"
+
+
+def test_orig_extra_restore_survives_restore_exception():
+    """복원 중 예외가 나도 marker는 제거된다 (오염 방지)."""
+
+    class _Strat:
+        pass
+
+    strat = _Strat()
+    strat._orig_extra = {"k_value": 0.5}
+
+    # 복원 중 예외 — params가 없는 경우 모사
+    try:
+        if hasattr(strat, "_orig_extra"):
+            try:
+                strat.params.extra = strat._orig_extra  # AttributeError (params 없음)
+            finally:
+                try:
+                    delattr(strat, "_orig_extra")
+                except AttributeError:
+                    pass
+    except AttributeError:
+        pass  # params 없어 에러 나도 marker는 정리됨
+
+    assert not hasattr(strat, "_orig_extra"), "예외 중에도 marker 정리돼야 함"
+
+
+# ===================================================================
+# 2. SDK usage 파싱 실패 시 크래시 없음
+# ===================================================================
+
+
+def test_call_claude_survives_missing_usage(db, monkeypatch):
+    """response.usage 자체가 없어도 응답 처리는 계속."""
+    a = LLMAnalyzer(db)
+    a._api_key = "sk-test"
+
+    class _FakeClient:
+        def __init__(self, api_key):
+            pass
+
+        @property
+        def messages(self):
+            return self
+
+        def create(self, **kwargs):
+            # usage 없는 응답
+            content_block = SimpleNamespace(
+                text='{"market_summary_kr":"t","market_state":"sideways",'
+                '"confidence":0.5,"aggression":0.5,"should_alert_stop":false,'
+                '"allow_trading":true,"recommended_strategy":"bb_rsi_combined",'
+                '"recommended_params":{},"reasoning":"t"}'
+            )
+            # usage 속성 자체 없음
+            resp = SimpleNamespace(content=[content_block])
+            return resp
+
+    monkeypatch.setattr("anthropic.Anthropic", _FakeClient)
+    result = a._call_claude("prompt")
+    # 크래시 없이 결과 반환
+    assert result is not None
+    assert result["_input_tokens"] == 0
+    assert result["_output_tokens"] == 0
+
+
+# ===================================================================
+# 3. 모니터링 외 코인 배정 거부
+# ===================================================================
+
+
+def test_apply_bulk_rejects_coin_not_in_active(db):
+    """active_coins에 없는 코인은 rejected."""
+    repo = CoinStrategyRepository(db)
+    result = repo.apply_bulk(
+        {"KRW-UNKNOWN": {"strategy": "volatility_breakout"}},
+        available_strategies={"volatility_breakout"},
+        active_coins={"KRW-BTC"},  # UNKNOWN은 여기 없음
+    )
+    assert not result["applied"]
+    assert result["rejected"][0]["reason"] == "coin not monitored"
+
+
+def test_apply_bulk_accepts_coin_in_active(db):
+    """active_coins에 있는 코인은 정상 배정."""
+    repo = CoinStrategyRepository(db)
+    result = repo.apply_bulk(
+        {"KRW-BTC": {"strategy": "volatility_breakout"}},
+        available_strategies={"volatility_breakout"},
+        active_coins={"KRW-BTC"},
+    )
+    assert "KRW-BTC" in result["applied"]
+
+
+def test_apply_bulk_active_coins_none_skips_check(db):
+    """active_coins=None이면 모니터링 필터 스킵 (기존 동작 호환)."""
+    repo = CoinStrategyRepository(db)
+    result = repo.apply_bulk(
+        {"KRW-NEW": {"strategy": "volatility_breakout"}},
+        available_strategies={"volatility_breakout"},
+        active_coins=None,
+    )
+    assert "KRW-NEW" in result["applied"]
+
+
+# ===================================================================
+# 4. SYSTEM_PROMPT 예시 JSON 완전성
+# ===================================================================
+
+
+def test_system_prompt_example_includes_strategy_specific_params():
+    """예시 JSON에 bb_rsi_combined 등 전략 파라미터 언급."""
+    # 최소 rsi_oversold와 bb_std가 예시나 부연 설명에 있어야 LLM이 포함할 확률↑
+    assert "rsi_oversold" in SYSTEM_PROMPT
+    assert "bb_std" in SYSTEM_PROMPT
+    # 전략별 파라미터 매핑 표도 있어야 함
+    assert "volatility_breakout: k_value" in SYSTEM_PROMPT
+
+
+# ===================================================================
+# 5. _orig_extra 일관성 — assignment_params=None vs {}
+# ===================================================================
+
+
+def test_selector_sets_orig_extra_when_assignment_empty_params(db):
+    """assignment가 있지만 params_json이 빈 dict여도 _orig_extra 설정."""
+    from cryptobot.bot.strategy_selector import StrategySelector
+
+    config = MagicMock()
+
+    def _cfg(key, default=None):
+        defaults = {
+            "stop_loss_pct": "-5.0",
+            "trailing_stop_pct": "-3.0",
+            "position_size_pct": "100.0",
+            "roi_table": "",
+            "fallback_strategy": "bb_rsi_combined",
+        }
+        return defaults.get(key, default if default is not None else "bb_rsi_combined")
+
+    config.get.side_effect = _cfg
+
+    # 빈 params_json으로 assignment 생성
+    repo = CoinStrategyRepository(db)
+    repo.assign("KRW-BTC", "volatility_breakout", params={})  # params 빈 dict
+
+    sel = StrategySelector(db, config)
+    strategy, _ = sel.get_coin_strategy("KRW-BTC", "btc", collectors={})
+
+    # 빈 params여도 _orig_extra 설정 (복원 일관성)
+    assert hasattr(strategy, "_orig_extra"), "params 빈 dict여도 _orig_extra 설정해야 함"


### PR DESCRIPTION
## 리뷰 결과 요약
Explore 에이전트로 전수 리뷰 — BUG 3, RISK 7, SMELL 4, NIT 2 식별.
현 설계상 문제 아닌 BUG 2건(재시도 누적/SQLite race)은 제외하고 5건 수정.

## 수정 요약
1. **_orig_extra 복원 안전성** (BUG) — finally 중첩 try로 복원 중 예외 방어
2. **SDK backward-compat** (RISK) — response.usage malformed 시 크래시 없음
3. **모니터링 외 코인 거부** (RISK) — apply_bulk에 active_coins 필터 추가
4. **SYSTEM_PROMPT 예시 완전성** (SMELL) — bb_rsi_combined 파라미터 예시 추가
5. **_orig_extra 일관성** (SMELL) — 빈 params도 세팅, repo.assign 빈 dict 버그 수정

## Test plan
- [x] pytest tests/test_review_followup_186.py 8/8
- [x] 전체 259/259
- [x] ruff 깨끗

Related: #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)