### PR TITLE
fix: 4h 헬스체크 스킵 — misfire_grace + caffeinate (#204)

### DIFF
--- a/scripts/start_daemon.sh
+++ b/scripts/start_daemon.sh
@@ -79,8 +79,15 @@ start_bg "api" ".venv/bin/uvicorn cryptobot.api.main:app --host 0.0.0.0 --port 8
 sleep 1
 
 # 2. 봇
+# caffeinate -i: Mac 유휴 절전 차단. 절전 진입 시 APScheduler 스레드가 멈춰
+# 4h 헬스체크·hourly 등 주기 job이 misfire로 스킵되는 문제를 예방한다.
+# 봇 프로세스 종료 시 caffeinate도 같이 종료됨.
 echo -e "${CYAN}[2/4] 트레이딩 봇${NC}"
-start_bg "bot" ".venv/bin/python -m cryptobot.bot.main"
+if command -v caffeinate &> /dev/null; then
+    start_bg "bot" "caffeinate -i .venv/bin/python -m cryptobot.bot.main"
+else
+    start_bg "bot" ".venv/bin/python -m cryptobot.bot.main"
+fi
 
 sleep 1
 

--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -67,13 +67,25 @@ class CryptoBot:
         self._notifier.notify_bot_status("시작됨")
         self._safety_check()
 
+        # Mac sleep/suspend 등으로 스케줄러가 수분간 멈추면 APScheduler 기본 misfire_grace=1초를
+        # 초과한 job은 스킵된다(2026-04-19 09:42 periodic_health 스킵 사례). 밀린 job이라도 깨어나면
+        # 1회 실행되도록 미스파이어 유예를 크게 + coalesce=True로 중복 누적 방지.
+        # tick은 실시간성이 중요하므로 기본값(짧게) 유지, 그 외 주기 job은 관대하게.
+        _LAX_MISFIRE = {"misfire_grace_time": 3600, "coalesce": True}
+
         self._scheduler.add_job(self._tick, "interval", seconds=self._tick_interval, id="main_tick")
-        self._scheduler.add_job(self._daily_report, "cron", hour=0, minute=0, id="daily_report")
-        self._scheduler.add_job(self._daily_health_check, "cron", hour=6, minute=0, id="daily_health")
+        self._scheduler.add_job(self._daily_report, "cron", hour=0, minute=0, id="daily_report", **_LAX_MISFIRE)
+        self._scheduler.add_job(self._daily_health_check, "cron", hour=6, minute=0, id="daily_health", **_LAX_MISFIRE)
         # #195: 4시간 주기 경량 헬스체크 — 외출 중에도 Slack으로 상태 확인
-        self._scheduler.add_job(self._periodic_health_check, "interval", hours=4, id="periodic_health")
-        self._scheduler.add_job(self._hourly_reconciliation, "interval", hours=1, id="hourly_reconciliation")
-        self._scheduler.add_job(self._weekly_report, "cron", day_of_week="sun", hour=3, minute=0, id="weekly_report")
+        self._scheduler.add_job(
+            self._periodic_health_check, "interval", hours=4, id="periodic_health", **_LAX_MISFIRE
+        )
+        self._scheduler.add_job(
+            self._hourly_reconciliation, "interval", hours=1, id="hourly_reconciliation", **_LAX_MISFIRE
+        )
+        self._scheduler.add_job(
+            self._weekly_report, "cron", day_of_week="sun", hour=3, minute=0, id="weekly_report", **_LAX_MISFIRE
+        )
         self._scheduler.add_job(
             self._weekly_backtest,
             "cron",
@@ -81,9 +93,12 @@ class CryptoBot:
             hour=2,
             minute=0,
             id="weekly_backtest",
+            **_LAX_MISFIRE,
         )
-        self._scheduler.add_job(self._monthly_audit, "cron", day=1, hour=4, minute=0, id="monthly_audit")
-        self._scheduler.add_job(self._llm_analyze, "interval", minutes=10, id="llm_analyze")
+        self._scheduler.add_job(
+            self._monthly_audit, "cron", day=1, hour=4, minute=0, id="monthly_audit", **_LAX_MISFIRE
+        )
+        self._scheduler.add_job(self._llm_analyze, "interval", minutes=10, id="llm_analyze", **_LAX_MISFIRE)
 
         signal.signal(signal.SIGINT, self._shutdown)
         signal.signal(signal.SIGTERM, self._shutdown)


### PR DESCRIPTION
## Summary
- 모든 주기 job(tick 제외)에 `misfire_grace_time=3600, coalesce=True` 설정 → Mac 절전에서 깨어나도 밀린 job 1회 실행
- `start_daemon.sh`에서 봇을 `caffeinate -i`로 실행 → 유휴 절전 자체 차단
- 예방(caffeinate) + 안전장치(grace) 이중화

## Test plan
- [x] `pytest tests/ -x -q` — 308건 통과
- [x] `bash -n scripts/start_daemon.sh` — 문법 OK
- [ ] 배포: stop/start 후 `ps -ef | grep caffeinate` 확인
- [ ] 재시작 직후 + 4h 후 두 번 Slack 헬스체크 도달 확인

Related: #204
🤖 Generated with [Claude Code](https://claude.com/claude-code)