### PR TITLE
feat: 계좌 전체 일일 손실 가드 + 리스크 한도 강화

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -102,8 +102,12 @@ class CryptoBot:
             self._coin_mgr.refresh()
 
             self._risk.limits.max_daily_trades = int(self._config_mgr.get("max_daily_trades", "10"))
-            self._risk.limits.max_daily_loss_pct = float(self._config_mgr.get("max_daily_loss_pct", "-10.0"))
+            self._risk.limits.max_daily_loss_pct = float(self._config_mgr.get("max_daily_loss_pct", "-7.0"))
             self._risk.limits.max_consecutive_losses = int(self._config_mgr.get("max_consecutive_losses", "3"))
+            self._risk.limits.max_position_size_krw = float(self._config_mgr.get("max_position_size_krw", "300000"))
+            self._risk.limits.max_daily_account_loss_pct = float(
+                self._config_mgr.get("max_daily_account_loss_pct", "-10.0")
+            )
 
             new_interval = int(self._config_mgr.get("tick_interval_seconds", "60"))
             if new_interval != self._tick_interval:
@@ -233,7 +237,24 @@ class CryptoBot:
             return
 
         bal = self._trader.get_balance_krw()
-        max_pct = float(self._config_mgr.get("max_position_per_coin_pct", "50"))
+        # 계좌 전체 일일 손실 한도 체크 — 매수만 차단, 매도는 영향 없음
+        ok_acct, reason_acct = self._risk.check_account_daily_loss(bal)
+        if not ok_acct:
+            self._recorder.record_signal(
+                coin=coin,
+                signal_type="buy",
+                strategy=sn,
+                confidence=sig.confidence,
+                trigger_reason=sig.reason,
+                current_price=price,
+                trigger_value=sig.trigger_value,
+                skip_reason=reason_acct,
+                snapshot_id=snapshot_id,
+                strategy_params_json=pj,
+            )
+            return
+
+        max_pct = float(self._config_mgr.get("max_position_per_coin_pct", "25"))
         avail = min(bal * max_pct / 100, bal - self._risk.limits.min_balance_krw)
         if avail <= 0:
             return

--- a/src/cryptobot/bot/risk.py
+++ b/src/cryptobot/bot/risk.py
@@ -17,12 +17,15 @@ class RiskLimits:
     """리스크 한도 설정."""
 
     max_daily_trades: int = 10  # 일일 최대 거래 횟수
-    max_daily_loss_pct: float = -10.0  # 일일 최대 손실률 (%)
-    max_position_size_krw: float = 1_000_000  # 최대 1회 매수 금액 (원)
+    max_daily_loss_pct: float = -7.0  # 코인별 일일 최대 손실률 (%)
+    max_position_size_krw: float = 300_000  # 최대 1회 매수 금액 (원)
     min_balance_krw: float = 5_000  # 최소 유지 잔고 (업비트 최소 주문금액)
-    max_consecutive_losses: int = 5  # 연속 손실 시 매매 중단 (최근 1일 윈도우)
+    max_consecutive_losses: int = 3  # 연속 손실 시 매매 중단 (최근 1일 윈도우)
     consecutive_loss_window_hours: int = 24  # 연속 손실 판정 윈도우
     min_order_krw: float = 5_000  # 업비트 최소 주문 금액 (원)
+    # 계좌 전체 일일 실현 손실 한도 (매수 차단용, 매도는 허용).
+    # 코인별 한도(max_daily_loss_pct)와 별도로 "계좌 전체"를 보호.
+    max_daily_account_loss_pct: float = -10.0
 
 
 class RiskManager:
@@ -80,6 +83,55 @@ class RiskManager:
     def check_can_sell(self, coin: str) -> tuple[bool, str]:
         """매도 가능 여부 점검. (현재는 항상 허용 — 손절은 막으면 안 됨)"""
         return True, "매도 허용"
