### PR TITLE
fix: 손절 vs 매수 신호 충돌 통합 의사결정 (#210)

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -130,6 +130,12 @@ class CryptoBot:
             self._risk.limits.coin_reentry_cooldown_minutes = int(
                 self._config_mgr.get("coin_reentry_cooldown_minutes", "10")
             )
+            self._risk.limits.signal_conflict_buy_confidence_threshold = float(
+                self._config_mgr.get("signal_conflict_buy_confidence_threshold", "0.7")
+            )
+            self._risk.limits.hard_stop_loss_floor_pct = float(
+                self._config_mgr.get("hard_stop_loss_floor_pct", "-10.0")
+            )
 
             new_interval = int(self._config_mgr.get("tick_interval_seconds", "60"))
             if new_interval != self._tick_interval:
@@ -431,6 +437,42 @@ class CryptoBot:
 
         pnl_pct = (price - buy_price) / buy_price * 100
         net_pnl = pnl_pct - BaseStrategy.ROUND_TRIP_FEE_PCT
+
+        # #210: 손절 vs 매수 신호 충돌 통합 의사결정 ("더 높은 신호 채택").
+        # ALGO처럼 손절 직후 1분 뒤 RSI 매수 신호로 재매수하는 패턴은 같은 가격 사건에 대한
+        # 모순적 결정. 손절 시점에 매수 신호 강도가 임계 이상이면 손절 보류 ("들고 간다").
+        # 단 pnl <= hard_floor면 안전장치로 무조건 손절.
+        if not sig.is_profit_taking and "손절" in sig.reason:
+            hard_floor = self._risk.limits.hard_stop_loss_floor_pct
+            if pnl_pct > hard_floor:
+                buy_sig = s.check_buy(df, price)
+                conf_threshold = self._risk.limits.signal_conflict_buy_confidence_threshold
+                if buy_sig.signal_type == "buy" and buy_sig.confidence >= conf_threshold:
+                    skip_msg = (
+                        f"손절-매수 충돌: 손절 -{abs(pnl_pct):.2f}% vs "
+                        f"매수 confidence {buy_sig.confidence:.2f} ≥ {conf_threshold:.2f} → 보유 유지"
+                    )
+                    logger.info("[%s] %s", coin, skip_msg)
+                    self._recorder.record_signal(
+                        coin=coin,
+                        signal_type="hold",
+                        strategy=sn,
+                        confidence=buy_sig.confidence,
+                        trigger_reason=f"신호 충돌: {sig.reason} vs {buy_sig.reason}",
+                        current_price=price,
+                        trigger_value=pnl_pct,
+                        skip_reason=skip_msg,
+                        snapshot_id=snapshot_id,
+                        strategy_params_json=pj,
+                    )
+                    if self._notifier and self._notifier.is_configured:
+                        self._notifier.send(
+                            f"⚖️ *손절-매수 충돌 보류* — {coin}\n"
+                            f">  손절 {pnl_pct:+.2f}% vs 매수 conf {buy_sig.confidence:.2f}\n"
+                            f">  사유: {buy_sig.reason}"
+                        )
+                    return
+
         # 수수료 가드: Signal에 명시된 is_profit_taking 플래그 기반 (이전엔 reason 문자열 매칭 취약).
         # 익절 신호(ROI/트레일링/중간선 등)만 수수료로 인한 실질 음수 시 차단.
         # 손절/전략 판단(RSI 정상복귀, 데드크로스 등)은 통과.

--- a/src/cryptobot/bot/risk.py
+++ b/src/cryptobot/bot/risk.py
@@ -25,6 +25,11 @@ class RiskLimits:
     # #208: 매도 직후 같은 코인 재매수 차단. 손절(-5%)과 RSI 과매도 매수 신호가
     # 같은 가격 사건에 대해 모순적으로 발생하는 패턴(수수료 왕복 0.1% 손실)을 막는다.
     coin_reentry_cooldown_minutes: int = 10
+    # #210: 손절 vs 매수 신호 충돌 통합 의사결정.
+    # 손절 트리거 시점에 같은 코인 매수 신호 confidence가 이 값 이상이면 손절 보류 ("들고 간다").
+    # 단 pnl <= hard_stop_loss_floor_pct는 매수 신호 무관 무조건 손절 (안전장치).
+    signal_conflict_buy_confidence_threshold: float = 0.7
+    hard_stop_loss_floor_pct: float = -10.0
     min_order_krw: float = 5_000  # 업비트 최소 주문 금액 (원)
     # 계좌 전체 일일 실현 손실 한도 (매수 차단용, 매도는 허용).
     # 코인별 한도(max_daily_loss_pct)와 별도로 "계좌 전체"를 보호.

--- a/tests/test_llm_logic_accuracy.py
+++ b/tests/test_llm_logic_accuracy.py
@@ -259,11 +259,19 @@ def test_fee_guard_allows_stop_loss_even_when_negative(db):
         "손절",
         is_profit_taking=False,
     )
