### PR TITLE
feat: 추가 입금(KRW) 자동 추적 — capital_deposits (#206)

### DIFF
--- a/scripts/backfill_deposits.py
+++ b/scripts/backfill_deposits.py
@@ -1,0 +1,67 @@
+"""capital_deposits 백필 스크립트 (#206).
+
+업비트 입금 내역을 1회 가져와 capital_deposits 테이블에 등록한다.
+초기 자본(daily_reports의 첫 starting_balance)이 별도 등록되어 있지 않으면
+'initial' source로 같이 시드한다.
+
+사용법:
+    .venv/bin/python scripts/backfill_deposits.py
+"""
+
+import logging
+import sys
+
+from cryptobot.bot.config import config
+from cryptobot.bot.health_checker import HealthChecker
+from cryptobot.bot.trader import Trader
+from cryptobot.data.database import Database
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    db = Database(config.bot.db_path)
+    db.initialize()
+
+    trader = Trader()
+    if not trader.is_ready:
+        logger.error("업비트 API Key 미설정")
+        return 1
+
+    # 1. 초기 자본 시드 (capital_deposits가 비어 있을 때만)
+    existing = db.execute("SELECT COUNT(*) AS c FROM capital_deposits").fetchone()
+    if dict(existing)["c"] == 0:
+        # 봇 시작일 첫 daily_reports 기준으로 'initial' 등록
+        first = db.execute(
+            "SELECT date, starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
+        ).fetchone()
+        if first:
+            f = dict(first)
+            db.execute(
+                """
+                INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source, note)
+                VALUES ('KRW', ?, ?, 'initial', '봇 시작일 첫 잔고 기준')
+                """,
+                (f["starting_balance_krw"], f"{f['date']} 00:00:00"),
+            )
+            db.commit()
+            logger.info("초기 자본 시드: %s = %.0f원", f["date"], f["starting_balance_krw"])
+
+    # 2. 업비트 입금 내역 sync
+    checker = HealthChecker(db, trader, notifier=None)
+    result = checker.sync_deposits()
+    logger.info("sync 결과: %s", result)
+
+    # 3. 현재 총 입금액
+    total_row = db.execute(
+        "SELECT COALESCE(SUM(amount_krw), 0) AS total FROM capital_deposits WHERE currency='KRW'"
+    ).fetchone()
+    logger.info("총 등록 입금액: %.0f원", dict(total_row)["total"])
+
+    db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cryptobot/bot/health_checker.py
+++ b/src/cryptobot/bot/health_checker.py
@@ -312,6 +312,86 @@ class HealthChecker:
             logger.error("전략 일관성 체크 실패: %s", e)
             return {"status": "warning", "message": str(e)}
 
+    def sync_deposits(self, since: str | None = None) -> dict:
+        """업비트 입금 내역을 조회해 capital_deposits 테이블에 신규 건만 등록.
+
+        upbit_uuid UNIQUE 제약으로 중복 삽입 방지. 신규 건이 있으면 Slack 알림.
+
+        Args:
+            since: ISO datetime 문자열 (예: '2026-04-04'). 이 시각 이전 입금은 무시.
+                None이면 첫 daily_reports.date(=봇 시작일)를 자동 사용.
+                업비트 API가 수년 전 입금까지 반환하는데 그건 운영 자본과 무관하므로 cutoff 필수.
+
+        Returns:
+            {"status", "fetched", "new", "total_added_krw"}
+        """
+        try:
+            if not self._trader or not self._trader.is_ready:
+                return {"status": "ok", "message": "API 미설정 — 스킵"}
+
+            # cutoff 결정
+            if since is None:
+                first = self._db.execute(
+                    "SELECT date FROM daily_reports ORDER BY date ASC LIMIT 1"
+                ).fetchone()
+                since = dict(first)["date"] if first else "2000-01-01"
+            since_str = str(since)[:10]  # 'YYYY-MM-DD'
+
+            history = self._trader.get_deposit_history(currency="KRW", limit=100)
+            fetched = len(history)
+            if fetched == 0:
+                return {"status": "ok", "fetched": 0, "new": 0}
+
+            new_count = 0
+            new_total = 0.0
+            new_items: list[dict] = []
+            skipped_old = 0
+            for h in history:
+                if not h.get("uuid"):
+                    continue
+                # cutoff 비교 (deposited_at는 ISO 문자열, 앞 10자리가 날짜)
+                dep_date = str(h.get("deposited_at") or "")[:10]
+                if dep_date < since_str:
+                    skipped_old += 1
+                    continue
+                # 이미 있는지
+                exist = self._db.execute(
+                    "SELECT 1 FROM capital_deposits WHERE upbit_uuid = ?", (h["uuid"],)
+                ).fetchone()
+                if exist:
+                    continue
+                self._db.execute(
+                    """
+                    INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source, upbit_uuid)
+                    VALUES ('KRW', ?, ?, 'api', ?)
+                    """,
+                    (h["amount_krw"], h["deposited_at"], h["uuid"]),
+                )
+                new_count += 1
+                new_total += h["amount_krw"]
+                new_items.append(h)
+
+            self._db.commit()
+
+            if new_count > 0 and self._notifier:
+                lines = [f"💰 *신규 입금 감지* — `{new_count}건` (총 `{new_total:,.0f}원`)"]
+                for it in new_items[:5]:
+                    lines.append(f">  · {it['deposited_at']}  ·  `{it['amount_krw']:,.0f}원`")
+                self._notifier.send("\n".join(lines))
+                logger.info("신규 입금 %d건 등록: %.0f원", new_count, new_total)
+
+            return {
+                "status": "ok",
+                "fetched": fetched,
+                "new": new_count,
+                "total_added_krw": new_total,
+                "skipped_old": skipped_old,
+                "since": since_str,
+            }
+        except Exception as e:
+            logger.error("입금 sync 실패: %s", e, exc_info=True)
+            return {"status": "warning", "message": str(e)}
+
     def reconcile_trades(self) -> dict:
         """미검증 거래의 체결 정합성을 검증하고 보정한다.
 
@@ -558,13 +638,19 @@ class HealthChecker:
                 if cp:
                     db_coin_value += ad["amount"] * cp
 
-            # 최초 입금액이 없으므로 daily_reports의 starting_balance 참고
-            first_report = self._db.execute(
-                "SELECT starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
+            # 총 입금액: capital_deposits 테이블에 등록된 모든 입금 합산.
+            # 비어 있으면(레거시) 첫 daily_reports.starting_balance를 fallback.
+            dep_row = self._db.execute(
+                "SELECT COALESCE(SUM(amount_krw), 0) AS total FROM capital_deposits WHERE currency = 'KRW'"
             ).fetchone()
-            initial_balance = dict(first_report)["starting_balance_krw"] if first_report else 0
+            total_deposits = dict(dep_row)["total"] if dep_row else 0
+            if total_deposits <= 0:
+                first_report = self._db.execute(
+                    "SELECT starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
+                ).fetchone()
+                total_deposits = dict(first_report)["starting_balance_krw"] if first_report else 0
 
-            return initial_balance + net_flow + db_coin_value
+            return total_deposits + net_flow + db_coin_value
         except Exception as e:
             logger.error("DB 총자산 역산 실패: %s", e)
             return 0

--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -83,6 +83,10 @@ class CryptoBot:
         self._scheduler.add_job(
             self._hourly_reconciliation, "interval", hours=1, id="hourly_reconciliation", **_LAX_MISFIRE
         )
+        # #206: 일일 입금 sync (06:30) — 일일 헬스체크(06:00) 직후 실행
+        self._scheduler.add_job(
+            self._daily_deposit_sync, "cron", hour=6, minute=30, id="daily_deposit_sync", **_LAX_MISFIRE
+        )
         self._scheduler.add_job(
             self._weekly_report, "cron", day_of_week="sun", hour=3, minute=0, id="weekly_report", **_LAX_MISFIRE
         )
@@ -640,6 +644,14 @@ class CryptoBot:
             checker.run_periodic()
         except Exception as e:
             logger.error("주기 헬스체크 에러: %s", e, exc_info=True)
+
+    def _daily_deposit_sync(self):
+        """#206: 매일 1회 업비트 입금 내역 sync — 신규 입금 자동 등록 + Slack 알림."""
+        try:
+            checker = HealthChecker(self._db, self._trader, self._notifier)
+            checker.sync_deposits()
+        except Exception as e:
+            logger.error("입금 sync 에러: %s", e, exc_info=True)
 
     def _hourly_reconciliation(self):
         """매시간 체결 정합성 검증."""

--- a/src/cryptobot/bot/trader.py
+++ b/src/cryptobot/bot/trader.py
@@ -295,6 +295,66 @@ class Trader:
         self._ensure_ready()
         return self._fetch_order_detail(order_uuid)
 
+    def get_deposit_history(self, currency: str = "KRW", limit: int = 100) -> list[dict]:
+        """업비트 입금 내역을 조회한다 (state=ACCEPTED만).
+
+        pyupbit가 입금 API를 노출하지 않아 직접 JWT 서명 후 호출.
+
+        Args:
+            currency: 'KRW' 등
+            limit: 최대 조회 건수 (업비트는 100이 한도)
+
+        Returns:
+            [{"uuid", "amount_krw", "deposited_at"}, ...] (최신순)
+        """
+        self._ensure_ready()
+        import hashlib
+        import uuid as _uuid
+        from urllib.parse import urlencode
+
+        import jwt
+        import requests
+
+        query = {"currency": currency, "state": "ACCEPTED", "limit": str(limit)}
+        qhash = hashlib.sha512(urlencode(query).encode()).hexdigest()
+        payload = {
+            "access_key": config.upbit.access_key,
+            "nonce": str(_uuid.uuid4()),
+            "query_hash": qhash,
+            "query_hash_alg": "SHA512",
+        }
+        token = jwt.encode(payload, config.upbit.secret_key)
+        try:
+            resp = requests.get(
+                "https://api.upbit.com/v1/deposits",
+                params=query,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning("입금 내역 조회 실패: %s", e)
+            raise APIError(f"입금 내역 조회 실패: {e}") from e
+
+        if not isinstance(data, list):
+            return []
+
+        results = []
+        for d in data:
+            try:
+                results.append(
+                    {
+                        "uuid": d.get("uuid"),
+                        "amount_krw": float(d.get("amount", 0)),
+                        # done_at(완료시각) 우선, 없으면 created_at
+                        "deposited_at": d.get("done_at") or d.get("created_at"),
+                    }
+                )
+            except (TypeError, ValueError):
+                continue
+        return results
+
     def _ensure_ready(self) -> None:
         """API Key 설정 확인."""
         if not self.is_ready:

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -303,6 +303,19 @@ CREATE TABLE IF NOT EXISTS backtest_results (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_bt_run_date ON backtest_results(run_date, strategy_name, coin);
+
+-- #206: 추가 입금 추적. 잔고 검증이 첫 starting_balance만 "총 입금액"으로 보던 한계 해결.
+CREATE TABLE IF NOT EXISTS capital_deposits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    currency TEXT NOT NULL DEFAULT 'KRW',
+    amount_krw REAL NOT NULL,
+    deposited_at DATETIME NOT NULL,
+    source TEXT NOT NULL DEFAULT 'api',           -- 'api' | 'manual' | 'initial'
+    upbit_uuid TEXT UNIQUE,                       -- 업비트 입금 uuid (중복 방지)
+    note TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_capital_deposits_at ON capital_deposits(deposited_at DESC);
 """
 
 # 기본 전략 파라미터 (최초 1회 삽입)

--- a/tests/test_capital_deposits_206.py
+++ b/tests/test_capital_deposits_206.py
@@ -1,0 +1,235 @@
+"""#206: capital_deposits 테이블 + sync_deposits 테스트.
+
+- 신규 입금 등록
+- upbit_uuid 중복 방지
+- _calculate_db_total_asset이 capital_deposits 합산을 사용
+- 빈 테이블 fallback (legacy daily_reports.starting_balance)
+"""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cryptobot.bot.health_checker import HealthChecker
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+class _FakeTrader:
+    def __init__(self, deposits):
+        self._deposits = deposits
+        self.is_ready = True
+
+    def get_deposit_history(self, currency="KRW", limit=100):
+        return list(self._deposits)
+
+
+class _FakeNotifier:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg):
+        self.sent.append(msg)
+
+
+# ===================================================================
+# 스키마
+# ===================================================================
+
+
+def test_capital_deposits_table_exists(db):
+    """initialize 후 테이블 생성 확인."""
+    rows = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='capital_deposits'"
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_capital_deposits_columns(db):
+    """필수 컬럼 존재 확인."""
+    cols = {dict(r)["name"] for r in db.execute("PRAGMA table_info(capital_deposits)").fetchall()}
+    assert {"id", "currency", "amount_krw", "deposited_at", "source", "upbit_uuid", "note"} <= cols
+
+
+def test_upbit_uuid_unique_constraint(db):
+    """upbit_uuid UNIQUE — 같은 uuid 두 번 못 들어감."""
+    db.execute(
+        "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, upbit_uuid) "
+        "VALUES ('KRW', 100000, '2026-04-19 22:06:00', 'uuid-1')"
+    )
+    db.commit()
+    with pytest.raises(Exception):
+        db.execute(
+            "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, upbit_uuid) "
+            "VALUES ('KRW', 100000, '2026-04-19 22:06:00', 'uuid-1')"
+        )
+        db.commit()
+
+
+# ===================================================================
+# sync_deposits
+# ===================================================================
+
+
+def test_sync_inserts_new_deposits(db):
+    """신규 입금 모두 등록."""
+    trader = _FakeTrader(
+        [
+            {"uuid": "u1", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+            {"uuid": "u2", "amount_krw": 100000.0, "deposited_at": "2026-04-03T22:51:55+09:00"},
+        ]
+    )
+    notifier = _FakeNotifier()
+    checker = HealthChecker(db, trader, notifier)
+    result = checker.sync_deposits()
+    assert result["status"] == "ok"
+    assert result["fetched"] == 2
+    assert result["new"] == 2
+    assert result["total_added_krw"] == 500000.0
+    # Slack 호출됨
+    assert len(notifier.sent) == 1
+    assert "신규 입금" in notifier.sent[0]
+
+
+def test_sync_skips_existing_deposits(db):
+    """이미 등록된 uuid는 다시 안 넣음."""
+    trader = _FakeTrader(
+        [{"uuid": "u1", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"}]
+    )
+    notifier = _FakeNotifier()
+    checker = HealthChecker(db, trader, notifier)
+    # 1차
+    r1 = checker.sync_deposits()
+    assert r1["new"] == 1
+    # 2차 — 같은 입금
+    r2 = checker.sync_deposits()
+    assert r2["new"] == 0
+    assert r2["fetched"] == 1
+    # 두 번째에는 Slack 안 보냄 (new==0)
+    assert len(notifier.sent) == 1
+
+
+def test_sync_partial_new(db):
+    """일부 기존 + 일부 신규 — 신규만 등록."""
+    trader = _FakeTrader(
+        [
+            {"uuid": "u1", "amount_krw": 100000.0, "deposited_at": "2026-04-01T00:00:00+09:00"},
+            {"uuid": "u2", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+        ]
+    )
+    notifier = _FakeNotifier()
+    checker = HealthChecker(db, trader, notifier)
+    checker.sync_deposits()  # u1, u2 등록
+
+    # 새 입금 추가
+    trader._deposits.insert(0, {"uuid": "u3", "amount_krw": 50000.0, "deposited_at": "2026-04-20T10:00:00+09:00"})
+    r = checker.sync_deposits()
+    assert r["new"] == 1
+    assert r["total_added_krw"] == 50000.0
+
+
+def test_sync_no_trader_returns_skip(db):
+    """API 미설정이면 스킵."""
+    checker = HealthChecker(db, trader=None, notifier=None)
+    result = checker.sync_deposits()
+    assert result["status"] == "ok"
+    assert "스킵" in result["message"]
+
+
+def test_sync_skips_old_deposits_via_cutoff(db):
+    """첫 daily_report.date 이전 입금은 자동 제외 (운영 자본과 무관한 옛날 입금 보호)."""
+    db.execute(
+        "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
+        "VALUES ('2026-04-04', 95000, 95000)"
+    )
+    db.commit()
+
+    trader = _FakeTrader(
+        [
+            {"uuid": "old", "amount_krw": 2000000.0, "deposited_at": "2021-12-15T07:11:13+09:00"},
+            {"uuid": "new", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+        ]
+    )
+    checker = HealthChecker(db, trader, notifier=None)
+    r = checker.sync_deposits()
+    assert r["new"] == 1
+    assert r["total_added_krw"] == 400000.0
+    assert r["skipped_old"] == 1
+    assert r["since"] == "2026-04-04"
+
+
+def test_sync_explicit_since_overrides_default(db):
+    """since 인자가 명시되면 daily_reports 무시하고 그대로 사용."""
+    trader = _FakeTrader(
+        [
+            {"uuid": "u1", "amount_krw": 100000.0, "deposited_at": "2026-04-10T00:00:00+09:00"},
+            {"uuid": "u2", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+        ]
+    )
+    checker = HealthChecker(db, trader, notifier=None)
+    r = checker.sync_deposits(since="2026-04-15")
+    assert r["new"] == 1
+    assert r["total_added_krw"] == 400000.0
+
+
+def test_sync_handles_uuid_none(db):
+    """uuid 없는 항목은 스킵."""
+    trader = _FakeTrader(
+        [
+            {"uuid": None, "amount_krw": 100000.0, "deposited_at": "2026-04-01T00:00:00+09:00"},
+            {"uuid": "u1", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+        ]
+    )
+    checker = HealthChecker(db, trader, notifier=None)
+    r = checker.sync_deposits()
+    assert r["new"] == 1
+
+
+# ===================================================================
+# _calculate_db_total_asset가 capital_deposits 사용
+# ===================================================================
+
+
+def test_total_asset_uses_capital_deposits(db):
+    """capital_deposits 합산이 total_deposits로 사용됨."""
+    db.execute(
+        "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source) "
+        "VALUES ('KRW', 100000, '2026-04-04 00:00:00', 'initial')"
+    )
+    db.execute(
+        "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source) "
+        "VALUES ('KRW', 400000, '2026-04-19 22:06:00', 'api')"
+    )
+    db.commit()
+
+    checker = HealthChecker(db, trader=None, notifier=None)
+    total = checker._calculate_db_total_asset()
+    # net_flow=0, db_coin_value=0 (거래 없음)
+    assert total == 500000
+
+
+def test_total_asset_fallback_to_daily_reports(db):
+    """capital_deposits 비었으면 첫 daily_reports.starting_balance 사용."""
+    db.execute(
+        "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
+        "VALUES ('2026-04-04', 95000, 95000)"
+    )
+    db.execute(
+        "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
+        "VALUES ('2026-04-05', 96000, 96000)"
+    )
+    db.commit()
+
+    checker = HealthChecker(db, trader=None, notifier=None)
+    total = checker._calculate_db_total_asset()
+    assert total == 95000  # 첫 날 기준


### PR DESCRIPTION
## Summary
- 봇 시작 후 추가로 입금된 KRW를 별도 테이블(`capital_deposits`)로 추적
- 잔고 검증(`_calculate_db_total_asset`)이 첫 `starting_balance`만 입금액으로 보던 가정 수정 → 추가 입금 시 자동 반영
- 매일 06:30 업비트 입금 내역 자동 sync, 신규 입금 시 Slack 알림
- since cutoff(기본=첫 daily_report.date) 이전 옛날 입금 자동 제외 (업비트는 수년치 과거 반환)
- 운영 DB 백필 완료: 4/19 입금 400,000원 등록 → 잔고 차이 0.46%로 정합성 회복

## 변경 파일
- `src/cryptobot/data/database.py` — `capital_deposits` 스키마
- `src/cryptobot/bot/trader.py` — `get_deposit_history()` 추가
- `src/cryptobot/bot/health_checker.py` — `sync_deposits()`, `_calculate_db_total_asset` 수정
- `src/cryptobot/bot/main.py` — `_daily_deposit_sync` 스케줄러
- `scripts/backfill_deposits.py` — 1회 백필
- `tests/test_capital_deposits_206.py` — 단위 테스트 12개

## Test plan
- [x] `pytest tests/test_capital_deposits_206.py -v` — 12건 통과 (cutoff, 중복 방지, fallback 포함)
- [x] `pytest tests/ -x -q` — 320건 전부 통과
- [x] 운영 DB 백필 → `_check_balance_consistency` status=ok

Related: #206
🤖 Generated with [Claude Code](https://claude.com/claude-code)