### PR TITLE
fix: Emergency 과호출 방지 + 일일 상한 20회 (#190)

### DIFF
--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -308,11 +308,13 @@ class LLMAnalyzer:
     # Haiku 4.5 공식가 (platform.claude.com/docs/en/docs/about-claude/pricing)
     PRICE_INPUT_PER_M = 1.00  # $1.00 / 1M 입력 토큰
     PRICE_OUTPUT_PER_M = 5.00  # $5.00 / 1M 출력 토큰
-    MAX_DAILY_CALLS = 36  # 하드 리밋 (활발 시 24회 + 긴급 여유)
+    MAX_DAILY_CALLS = 20  # 하드 리밋 (#190)
     # 동적 주기 (시장 활동량에 따라)
     INTERVAL_ACTIVE_MIN = 60  # 활발: 1시간 (30분은 파라미터 진동만 유발)
     INTERVAL_NORMAL_MIN = 120  # 보통: 2시간
     INTERVAL_QUIET_MIN = 240  # 한산: 4시간
+    # #190: Emergency 과호출 방지 — force=True여도 이 시간 경과해야 실행
+    EMERGENCY_MIN_COOLDOWN_MIN = 20
 
     def _get_dynamic_interval_minutes(self) -> int:
         """시장 활동량에 따른 LLM 호출 간격(분) 결정.
@@ -362,22 +364,35 @@ class LLMAnalyzer:
             logger.warning("LLM 일일 호출 제한 도달: %d/%d", daily_count, self.MAX_DAILY_CALLS)
             return False
 
-        # 강제 실행 (시장 급변)
-        if force:
-            logger.info("LLM 즉시 분석 (시장 급변 감지)")
-            return True
-
-        # 동적 간격 체크
+        # 동적 간격 체크 (force도 최소 쿨다운 적용)
+        # #190: 기존에는 force=True면 즉시 실행 → check_emergency가 거의 매번 발동해
+        # 10분 간격 호출을 유발. 이제 force라도 EMERGENCY_MIN_COOLDOWN_MIN 이상
+        # 경과해야 실행되도록 해서 과호출 차단.
         row = self._db.execute("SELECT timestamp FROM llm_decisions ORDER BY id DESC LIMIT 1").fetchone()
         if row is None:
+            # 첫 호출은 무조건 허용
+            if force:
+                logger.info("LLM 즉시 분석 (첫 호출, 시장 급변 감지)")
             return True
 
         last = datetime.fromisoformat(dict(row)["timestamp"])
         if last.tzinfo is None:
             last = last.replace(tzinfo=timezone.utc)
         elapsed_min = (datetime.now(timezone.utc) - last).total_seconds() / 60
-        interval = self._get_dynamic_interval_minutes()
 
+        if force:
+            # #190: Emergency도 최소 쿨다운 — 10분 간격 스파이크 차단
+            if elapsed_min < self.EMERGENCY_MIN_COOLDOWN_MIN:
+                logger.info(
+                    "LLM Emergency 스킵: %.0f분 전 (최소 쿨다운 %d분)",
+                    elapsed_min,
+                    self.EMERGENCY_MIN_COOLDOWN_MIN,
+                )
+                return False
+            logger.info("LLM 즉시 분석 (시장 급변, %.0f분 경과)", elapsed_min)
+            return True
+
+        interval = self._get_dynamic_interval_minutes()
         if elapsed_min < interval:
             logger.info("LLM 스킵: %.0f분 전 (다음: %d분 간격)", elapsed_min, interval)
             return False

--- a/tests/test_emergency_cooldown_190.py
+++ b/tests/test_emergency_cooldown_190.py
@@ -1,0 +1,128 @@
+"""#190 — Emergency 과호출 방지 테스트.
+
+실측: 4/13 47회/일 — check_emergency가 10분마다 True 반환해 동적 간격 무력화.
+
+수정:
+- _should_run(force=True)도 EMERGENCY_MIN_COOLDOWN_MIN(20분) 쿨다운 적용
+- MAX_DAILY_CALLS 36 → 20 하향
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+from cryptobot.llm.analyzer import LLMAnalyzer
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _insert_decision(db, minutes_ago: int) -> None:
+    """N분 전 LLM 호출 기록 삽입."""
+    db.execute(
+        "INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now', ?), 'test')",
+        (f"-{minutes_ago} minutes",),
+    )
+    db.commit()
+
+
+# ===================================================================
+# 1. Emergency 쿨다운 (force=True도 너무 잦으면 스킵)
+# ===================================================================
+
+
+def test_force_skipped_within_cooldown(db):
+    """force=True라도 최근 호출 후 20분 미만이면 스킵."""
+    _insert_decision(db, minutes_ago=10)  # 10분 전 호출
+    a = LLMAnalyzer(db)
+    assert a._should_run(force=True) is False
+
+
+def test_force_allowed_after_cooldown(db):
+    """force=True + 20분 경과 → 실행."""
+    _insert_decision(db, minutes_ago=25)  # 25분 전 호출
+    a = LLMAnalyzer(db)
+    assert a._should_run(force=True) is True
+
+
+def test_force_allowed_when_no_prior_calls(db):
+    """첫 호출은 force=True 즉시 실행 (이전 기록 없음)."""
+    a = LLMAnalyzer(db)
+    assert a._should_run(force=True) is True
+
+
+def test_force_at_exact_cooldown_boundary(db):
+    """정확히 EMERGENCY_MIN_COOLDOWN_MIN(20분) 경과 시 실행."""
+    _insert_decision(db, minutes_ago=21)  # 약간의 margin
+    a = LLMAnalyzer(db)
+    assert a._should_run(force=True) is True
+
+
+# ===================================================================
+# 2. 일반 호출(force=False)은 기존 동적 간격 유지
+# ===================================================================
+
+
+def test_non_force_respects_interval(db):
+    """force=False이면 기존 동적 간격(QUIET=240분 등) 유지."""
+    _insert_decision(db, minutes_ago=30)  # 30분 전
+    a = LLMAnalyzer(db)
+    # 매매/포지션 0 → QUIET(240분) → 30분 미만이므로 스킵
+    assert a._should_run(force=False) is False
+
+
+def test_non_force_runs_after_interval(db):
+    """QUIET 간격(240분) 경과 후 일반 호출 실행."""
+    _insert_decision(db, minutes_ago=250)
+    a = LLMAnalyzer(db)
+    assert a._should_run(force=False) is True
+
+
+# ===================================================================
+# 3. MAX_DAILY_CALLS 하향 (36 → 20)
+# ===================================================================
+
+
+def test_max_daily_calls_is_20(db):
+    a = LLMAnalyzer(db)
+    assert a.MAX_DAILY_CALLS == 20
+
+
+def test_daily_limit_blocks_even_force(db):
+    """MAX_DAILY_CALLS 도달 시 force=True도 차단."""
+    a = LLMAnalyzer(db)
+    # 오늘 20건 삽입
+    for _ in range(20):
+        db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now', '-5 minutes'), 'test')")
+    db.commit()
+
+    # force=True여도 일일 한도 초과라 스킵
+    assert a._should_run(force=True) is False
+
+
+def test_under_daily_limit_allows_call(db):
+    """19건이면 force=True 한 번 더 허용."""
+    a = LLMAnalyzer(db)
+    for _ in range(19):
+        db.execute("INSERT INTO llm_decisions (timestamp, model) VALUES (datetime('now', '-30 minutes'), 'test')")
+    db.commit()
+
+    # 20분 쿨다운 통과 + 20회 미만 → True
+    assert a._should_run(force=True) is True
+
+
+# ===================================================================
+# 4. EMERGENCY_MIN_COOLDOWN_MIN 상수 존재 확인
+# ===================================================================
+
+
+def test_emergency_cooldown_constant():
+    assert LLMAnalyzer.EMERGENCY_MIN_COOLDOWN_MIN == 20


### PR DESCRIPTION
## 증상 (실측)
- 4/13: 47회/일
- 4/18 03시대: 10분 간격 4회 연속 호출
- 원인: \`check_emergency\`가 10분마다 True → force=True로 동적 간격 우회

## 수정
1. **근본 원인**: \`_should_run(force=True)\`도 \`EMERGENCY_MIN_COOLDOWN_MIN=20분\` 적용
2. **상한 하향**: MAX_DAILY_CALLS 36 → 20

## 예상 효과
월 비용: \$60~69 → **\$35~45** (추가 40% 절감)

## Test plan
- [x] 10건 신규 테스트 (쿨다운 / 일일 한도 / 회귀 방지)
- [x] 278/278 전체 통과
- [x] ruff 깨끗

Related: #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)