### PR TITLE
fix: LLM max_tokens=1024로 JSON 응답 잘림 (#202)

### DIFF
--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -1461,6 +1461,10 @@ class LLMAnalyzer:
         "roi_120min",
     ]
     MAX_RETRIES = 2
+    # #200 opportunity-focused 프롬프트는 coin_strategies dict + reasoning으로
+    # 응답이 길어져 기존 1024로는 JSON이 잘림("Unterminated string" 파싱 실패).
+    # 2048로 상향 — 실제 출력만큼만 과금되므로 비용 영향 없음.
+    MAX_TOKENS = 2048
 
     def _call_claude(self, prompt: str) -> dict | None:
         """Claude API 호출 (최대 2회 재시도 + 응답 검증)."""
@@ -1484,7 +1488,7 @@ class LLMAnalyzer:
                     try:
                         response = client.messages.create(
                             model=self._model,
-                            max_tokens=1024,
+                            max_tokens=self.MAX_TOKENS,
                             system=[
                                 {
                                     "type": "text",
@@ -1505,7 +1509,7 @@ class LLMAnalyzer:
                             use_caching = False
                             response = client.messages.create(
                                 model=self._model,
-                                max_tokens=1024,
+                                max_tokens=self.MAX_TOKENS,
                                 system=SYSTEM_PROMPT,
                                 messages=[{"role": "user", "content": prompt}],
                             )
@@ -1515,7 +1519,7 @@ class LLMAnalyzer:
                     # 이전 시도에서 캐싱 실패했으면 남은 시도는 캐싱 없이
                     response = client.messages.create(
                         model=self._model,
-                        max_tokens=1024,
+                        max_tokens=self.MAX_TOKENS,
                         system=SYSTEM_PROMPT,
                         messages=[{"role": "user", "content": prompt}],
                     )

--- a/tests/test_prompt_caching_183.py
+++ b/tests/test_prompt_caching_183.py
@@ -241,6 +241,35 @@ def test_call_claude_passes_system_with_cache_control(db, monkeypatch):
     assert captured["messages"][0]["content"] == "user data prompt"
 
 
+def test_call_claude_uses_max_tokens_constant(db, monkeypatch):
+    """#200 프롬프트는 응답이 길어 1024로 잘림 — MAX_TOKENS(2048)를 전달해야."""
+    assert LLMAnalyzer.MAX_TOKENS >= 2048, (
+        "opportunity-focused 프롬프트 응답에 최소 2048 토큰 필요"
+    )
+
+    a = LLMAnalyzer(db)
+    a._api_key = "sk-test"
+
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, api_key):
+            pass
+
+        @property
+        def messages(self):
+            return self
+
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return _mock_response()
+
+    monkeypatch.setattr("anthropic.Anthropic", _FakeClient)
+    a._call_claude("user data prompt")
+
+    assert captured.get("max_tokens") == LLMAnalyzer.MAX_TOKENS
+
+
 def test_call_claude_aggregates_cache_tokens(db, monkeypatch):
     """응답의 cache_creation/cache_read 토큰이 result에 반영."""
     a = LLMAnalyzer(db)


### PR DESCRIPTION
## Summary
- `_call_claude`의 `max_tokens`를 1024 → 2048로 상향 (`MAX_TOKENS` 상수화, 3경로 통일)
- #200 opportunity-focused 프롬프트 이후 응답에 `coin_strategies` dict + reasoning이 추가돼 1024 토큰에서 JSON 잘림 → MAX_RETRIES 전부 실패
- 실제 출력만큼만 과금되므로 비용 영향 미미

## Test plan
- [x] `pytest tests/test_prompt_caching_183.py -v` — 신규 `test_call_claude_uses_max_tokens_constant` 포함 23건 통과
- [x] `pytest tests/ -x -q` — 308건 전부 통과
- [ ] 배포 후 Slack AI 분석 알림이 SUCCESS로 돌아오는지 확인

Related: #202
🤖 Generated with [Claude Code](https://claude.com/claude-code)