### PR TITLE
fix: 대시보드 시작금액 동적화 — capital_deposits 사용 (#218)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -85,12 +85,16 @@ export default function DashboardPage() {
         const totalCost = pos.reduce((s: number, p: any) => s + (p.total_krw || 0), 0);
         const totalValue = pos.reduce((s: number, p: any) => s + (p.amount || 0) * (p.current_price || 0), 0);
         const totalAsset = (balance?.krw_balance || 0) + totalValue;
-        const STARTING_BALANCE = 100000;
-        const totalPnl = totalAsset - STARTING_BALANCE;
+        // #218: 시작 금액은 capital_deposits 누적 합산 (백엔드에서 계산). 추가 입금 시 자동 반영.
+        // API에서 못 받아오면(레거시 등) 100,000 fallback — 그래도 손익 부호는 의미 있음.
+        const totalDeposits = balance?.total_deposits_krw && balance.total_deposits_krw > 0
+          ? balance.total_deposits_krw
+          : 100000;
+        const totalPnl = totalAsset - totalDeposits;
         return (
           <div className="kpi-grid">
             <StatCard label="총 보유 자산" value={balance ? formatKRW(totalAsset) : "-"} sub={`KRW ${formatKRW(balance?.krw_balance || 0)} + 코인 ${formatKRW(totalValue)}`} />
-            <StatCard label="총 손익" value={`${formatKRW(totalPnl)} (${formatPercent(totalPnl / STARTING_BALANCE * 100)})`} valueClass={totalPnl >= 0 ? "positive" : "negative"} sub={`시작 ₩${STARTING_BALANCE.toLocaleString()} 기준`} />
+            <StatCard label="총 손익" value={`${formatKRW(totalPnl)} (${formatPercent(totalDeposits > 0 ? totalPnl / totalDeposits * 100 : 0)})`} valueClass={totalPnl >= 0 ? "positive" : "negative"} sub={`누적 입금 ₩${totalDeposits.toLocaleString()} 기준`} />
             <StatCard label="매수 금액" value={formatKRW(totalCost)} sub={`${pos.length}종목 보유`} />
             <StatCard label="평가 금액" value={formatKRW(totalValue)} valueClass={totalValue >= totalCost ? "positive" : "negative"} sub={totalCost > 0 ? `${formatPercent((totalValue - totalCost) / totalCost * 100)} 수익률` : ""} />
           </div>

--- a/admin/src/types/balance.ts
+++ b/admin/src/types/balance.ts
@@ -5,6 +5,7 @@ export interface BalanceResponse {
   coin_balance: number;
   coin_value_krw: number;
   total_asset_krw: number;
+  total_deposits_krw: number;  // #218: capital_deposits 누적 합 (대시보드 손익 기준)
   api_connected: boolean;
 }
 

--- a/src/cryptobot/api/routes/balance.py
+++ b/src/cryptobot/api/routes/balance.py
@@ -13,12 +13,36 @@ router = APIRouter(prefix="/api/balance", tags=["balance"])
 
 @router.get("")
 def get_balance(_: UserResponse = Depends(get_current_user)):
-    """현재 잔고 + 보유 포지션."""
+    """현재 잔고 + 보유 포지션 + 누적 입금액."""
     from cryptobot.bot.config import config
     from cryptobot.bot.trader import Trader
 
     trader = Trader()
-    result = {"krw_balance": 0, "coin_balance": 0, "coin_value_krw": 0, "total_asset_krw": 0, "api_connected": False}
+    result = {
+        "krw_balance": 0,
+        "coin_balance": 0,
+        "coin_value_krw": 0,
+        "total_asset_krw": 0,
+        "total_deposits_krw": 0,  # #218: 누적 입금액 (대시보드 손익 계산 기준)
+        "api_connected": False,
+    }
+
+    # #218: capital_deposits 합산 — 추가 입금이 있어도 손익 기준이 정확.
+    # 비어 있으면 첫 daily_reports.starting_balance fallback.
+    try:
+        db = get_db()
+        dep_row = db.execute(
+            "SELECT COALESCE(SUM(amount_krw), 0) AS total FROM capital_deposits WHERE currency = 'KRW'"
+        ).fetchone()
+        total_deposits = dict(dep_row)["total"] if dep_row else 0
+        if total_deposits <= 0:
+            first = db.execute(
+                "SELECT starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
+            ).fetchone()
+            total_deposits = dict(first)["starting_balance_krw"] if first else 0
+        result["total_deposits_krw"] = float(total_deposits)
+    except Exception as e:
+        logger.warning("누적 입금액 조회 실패: %s", e)
 
     if trader.is_ready:
         try:

--- a/tests/test_balance_total_deposits_218.py
+++ b/tests/test_balance_total_deposits_218.py
@@ -1,0 +1,101 @@
+"""#218: /api/balance 응답에 total_deposits_krw 포함 검증.
+
+대시보드 시작금액 100,000 고정값 → capital_deposits 합산으로 동적화.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def db_path():
+    tmpdir = tempfile.mkdtemp()
+    p = Path(tmpdir) / "test.db"
+    db = Database(p)
+    db.initialize()
+    db.close()
+    return p
+
+
+def _client(db_path):
+    """API TestClient — auth bypass + db override."""
+    from cryptobot.api.main import app
+    from cryptobot.api.auth import UserResponse, get_current_user
+    from cryptobot.api.deps import get_db
+
+    fake_user = UserResponse(id=1, username="test", display_name="test", is_admin=True)
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+
+    db = Database(db_path)
+    db.initialize()
+    # get_db는 함수라 monkeypatch
+    import cryptobot.api.routes.balance as bal_mod
+    bal_mod.get_db = lambda: db
+
+    return TestClient(app), db
+
+
+def test_balance_includes_total_deposits_field(db_path):
+    """기본 응답에 total_deposits_krw 필드 포함."""
+    client, db = _client(db_path)
+    with patch("cryptobot.bot.trader.Trader") as MockTrader:
+        MockTrader.return_value.is_ready = False
+        r = client.get("/api/balance")
+    assert r.status_code == 200
+    data = r.json()
+    assert "total_deposits_krw" in data
+
+
+def test_balance_sums_capital_deposits(db_path):
+    """capital_deposits 합산이 반환됨."""
+    db = Database(db_path)
+    db.initialize()
+    db.execute(
+        "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source) "
+        "VALUES ('KRW', 100000, '2026-04-04 00:00:00', 'initial')"
+    )
+    db.execute(
+        "INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source) "
+        "VALUES ('KRW', 400000, '2026-04-19 22:06:00', 'api')"
+    )
+    db.commit()
+    db.close()
+
+    client, _ = _client(db_path)
+    with patch("cryptobot.bot.trader.Trader") as MockTrader:
+        MockTrader.return_value.is_ready = False
+        r = client.get("/api/balance")
+    assert r.json()["total_deposits_krw"] == 500000
+
+
+def test_balance_fallback_to_first_daily_report(db_path):
+    """capital_deposits 비었으면 첫 daily_reports.starting_balance fallback."""
+    db = Database(db_path)
+    db.initialize()
+    db.execute(
+        "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
+        "VALUES ('2026-04-04', 95000, 95000)"
+    )
+    db.commit()
+    db.close()
+
+    client, _ = _client(db_path)
+    with patch("cryptobot.bot.trader.Trader") as MockTrader:
+        MockTrader.return_value.is_ready = False
+        r = client.get("/api/balance")
+    assert r.json()["total_deposits_krw"] == 95000
+
+
+def test_balance_zero_when_no_data(db_path):
+    """둘 다 비었으면 0."""
+    client, _ = _client(db_path)
+    with patch("cryptobot.bot.trader.Trader") as MockTrader:
+        MockTrader.return_value.is_ready = False
+        r = client.get("/api/balance")
+    assert r.json()["total_deposits_krw"] == 0


### PR DESCRIPTION
## Summary
- 대시보드 \"총 손익\" 카드가 100,000원 하드코딩이라 추가 입금 시 손익률 4배 환각
- 백엔드 /api/balance에 total_deposits_krw 추가, 프론트가 사용

## 효과
- 4배 환각 (+398%) → 실제 (+0.64%) 정확한 손익률 표시
- 추가 입금 시 자동 반영 (#206 capital_deposits 활용)

## Test plan
- [x] 백엔드 4건 통과
- [x] 전체 375건 통과
- [x] 프론트 빌드 OK

Related: #218
🤖 Generated with [Claude Code](https://claude.com/claude-code)