+    # #210 충돌 가드: 매수 신호 없음 → 손절 진행 (이 테스트의 기대 동작 유지)
+    strat.check_buy.return_value = Signal("hold", 0.0, "매수 신호 없음")
     strat.params = MagicMock()
     strat.params.extra = {}
     strat.params.stop_loss_pct = -5
     strat.params.trailing_stop_pct = -2
     strat._hold_minutes = 10
+    # #210: _risk mock — 충돌 가드가 limits 참조
+    bot._risk = MagicMock()
+    bot._risk.limits = MagicMock(
+        signal_conflict_buy_confidence_threshold=0.7,
+        hard_stop_loss_floor_pct=-10.0,
+    )
     bot._strategy_sel = MagicMock()
     bot._strategy_sel.current_strategy = strat
     bot._strategy_sel.current_strategy_name = "test_strategy"

--- a/tests/test_signal_conflict_210.py
+++ b/tests/test_signal_conflict_210.py
@@ -1,0 +1,243 @@
+"""#210: 손절 vs 매수 신호 충돌 통합 의사결정 테스트.
+
+ALGO 사례: 20:39 손절 -5.65% → 1분 뒤 RSI 매수 신호로 재매수.
+같은 가격 사건에 대한 모순적 결정. 사용자 표현: "더 높은 애 거로 들어야지".
+
+가드:
+- 손절 시 매수 신호 confidence ≥ 임계 (기본 0.7) → 손절 보류 (들고 간다)
+- pnl ≤ hard_stop_loss_floor_pct (-10%) → 매수 신호 무관 무조건 손절 (안전장치)
+- ROI/트레일링(is_profit_taking=True) → 충돌 가드 미적용 (기존 로직)
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cryptobot.bot.risk import RiskLimits
+from cryptobot.data.database import Database
+from cryptobot.data.recorder import DataRecorder
+from cryptobot.strategies.base import Signal
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _make_bot(db, sell_sig: Signal, buy_sig: Signal, conf_threshold: float = 0.7, hard_floor: float = -10.0):
+    """Bot mock with risk limits and strategy mock."""
+    from cryptobot.bot.main import CryptoBot
+
+    bot = CryptoBot.__new__(CryptoBot)
+    bot._db = db
+    bot._recorder = DataRecorder(db)
+    bot._notifier = MagicMock()
+    bot._notifier.is_configured = True
+    bot._trader = MagicMock()
+    bot._trader.is_ready = True
+    bot._config_mgr = MagicMock()
+    bot._config_mgr.get_strategy_params_json.return_value = None
+
+    bot._risk = MagicMock()
+    bot._risk.limits = MagicMock(
+        signal_conflict_buy_confidence_threshold=conf_threshold,
+        hard_stop_loss_floor_pct=hard_floor,
+    )
+
+    strat = MagicMock()
+    strat.check_sell.return_value = sell_sig
+    strat.check_buy.return_value = buy_sig
+    strat.params = MagicMock(stop_loss_pct=-5, trailing_stop_pct=-2, extra={})
+    strat._hold_minutes = 10
+    bot._strategy_sel = MagicMock()
+    bot._strategy_sel.current_strategy = strat
+    bot._strategy_sel.current_strategy_name = "test"
+    coll = MagicMock()
+    coll.latest_df = pd.DataFrame({"close": [100] * 30})
+    bot._coin_mgr = MagicMock(collectors={"KRW-BTC": coll})
+
+    return bot, strat
+
+
+def _seed_buy(db, price: float = 100.0):
+    """선행 매수 레코드. orphan 가드 회피."""
+    rec = DataRecorder(db)
+    return rec.record_trade(
+        coin="KRW-BTC", side="buy", price=price, amount=1, total_krw=int(price * 100),
+        fee_krw=5, strategy="test", trigger_reason="seed",
+    )
+
+
+# ===================================================================
+# 기본값
+# ===================================================================
+
+
+def test_risk_limits_default_threshold_and_floor():
+    limits = RiskLimits()
+    assert limits.signal_conflict_buy_confidence_threshold == 0.7
+    assert limits.hard_stop_loss_floor_pct == -10.0
+
+
+# ===================================================================
+# 핵심: 충돌 보류 vs 손절 진행
+# ===================================================================
+
+
+def test_strong_buy_signal_holds_stop_loss(db):
+    """손절 신호 + 강한 매수 신호(0.8) → 손절 보류."""
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("buy", 0.8, "RSI 13 극과매도")
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig)
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    # 가격 95 → -5% 손절 트리거
+    bot._check_and_sell(active_trade, price=95.0, snapshot_id=None, coin="KRW-BTC")
+
+    # 매도 안 일어남 (보류)
+    bot._trader.sell_market.assert_not_called()
+    # Slack 알림 발송
+    assert bot._notifier.send.called
+    msg = bot._notifier.send.call_args[0][0]
+    assert "손절-매수 충돌" in msg
+    # trade_signals에 hold + skip_reason 기록
+    row = db.execute("SELECT signal_type, skip_reason FROM trade_signals ORDER BY id DESC LIMIT 1").fetchone()
+    d = dict(row)
+    assert d["signal_type"] == "hold"
+    assert "보유 유지" in d["skip_reason"]
+
+
+def test_weak_buy_signal_executes_stop_loss(db):
+    """손절 신호 + 약한 매수(0.5 < 임계 0.7) → 손절 진행."""
+    from cryptobot.bot.trader import OrderResult
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("buy", 0.5, "약한 매수")
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig)
+    bot._trader.sell_market.return_value = OrderResult(
+        success=True, side="sell", coin="KRW-BTC",
+        price=95, amount=1, total_krw=9500, fee_krw=5, order_uuid="u1",
+    )
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    bot._check_and_sell(active_trade, price=95.0, snapshot_id=None, coin="KRW-BTC")
+
+    # 매도 진행
+    bot._trader.sell_market.assert_called_once_with("KRW-BTC")
+
+
+def test_no_buy_signal_executes_stop_loss(db):
+    """손절 + check_buy가 hold 반환 → 손절 진행."""
+    from cryptobot.bot.trader import OrderResult
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("hold", 0.0, "매수 신호 없음")
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig)
+    bot._trader.sell_market.return_value = OrderResult(
+        success=True, side="sell", coin="KRW-BTC",
+        price=95, amount=1, total_krw=9500, fee_krw=5, order_uuid="u1",
+    )
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    bot._check_and_sell(active_trade, price=95.0, snapshot_id=None, coin="KRW-BTC")
+
+    bot._trader.sell_market.assert_called_once_with("KRW-BTC")
+
+
+# ===================================================================
+# 안전장치: 하드 플로어
+# ===================================================================
+
+
+def test_hard_floor_overrides_buy_signal(db):
+    """pnl ≤ -10% (하드 플로어) → 강한 매수 신호 무시, 무조건 손절."""
+    from cryptobot.bot.trader import OrderResult
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("buy", 0.95, "초강한 매수")  # 임계 훨씬 위
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig, hard_floor=-10.0)
+    bot._trader.sell_market.return_value = OrderResult(
+        success=True, side="sell", coin="KRW-BTC",
+        price=88, amount=1, total_krw=8800, fee_krw=5, order_uuid="u1",
+    )
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    # 가격 88 → -12% (하드 플로어 -10% 초과)
+    bot._check_and_sell(active_trade, price=88.0, snapshot_id=None, coin="KRW-BTC")
+
+    # 매수 신호 강해도 무조건 손절
+    bot._trader.sell_market.assert_called_once_with("KRW-BTC")
+
+
+def test_just_above_hard_floor_with_strong_buy_holds(db):
+    """pnl=-9.5% (하드 플로어 -10% 안쪽) + 강한 매수 → 보류 가능."""
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("buy", 0.85, "강한 매수")
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig, hard_floor=-10.0)
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    bot._check_and_sell(active_trade, price=90.5, snapshot_id=None, coin="KRW-BTC")  # -9.5%
+
+    bot._trader.sell_market.assert_not_called()
+
+
+# ===================================================================
+# ROI/트레일링은 충돌 가드 미적용
+# ===================================================================
+
+
+def test_roi_sell_not_affected_by_buy_signal(db):
+    """is_profit_taking=True인 ROI 매도는 충돌 가드 미적용."""
+    from cryptobot.bot.trader import OrderResult
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 0.9, "ROI 도달 (60분 보유, 실질 +1.5%)", is_profit_taking=True)
+    buy_sig = Signal("buy", 0.95, "강한 매수 (영향 없어야)")
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig)
+    bot._trader.sell_market.return_value = OrderResult(
+        success=True, side="sell", coin="KRW-BTC",
+        price=102, amount=1, total_krw=10200, fee_krw=5, order_uuid="u1",
+    )
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    bot._check_and_sell(active_trade, price=102.0, snapshot_id=None, coin="KRW-BTC")
+
+    # ROI는 그대로 진행
+    bot._trader.sell_market.assert_called_once_with("KRW-BTC")
+    # 충돌 알림은 발송 안 됨
+    if bot._notifier.send.called:
+        for call in bot._notifier.send.call_args_list:
+            assert "충돌" not in call[0][0]
+
+
+# ===================================================================
+# 임계값 조정
+# ===================================================================
+
+
+def test_lower_threshold_holds_more_aggressively(db):
+    """임계 0.5로 낮추면 더 자주 보류."""
+    buy_id = _seed_buy(db, price=100)
+    sell_sig = Signal("sell", 1.0, "손절", is_profit_taking=False)
+    buy_sig = Signal("buy", 0.5, "중간 강도")  # 0.7이면 미달, 0.5면 정확히 통과
+
+    bot, _ = _make_bot(db, sell_sig, buy_sig, conf_threshold=0.5)
+    active_trade = {"id": buy_id, "price": 100.0, "total_krw": 10000, "fee_krw": 5,
+                    "timestamp": "2026-04-19T11:00:00+00:00"}
+    bot._check_and_sell(active_trade, price=95.0, snapshot_id=None, coin="KRW-BTC")
+
+    bot._trader.sell_market.assert_not_called()


### PR DESCRIPTION
## Summary

ALGO 케이스 — 손절 직후 1분 뒤 RSI 매수로 재매수하는 모순 패턴의 근본 해결.
사용자 직관 \"더 높은 confidence 신호 채택\" 정식 도입.

### 동작
- 손절 트리거 → 같은 코인 매수 신호 강도 즉시 평가
- 매수 conf ≥ 0.7 → 손절 보류 (\"들고 간다\") + Slack 알림
- pnl ≤ −10% → 안전장치로 무조건 손절
- ROI/트레일링은 미적용 (기존 RSI 보류 로직 유지)

### 코드
- `RiskLimits.signal_conflict_buy_confidence_threshold = 0.7`
- `RiskLimits.hard_stop_loss_floor_pct = -10.0`
- `_check_and_sell`: 손절 시 `check_buy()` 호출 후 비교
- 동적 config sync

## Test plan
- [x] `pytest tests/test_signal_conflict_210.py -v` — 8건 통과
- [x] `pytest tests/ -x -q` — 340건 전부 통과
- [ ] 배포 후 ALGO 같은 패턴 감지 시 \"⚖️ 손절-매수 충돌 보류\" Slack 도달

## 한계 / 후속 PR 후보
- 보류 후 가격이 더 떨어지면 결국 −10% 안전장치 손절 — 큰 손실 가능
- 더 정교한 해결: stop_loss 동적화(ATR 기반) — 변동성 큰 코인에 −5% 고정이 너무 빡빡

Related: #210
🤖 Generated with [Claude Code](https://claude.com/claude-code)