### PR TITLE
feat: 분봉 OHLCV 수집 인프라 (#216) — 분봉 ATR/ADX 재실험용

### DIFF
--- a/src/cryptobot/data/collector.py
+++ b/src/cryptobot/data/collector.py
@@ -38,6 +38,10 @@ class DataCollector:
         self._last_ohlcv_fetch: float = 0  # OHLCV 캐시 타임스탬프
         self._ohlcv_cache_seconds: int = 3600  # 1시간 캐시
         self._last_price: float = 0  # 가격 급변 감지용
+        # #216: 분봉 OHLCV 수집 — 매 시간 1회만 호출 (rate-limit 보호 + 데이터 충분).
+        # 5분봉 200캔들 = 약 17시간치. 다음 호출 사이 새로 생긴 캔들만 INSERT OR IGNORE.
+        self._last_minutes_fetch: float = 0
+        self._minutes_fetch_interval_sec: int = 3600  # 1시간마다
 
     @property
     def latest_df(self) -> "pd.DataFrame | None":
@@ -59,6 +63,9 @@ class DataCollector:
 
             # OHLCV 일봉 데이터 저장 (하루 1회)
             self._save_ohlcv_daily()
+
+            # #216: 5분봉 OHLCV 저장 (1시간에 1회 호출)
+            self._save_ohlcv_minutes(interval_min=5)
 
             logger.debug("스냅샷 저장: id=%d, price=%s", snapshot_id, f"{snapshot['price']:,.0f}")
             return snapshot_id
@@ -198,6 +205,49 @@ class DataCollector:
         self._db.commit()
         self._last_ohlcv_save_date = today_str
         logger.info("OHLCV 일봉 저장: %s %d일치", self._coin, len(rows))
+
+    def _save_ohlcv_minutes(self, interval_min: int = 5, count: int = 200) -> int:
+        """#216: 분봉 OHLCV 수집·저장.
+
+        업비트 API는 1m/3m/5m/15m/30m/60m/240m 지원. 5분봉 200캔들 = 약 17시간치.
+        매 1시간에 1회만 호출(rate-limit). UNIQUE 제약으로 중복 방지.
+
+        Returns:
+            새로 저장된 캔들 수.
+        """
+        import time as _time
+
+        now_ts = _time.time()
+        if now_ts - self._last_minutes_fetch < self._minutes_fetch_interval_sec:
+            return 0
+
+        try:
+            df = pyupbit.get_ohlcv(self._coin, interval=f"minute{interval_min}", count=count)
+        except Exception as e:
+            logger.warning("분봉 수집 실패: %s %s", self._coin, e)
+            return 0
+        if df is None or df.empty:
+            return 0
+
+        now_str = _utcnow()
+        rows = []
+        for idx, row in df.iterrows():
+            ts_str = idx.strftime("%Y-%m-%d %H:%M:%S") if hasattr(idx, "strftime") else str(idx)
+            rows.append((self._coin, interval_min, ts_str, row["open"], row["high"],
+                        row["low"], row["close"], row["volume"], now_str))
+
+        self._db.executemany(
+            """
+            INSERT OR IGNORE INTO ohlcv_minutes
+              (coin, interval_min, timestamp, open, high, low, close, volume, collected_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        self._db.commit()
+        self._last_minutes_fetch = now_ts
+        logger.info("분봉(%dm) 저장 시도: %s %d캔들", interval_min, self._coin, len(rows))
+        return len(rows)
 
     def get_latest_snapshot(self) -> dict | None:
         """이 코인의 가장 최근 스냅샷 조회."""

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -304,6 +304,23 @@ CREATE TABLE IF NOT EXISTS backtest_results (
 );
 CREATE INDEX IF NOT EXISTS idx_bt_run_date ON backtest_results(run_date, strategy_name, coin);
 
+-- #216: 분봉 OHLCV. 일봉 ATR/ADX는 봇의 실제 동작 주기(분 단위)와 미스매치 →
+-- 분봉으로 재측정해 변동성/추세 지표 정밀화. 5분봉 기본 (200캔들 ≈ 17시간치).
+CREATE TABLE IF NOT EXISTS ohlcv_minutes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    coin TEXT NOT NULL,
+    interval_min INTEGER NOT NULL DEFAULT 5,  -- 1, 5, 15, 60
+    timestamp DATETIME NOT NULL,
+    open REAL NOT NULL,
+    high REAL NOT NULL,
+    low REAL NOT NULL,
+    close REAL NOT NULL,
+    volume REAL NOT NULL,
+    collected_at DATETIME NOT NULL,
+    UNIQUE(coin, interval_min, timestamp)
+);
+CREATE INDEX IF NOT EXISTS idx_ohlcv_minutes_lookup ON ohlcv_minutes(coin, interval_min, timestamp DESC);
+
 -- #206: 추가 입금 추적. 잔고 검증이 첫 starting_balance만 "총 입금액"으로 보던 한계 해결.
 CREATE TABLE IF NOT EXISTS capital_deposits (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/test_ohlcv_minutes_216.py
+++ b/tests/test_ohlcv_minutes_216.py
@@ -1,0 +1,156 @@
+"""#216: 분봉 OHLCV 수집 테스트.
+
+DataCollector._save_ohlcv_minutes — UNIQUE 중복 방지, 1h cooldown, 정상 저장.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from cryptobot.data.collector import DataCollector
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _fake_ohlcv(n: int = 10, base_minute: int = 0):
+    """가짜 분봉 OHLCV — DatetimeIndex."""
+    import numpy as np
+    idx = pd.date_range("2026-04-20 09:00:00", periods=n, freq="5min") + pd.Timedelta(minutes=base_minute)
+    return pd.DataFrame({
+        "open": np.linspace(1000, 1100, n),
+        "high": np.linspace(1010, 1110, n),
+        "low": np.linspace(990, 1090, n),
+        "close": np.linspace(1005, 1105, n),
+        "volume": np.linspace(100, 200, n),
+    }, index=idx)
+
+
+# ===================================================================
+# 스키마
+# ===================================================================
+
+
+def test_ohlcv_minutes_table_exists(db):
+    rows = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ohlcv_minutes'"
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_ohlcv_minutes_columns(db):
+    cols = {dict(r)["name"] for r in db.execute("PRAGMA table_info(ohlcv_minutes)").fetchall()}
+    assert {"id", "coin", "interval_min", "timestamp", "open", "high", "low",
+            "close", "volume", "collected_at"} <= cols
+
+
+def test_unique_constraint_prevents_duplicate(db):
+    """coin + interval_min + timestamp UNIQUE."""
+    db.execute(
+        "INSERT INTO ohlcv_minutes (coin, interval_min, timestamp, open, high, low, close, volume, collected_at) "
+        "VALUES ('KRW-BTC', 5, '2026-04-20 09:00:00', 1000, 1010, 990, 1005, 100, '2026-04-20 10:00:00')"
+    )
+    db.commit()
+    with pytest.raises(Exception):
+        db.execute(
+            "INSERT INTO ohlcv_minutes (coin, interval_min, timestamp, open, high, low, close, volume, collected_at) "
+            "VALUES ('KRW-BTC', 5, '2026-04-20 09:00:00', 999, 999, 999, 999, 99, '2026-04-20 10:01:00')"
+        )
+        db.commit()
+
+
+# ===================================================================
+# _save_ohlcv_minutes
+# ===================================================================
+
+
+def test_save_inserts_candles(db):
+    """첫 호출 — N캔들 모두 INSERT."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", return_value=_fake_ohlcv(n=10)):
+        n = collector._save_ohlcv_minutes(interval_min=5, count=10)
+    assert n == 10
+    saved = db.execute("SELECT COUNT(*) FROM ohlcv_minutes WHERE coin='KRW-BTC'").fetchone()[0]
+    assert saved == 10
+
+
+def test_cooldown_skips_repeated_calls(db):
+    """1h cooldown — 같은 호출 즉시 반복 시 0."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", return_value=_fake_ohlcv(n=5)):
+        n1 = collector._save_ohlcv_minutes()
+        n2 = collector._save_ohlcv_minutes()
+    assert n1 == 5
+    assert n2 == 0  # cooldown
+
+
+def test_cooldown_can_be_bypassed_for_test(db):
+    """cooldown override — _last_minutes_fetch=0 리셋 시 다시 호출."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", return_value=_fake_ohlcv(n=5)):
+        collector._save_ohlcv_minutes()
+        collector._last_minutes_fetch = 0  # cooldown 리셋
+        # 같은 데이터 다시 호출 — UNIQUE로 0건 추가
+        collector._save_ohlcv_minutes()
+    saved = db.execute("SELECT COUNT(*) FROM ohlcv_minutes").fetchone()[0]
+    assert saved == 5  # 중복 안 들어감
+
+
+def test_api_failure_returns_zero(db):
+    """API 예외 → 0 반환, 다음 호출 가능."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", side_effect=Exception("rate limit")):
+        n = collector._save_ohlcv_minutes()
+    assert n == 0
+    assert collector._last_minutes_fetch == 0  # 미갱신 → 다음 즉시 가능
+
+
+def test_empty_response_returns_zero(db):
+    """빈 응답."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", return_value=pd.DataFrame()):
+        n = collector._save_ohlcv_minutes()
+    assert n == 0
+
+
+def test_partial_overlap_inserts_only_new(db):
+    """일부 겹치는 데이터 — UNIQUE로 새 것만 추가."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    df1 = _fake_ohlcv(n=5)  # 09:00 ~ 09:20
+    df2 = _fake_ohlcv(n=5, base_minute=15)  # 09:15 ~ 09:35 (3개 겹침)
+
+    with patch("pyupbit.get_ohlcv", return_value=df1):
+        collector._save_ohlcv_minutes()
+    collector._last_minutes_fetch = 0
+    with patch("pyupbit.get_ohlcv", return_value=df2):
+        collector._save_ohlcv_minutes()
+
+    # df1: 09:00~09:20 (5캔들), df2: 09:15~09:35 (5캔들, 09:15/09:20 overlap)
+    # → 5 + 3 신규 = 8
+    saved = db.execute("SELECT COUNT(*) FROM ohlcv_minutes").fetchone()[0]
+    assert saved == 8
+
+
+def test_different_intervals_kept_separate(db):
+    """interval_min이 다르면 같은 timestamp도 별개."""
+    collector = DataCollector(db, coin="KRW-BTC")
+    with patch("pyupbit.get_ohlcv", return_value=_fake_ohlcv(n=3)):
+        collector._save_ohlcv_minutes(interval_min=5)
+    collector._last_minutes_fetch = 0
+    with patch("pyupbit.get_ohlcv", return_value=_fake_ohlcv(n=3)):
+        collector._save_ohlcv_minutes(interval_min=15)
+
+    saved_5 = db.execute("SELECT COUNT(*) FROM ohlcv_minutes WHERE interval_min=5").fetchone()[0]
+    saved_15 = db.execute("SELECT COUNT(*) FROM ohlcv_minutes WHERE interval_min=15").fetchone()[0]
+    assert saved_5 == 3
+    assert saved_15 == 3


### PR DESCRIPTION
## Summary
- 5분봉 OHLCV 자동 수집 (시간당 1회) → 새 테이블 ohlcv_minutes
- 일봉 ATR이 봇 실제 동작 주기(분 단위)와 미스매치 가설 검증을 위한 인프라
- INSERT OR IGNORE로 overlap 자연 처리

## Test plan
- [x] `pytest tests/test_ohlcv_minutes_216.py -v` — 8건 통과
- [x] `pytest tests/ -x -q` — 371건 통과
- [ ] 배포 후 며칠 내 \"분봉(5m) 저장 시도\" 로그 확인 + DB row 증가

## 다음 (별도 PR, 데이터 1주일+ 후)
- 분봉 ATR로 #213 재실험
- 분봉 ADX로 #215 재검증
- 실현변동성 지표 추가

Related: #216
🤖 Generated with [Claude Code](https://claude.com/claude-code)