### PR TITLE
fix: 2차 리뷰 후속 — HARD_LIMITS 검증 / 캐싱 fallback (#188)

### DIFF
--- a/src/cryptobot/data/coin_strategy_repository.py
+++ b/src/cryptobot/data/coin_strategy_repository.py
@@ -19,6 +19,35 @@ from cryptobot.data.database import Database
 logger = logging.getLogger(__name__)
 
 
+def _clip_to_hard_limits(params: dict) -> tuple[dict, list[dict]]:
+    """#188: coin_strategy_assignment 저장 직전 HARD_LIMITS 범위로 클리핑.
+
+    LLM이 범위 밖 값(예: bb_std=5.0, rsi_oversold=100)을 보내도 실제 전략에는
+    안전한 값만 적용되도록 한다. 원본과 클리핑 후 값을 함께 반환해 로깅.
+
+    Returns:
+        (clipped_params, clipped_log) — log는 [{field, original, clipped, range}]
+    """
+    # 순환 import 방지 — 함수 내부 import
+    from cryptobot.llm.analyzer import HARD_LIMITS
+
+    clipped = dict(params)
+    log: list[dict] = []
+    for key, val in list(params.items()):
+        if key not in HARD_LIMITS:
+            continue
+        try:
+            fv = float(val)
+        except (ValueError, TypeError):
+            continue
+        mn, mx = HARD_LIMITS[key]
+        new_val = max(mn, min(mx, fv))
+        if new_val != fv:
+            clipped[key] = new_val
+            log.append({"field": key, "original": fv, "clipped": new_val, "range": [mn, mx]})
+    return clipped, log
+
+
 class CoinStrategyRepository:
     """coin_strategy_assignment 테이블 CRUD."""
 
@@ -99,6 +128,18 @@ class CoinStrategyRepository:
                         return False
                 except (ValueError, TypeError):
                     pass  # 타임스탬프 파싱 실패 시 허용
+
+        # #188: HARD_LIMITS 범위 밖 파라미터 클리핑 (저장 전)
+        # LLM이 bb_std=5.0, rsi_oversold=100 같은 범위 밖 값 보내도 안전한 값만 저장됨
+        clipped_log: list[dict] = []
+        if params is not None:
+            params, clipped_log = _clip_to_hard_limits(params)
+            if clipped_log:
+                logger.warning(
+                    "coin_strategy_assignment 파라미터 클리핑: coin=%s | %s",
+                    coin,
+                    ", ".join(f"{c['field']}: {c['original']}→{c['clipped']}" for c in clipped_log),
+                )
 
         # #186: None과 빈 dict 구분 — 빈 dict는 명시적 "기본값 사용" 의사 표현
         params_json = json.dumps(params, ensure_ascii=False) if params is not None else None

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -1412,23 +1412,52 @@ class LLMAnalyzer:
         total_cache_creation = 0
         total_cache_read = 0
 
+        # #188: 캐싱 기능 에러 시 폴백 — 한 번 실패하면 남은 시도는 캐싱 없이
+        use_caching = True
         for attempt in range(1, self.MAX_RETRIES + 1):
             try:
                 client = anthropic.Anthropic(api_key=self._api_key)
                 # #183: Prompt Caching — SYSTEM은 1h 캐시, USER는 매번 새 데이터.
                 # ACTIVE 60분 간격 × 1h 캐시로 대부분 호출이 cache hit.
-                response = client.messages.create(
-                    model=self._model,
-                    max_tokens=1024,
-                    system=[
-                        {
-                            "type": "text",
-                            "text": SYSTEM_PROMPT,
-                            "cache_control": {"type": "ephemeral", "ttl": "1h"},
-                        }
-                    ],
-                    messages=[{"role": "user", "content": prompt}],
-                )
+                if use_caching:
+                    try:
+                        response = client.messages.create(
+                            model=self._model,
+                            max_tokens=1024,
+                            system=[
+                                {
+                                    "type": "text",
+                                    "text": SYSTEM_PROMPT,
+                                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                                }
+                            ],
+                            messages=[{"role": "user", "content": prompt}],
+                        )
+                    except Exception as cache_err:
+                        # 캐싱 관련 에러 의심 — 메시지에 cache/ephemeral/control 포함되면 fallback
+                        msg = str(cache_err).lower()
+                        if any(kw in msg for kw in ("cache", "ephemeral", "control")):
+                            logger.warning(
+                                "Prompt Caching 실패 — 이번 세션 캐싱 없이 재시도: %s",
+                                cache_err,
+                            )
+                            use_caching = False
+                            response = client.messages.create(
+                                model=self._model,
+                                max_tokens=1024,
+                                system=SYSTEM_PROMPT,
+                                messages=[{"role": "user", "content": prompt}],
+                            )
+                        else:
+                            raise
+                else:
+                    # 이전 시도에서 캐싱 실패했으면 남은 시도는 캐싱 없이
+                    response = client.messages.create(
+                        model=self._model,
+                        max_tokens=1024,
+                        system=SYSTEM_PROMPT,
+                        messages=[{"role": "user", "content": prompt}],
+                    )
 
                 # #186: usage 객체가 없거나 malformed여도 응답 처리는 계속
                 try:

--- a/tests/test_review_round2_188.py
+++ b/tests/test_review_round2_188.py
@@ -1,0 +1,204 @@
+"""#188 — 2차 리뷰 후속 수정 테스트.
+
+1. coin_strategy_assignment 파라미터 HARD_LIMITS 클리핑 (CRITICAL)
+2. Prompt Caching 실패 시 fallback 재시도 (HIGH)
+3. 비활성 전략 assignment 후 fallback 안전성 (MED)
+"""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cryptobot.data.coin_strategy_repository import (
+    CoinStrategyRepository,
+    _clip_to_hard_limits,
+)
+from cryptobot.data.database import Database
+from cryptobot.llm.analyzer import LLMAnalyzer
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+# ===================================================================
+# 1. HARD_LIMITS 클리핑 (CRITICAL)
+# ===================================================================
+
+
+def test_clip_to_hard_limits_clips_bb_std():
+    """bb_std=5.0 → 2.5 (HARD_LIMITS 상한)."""
+    params = {"bb_std": 5.0, "k_value": 0.5}
+    clipped, log = _clip_to_hard_limits(params)
+    assert clipped["bb_std"] == 2.5
+    assert clipped["k_value"] == 0.5  # 범위 내 → 변화 없음
+    assert any(c["field"] == "bb_std" for c in log)
+
+
+def test_clip_to_hard_limits_clips_rsi_oversold():
+    """rsi_oversold=100 → 45 (HARD_LIMITS 상한)."""
+    params = {"rsi_oversold": 100}
+    clipped, log = _clip_to_hard_limits(params)
+    assert clipped["rsi_oversold"] == 45
+
+
+def test_clip_to_hard_limits_ignores_unknown_keys():
+    """HARD_LIMITS에 없는 키는 그대로."""
+    params = {"custom_param": 9999}
+    clipped, log = _clip_to_hard_limits(params)
+    assert clipped["custom_param"] == 9999
+    assert not log
+
+
+def test_clip_to_hard_limits_handles_non_numeric():
+    """숫자 캐스팅 실패하는 값은 그대로 (에러 없음)."""
+    params = {"k_value": "not_a_number"}
+    clipped, log = _clip_to_hard_limits(params)
+    assert clipped["k_value"] == "not_a_number"
+
+
+def test_assign_clips_invalid_params(db):
+    """CoinStrategyRepository.assign이 범위 밖 값을 자동 클리핑."""
+    repo = CoinStrategyRepository(db)
+    repo.assign("KRW-BTC", "bb_rsi_combined", {"bb_std": 5.0, "rsi_oversold": 100})
+
+    a = repo.get_assignment("KRW-BTC")
+    # 클리핑된 값이 저장됨
+    assert a["params"]["bb_std"] == 2.5
+    assert a["params"]["rsi_oversold"] == 45
+
+
+def test_apply_bulk_clips_before_storing(db):
+    """apply_bulk도 assign을 거치므로 클리핑 적용됨."""
+    repo = CoinStrategyRepository(db)
+    result = repo.apply_bulk(
+        {"KRW-BTC": {"strategy": "bb_rsi_combined", "params": {"bb_std": 10.0}}},
+        available_strategies={"bb_rsi_combined"},
+    )
+    assert "KRW-BTC" in result["applied"]
+    a = repo.get_assignment("KRW-BTC")
+    assert a["params"]["bb_std"] == 2.5  # 클리핑됨
+
+
+# ===================================================================
+# 2. Prompt Caching fallback (HIGH)
+# ===================================================================
+
+
+def test_call_claude_falls_back_when_cache_rejected(db, monkeypatch):
+    """cache_control 관련 에러 시 system 평문으로 재시도."""
+    a = LLMAnalyzer(db)
+    a._api_key = "sk-test"
+
+    call_log = []
+
+    class _FakeClient:
+        def __init__(self, api_key):
+            pass
+
+        @property
+        def messages(self):
+            return self
+
+        def create(self, **kwargs):
+            call_log.append(kwargs)
+            # 첫 호출(캐시 포함): cache 에러 모사
+            if isinstance(kwargs.get("system"), list):
+                raise Exception("Invalid cache_control parameter")
+            # 두번째(평문): 정상 응답
+            usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+            content_block = SimpleNamespace(
+                text='{"market_summary_kr":"t","market_state":"sideways","confidence":0.5,'
+                '"aggression":0.5,"should_alert_stop":false,"allow_trading":true,'
+                '"recommended_strategy":"bb_rsi_combined","recommended_params":{},'
+                '"reasoning":"t"}'
+            )
+            return SimpleNamespace(usage=usage, content=[content_block])
+
+    monkeypatch.setattr("anthropic.Anthropic", _FakeClient)
+    result = a._call_claude("prompt")
+
+    # 재시도로 성공
+    assert result is not None
+    # 1회는 list(cache 포함), 1회는 평문 — 총 2회 호출
+    assert len(call_log) == 2
+    assert isinstance(call_log[0]["system"], list)
+    assert isinstance(call_log[1]["system"], str)
+
+
+def test_call_claude_non_cache_error_does_not_trigger_fallback(db, monkeypatch):
+    """캐시와 무관한 에러(예: 네트워크)는 fallback 유도하지 않음."""
+    a = LLMAnalyzer(db)
+    a._api_key = "sk-test"
+
+    call_log = []
+
+    class _FakeClient:
+        def __init__(self, api_key):
+            pass
+
+        @property
+        def messages(self):
+            return self
+
+        def create(self, **kwargs):
+            call_log.append(kwargs)
+            # 모든 호출 네트워크 에러
+            raise Exception("Connection timeout")
+
+    monkeypatch.setattr("anthropic.Anthropic", _FakeClient)
+    result = a._call_claude("prompt")
+    # 전부 실패하면 None — fallback이 아닌 재시도
+    assert result is None
+    # 모든 호출이 여전히 list system (fallback 안 됨)
+    for c in call_log:
+        assert isinstance(c["system"], list)
+
+
+# ===================================================================
+# 3. 비활성 전략 fallback (MED)
+# ===================================================================
+
+
+def test_disabled_strategy_in_assignment_falls_back_to_current(db):
+    """assignment에 있는 전략이 is_available=FALSE로 바뀐 경우 fallback 동작."""
+    from cryptobot.bot.strategy_selector import StrategySelector
+
+    # 특정 전략을 비활성으로 만듦 (coin에 배정된 상태)
+    repo = CoinStrategyRepository(db)
+    repo.assign("KRW-BTC", "ma_crossover", {"short_period": 5})
+
+    # 이제 ma_crossover를 is_available=FALSE로 전환
+    db.execute("UPDATE strategies SET is_available = 0 WHERE name = 'ma_crossover'")
+    db.execute("UPDATE strategies SET is_active = 1 WHERE name = 'bb_rsi_combined'")
+    db.commit()
+
+    config = MagicMock()
+
+    def _cfg(key, default=None):
+        defaults = {
+            "stop_loss_pct": "-5.0",
+            "trailing_stop_pct": "-3.0",
+            "position_size_pct": "100.0",
+            "roi_table": "",
+            "fallback_strategy": "bb_rsi_combined",
+        }
+        return defaults.get(key, default if default is not None else "bb_rsi_combined")
+
+    config.get.side_effect = _cfg
+
+    sel = StrategySelector(db, config)
+    # ma_crossover는 비활성 → 레지스트리에 없어 None 반환 → fallback 체인 타야 함
+    strategy, name = sel.get_coin_strategy("KRW-BTC", "btc", collectors={})
+    # 크래시 없이 어떤 전략이든 돌려받기
+    assert strategy is not None
+    # 비활성 전략이 아닌 다른 전략 (current_strategy or fallback)이 반환됨
+    assert name != "ma_crossover"


### PR DESCRIPTION
배포 전 2차 리뷰 결과 중 실제 수정 가치 있는 항목만 수정.

## 수정 요약

### CRITICAL (1건)
- **HARD_LIMITS 클리핑** — coin_strategy_assignment에 저장 전 검증. LLM이 bb_std=5.0 등 범위 밖 값 보내도 안전한 값만 전략에 반영.

### HIGH (1건)
- **Prompt Caching fallback** — cache_control 에러 시 system 평문으로 자동 재시도. Anthropic 계정에서 캐싱이 비활성되어도 봇 죽지 않음.

### MED (1건)
- 회귀 방지 테스트 9건 (비활성 전략 fallback 포함)

## 실측 검증
- SYSTEM_PROMPT: 1,279 tokens (min 1,024 + 25% 여유)
- 필수 섹션 13종 모두 포함 확인
- ANALYSIS placeholder 11종 모두 포함 확인

## Test plan
- [x] pytest tests/test_review_round2_188.py 9/9
- [x] 전체 268/268
- [x] ruff 깨끗
- [x] SYSTEM/ANALYSIS 크기·내용 실측 검증

## 배포 준비 완료
이 PR 머지 후 서버 재시작하면:
- 자동 마이그레이션: cache tokens, coin_strategy_assignment, before/after, impact_score/scope
- Prompt Caching 활성 (실패 시 자동 fallback)
- 코인별 전략 배정 준비
- HARD_LIMITS 자동 클리핑

Related: #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)