+
+    def check_account_daily_loss(self, current_krw: float) -> tuple[bool, str]:
+        """계좌 전체 오늘(KST) 실현 손실 %가 한도 이하면 매수 차단.
+
+        매도는 영향 없음 (check_can_sell은 항상 허용) — 손절·익절은 계속 작동해야 함.
+
+        계산 근사:
+          시작_자산 ≈ 현재_KRW + 보유_코인_원가_합 - 오늘_실현_PnL
+          손실% = 오늘_실현_PnL / 시작_자산 × 100
+
+        미실현 손익은 무시. "확정 손실" 기준.
+        """
+        today_pnl = self._get_today_account_pnl_krw()
+        if today_pnl >= 0:
+            return True, "오늘 흑자"
+
+        held_cost = self._get_held_coins_total_cost()
+        start_asset = current_krw + held_cost - today_pnl
+        if start_asset <= 0:
+            return True, "시작 자산 산정 불가"
+
+        loss_pct = today_pnl / start_asset * 100
+        limit = self.limits.max_daily_account_loss_pct
+        if loss_pct <= limit:
+            return False, (
+                f"계좌 일일 손실 한도 도달: {loss_pct:.1f}% ≤ {limit:.1f}% "
+                f"(실현 {today_pnl:,.0f}원 / 시작 {start_asset:,.0f}원). "
+                f"매도는 계속 허용, 매수만 차단."
+            )
+        return True, f"계좌 손실 {loss_pct:.1f}% (한도 {limit:.1f}%)"
+
+    def _get_today_account_pnl_krw(self) -> float:
+        """오늘(KST) 전체 실현 손익 합계."""
+        row = self._db.execute(
+            "SELECT COALESCE(SUM(profit_krw), 0) FROM trades "
+            "WHERE side='sell' AND DATE(timestamp, '+9 hours') = DATE('now', '+9 hours')"
+        ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def _get_held_coins_total_cost(self) -> float:
+        """현재 보유 중인 모든 코인의 매수 원가(+수수료) 합계."""
+        row = self._db.execute(
+            """
+            SELECT COALESCE(SUM(total_krw + COALESCE(fee_krw, 0)), 0)
+            FROM trades t WHERE side='buy'
+            AND NOT EXISTS (SELECT 1 FROM trades s WHERE s.buy_trade_id = t.id AND s.side='sell')
+            """
+        ).fetchone()
+        return float(row[0]) if row else 0.0
 
     def get_safe_position_size(
         self, balance_krw: float, confidence: float = 1.0, position_size_pct: float = 100.0

--- a/tests/test_account_daily_loss_guard.py
+++ b/tests/test_account_daily_loss_guard.py
@@ -1,0 +1,154 @@
+"""계좌 전체 일일 실현 손실 가드 테스트.
+
+- 매수는 차단하되 매도는 영향 없음 확인
+- 흑자/손익 근사치 계산 정확성
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.bot.risk import RiskLimits, RiskManager
+from cryptobot.data.database import Database
+from cryptobot.data.recorder import DataRecorder
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _record_sell_loss(db, coin: str, loss_krw: float) -> None:
+    """매수 + 손실 매도 기록 (오늘 KST 시각으로)."""
+    rec = DataRecorder(db)
+    buy_id = rec.record_trade(
+        coin=coin,
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=100_000,
+        fee_krw=50,
+        strategy="test",
+        trigger_reason="test",
+    )
+    rec.record_trade(
+        coin=coin,
+        side="sell",
+        price=95,
+        amount=1,
+        total_krw=95_000,
+        fee_krw=48,
+        strategy="test",
+        trigger_reason="손절",
+        buy_trade_id=buy_id,
+        profit_pct=-5.0,
+        profit_krw=loss_krw,
+    )
+
+
+# ===================================================================
+# 1. 계좌 일일 손실 한도 — 기본 동작
+# ===================================================================
+
+
+def test_account_loss_allows_when_no_losses(db):
+    """손실 없으면 매수 허용."""
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    ok, reason = rm.check_account_daily_loss(current_krw=1_000_000)
+    assert ok is True
+
+
+def test_account_loss_allows_when_within_limit(db):
+    """계좌 손실이 한도 안이면 허용."""
+    _record_sell_loss(db, "KRW-BTC", loss_krw=-50_000)  # -5%
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    # 현재 KRW = 950,000, 실현 -50,000 → 시작 자산 = 1,000,000 → 손실 -5%
+    ok, reason = rm.check_account_daily_loss(current_krw=950_000)
+    assert ok is True
+
+
+def test_account_loss_blocks_when_limit_reached(db):
+    """한도 초과 시 매수 차단."""
+    _record_sell_loss(db, "KRW-BTC", loss_krw=-120_000)  # -12%
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    # 시작 자산 = 880,000 + 0 + 120,000 = 1,000,000 → 손실 -12%
+    ok, reason = rm.check_account_daily_loss(current_krw=880_000)
+    assert ok is False
+    assert "계좌 일일 손실 한도" in reason
+
+
+def test_account_loss_uses_held_cost_in_start_asset(db):
+    """보유 포지션 원가도 시작 자산에 포함."""
+    rec = DataRecorder(db)
+    # 매도 없이 보유 중인 코인 (매수 원가 500,000)
+    rec.record_trade(
+        coin="KRW-ETH",
+        side="buy",
+        price=100,
+        amount=1,
+        total_krw=500_000,
+        fee_krw=250,
+        strategy="test",
+        trigger_reason="test",
+    )
+    # 오늘 다른 코인에서 -80,000 손실 (다른 buy + sell)
+    _record_sell_loss(db, "KRW-BTC", loss_krw=-80_000)
+
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    # 현재 KRW = 420,000, 보유 원가 = 500,000, 실현 -80,000
+    # 시작 자산 = 420,000 + 500,000 + 80,000 = 1,000,000 → 손실 -8% → 통과
+    ok, reason = rm.check_account_daily_loss(current_krw=420_000)
+    assert ok is True
+
+
+def test_account_loss_gate_does_not_affect_sell(db):
+    """check_can_sell은 항상 True — 계좌 손실 가드 무관."""
+    _record_sell_loss(db, "KRW-BTC", loss_krw=-200_000)  # -20%
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    # 매수는 차단
+    ok_buy, _ = rm.check_account_daily_loss(current_krw=800_000)
+    assert ok_buy is False
+    # 매도는 여전히 허용
+    ok_sell, _ = rm.check_can_sell("KRW-BTC")
+    assert ok_sell is True
+
+
+# ===================================================================
+# 2. 엣지 케이스
+# ===================================================================
+
+
+def test_account_loss_zero_start_asset_safe(db):
+    """시작 자산이 0이거나 음수면 (비정상) True 반환 (차단 안 함)."""
+    rm = RiskManager(db, RiskLimits())
+    ok, _ = rm.check_account_daily_loss(current_krw=0)
+    assert ok is True  # 0이면 계산 불가 → 통과
+
+
+def test_account_loss_multi_sells(db):
+    """같은 날 여러 매도 합계가 누적 계산됨."""
+    _record_sell_loss(db, "KRW-BTC", loss_krw=-60_000)
+    _record_sell_loss(db, "KRW-ETH", loss_krw=-50_000)
+    # 합계 -110,000 → 시작 자산 1,000,000 가정 → -11% → 차단
+    rm = RiskManager(db, RiskLimits(max_daily_account_loss_pct=-10.0))
+    ok, _ = rm.check_account_daily_loss(current_krw=890_000)
+    assert ok is False
+
+
+# ===================================================================
+# 3. 새 리스크 한도값
+# ===================================================================
+
+
+def test_new_risk_limits_defaults():
+    """#account-guard PR에서 기본값 조정."""
+    limits = RiskLimits()
+    assert limits.max_daily_loss_pct == -7.0  # 기존 -10 → -7
+    assert limits.max_consecutive_losses == 3  # 기존 5 → 3
+    assert limits.max_position_size_krw == 300_000  # 기존 1,000,000 → 300,000
+    assert limits.max_daily_account_loss_pct == -10.0  # 신규

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -63,6 +63,7 @@ def test_order_uuid_persisted_to_trades(db):
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.check_account_daily_loss.return_value = (True, "OK")
     bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
     bot._config_mgr = MagicMock()
     bot._config_mgr.get.return_value = "50"
@@ -130,6 +131,7 @@ def test_duplicate_buy_blocked_when_active_position_exists(db):
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.check_account_daily_loss.return_value = (True, "OK")
     bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
     bot._config_mgr = MagicMock()
     bot._config_mgr.get.return_value = "50"

--- a/tests/test_order_record_integrity.py
+++ b/tests/test_order_record_integrity.py
@@ -44,6 +44,7 @@ def test_check_and_buy_api_error_notifies_and_records_signal(db):
     # RiskManager/strategy selector mock
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.check_account_daily_loss.return_value = (True, "OK")
     bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
     bot._config_mgr = MagicMock()
     bot._config_mgr.get.return_value = "50"
@@ -158,6 +159,7 @@ def test_check_and_buy_commits_immediately_after_record(db):
     )
     bot._risk = MagicMock()
     bot._risk.check_can_buy.return_value = (True, "OK")
+    bot._risk.check_account_daily_loss.return_value = (True, "OK")
     bot._risk.limits = MagicMock(min_balance_krw=5000, max_position_size_krw=1_000_000)
     bot._config_mgr = MagicMock()
     bot._config_mgr.get.return_value = "50"


### PR DESCRIPTION
100만원 자본 스케일링 대비 안전장치.

## 설정 변경
| 항목 | 전 | 후 |
|---|---:|---:|
| max_daily_loss_pct | -10 | **-7** |
| max_consecutive_losses | 5 | **3** |
| max_position_per_coin_pct | 50 | **25** |
| max_position_size_krw | 1,000,000 | **300,000** |
| max_daily_account_loss_pct | 없음 | **-10 (신규)** |

## 신규 가드 (계좌 전체)
- 오늘(KST) 실현 손실 ≤ -10% → **매수 차단**
- **매도는 영향 없음** (손절/익절 계속 작동)
- 시작 자산 ≈ 현재_KRW + 보유_원가 - 오늘_실현_PnL

## Test plan
- [x] 8 신규 테스트
- [x] 전체 307/307
- [x] ruff 깨끗

🤖 Generated with [Claude Code](https://claude.com/claude-code)