### PR TITLE
fix: 입금 sync cutoff에 7일 여유 — 봇 시작 직전 입금 누락 방지 (#220)

### DIFF
--- a/scripts/backfill_deposits.py
+++ b/scripts/backfill_deposits.py
@@ -1,8 +1,7 @@
-"""capital_deposits 백필 스크립트 (#206).
+"""capital_deposits 백필 스크립트 (#206, #220 cutoff 7일 여유).
 
 업비트 입금 내역을 1회 가져와 capital_deposits 테이블에 등록한다.
-초기 자본(daily_reports의 첫 starting_balance)이 별도 등록되어 있지 않으면
-'initial' source로 같이 시드한다.
+sync_deposits가 봇 시작일 -7일 cutoff로 직전 입금까지 자동 포함하므로 별도 시드 불필요.
 
 사용법:
     .venv/bin/python scripts/backfill_deposits.py
@@ -29,26 +28,11 @@ def main() -> int:
         logger.error("업비트 API Key 미설정")
         return 1
 
-    # 1. 초기 자본 시드 (capital_deposits가 비어 있을 때만)
-    existing = db.execute("SELECT COUNT(*) AS c FROM capital_deposits").fetchone()
-    if dict(existing)["c"] == 0:
-        # 봇 시작일 첫 daily_reports 기준으로 'initial' 등록
-        first = db.execute(
-            "SELECT date, starting_balance_krw FROM daily_reports ORDER BY date ASC LIMIT 1"
-        ).fetchone()
-        if first:
-            f = dict(first)
-            db.execute(
-                """
-                INSERT INTO capital_deposits (currency, amount_krw, deposited_at, source, note)
-                VALUES ('KRW', ?, ?, 'initial', '봇 시작일 첫 잔고 기준')
-                """,
-                (f["starting_balance_krw"], f"{f['date']} 00:00:00"),
-            )
-            db.commit()
-            logger.info("초기 자본 시드: %s = %.0f원", f["date"], f["starting_balance_krw"])
+    # #220: initial 시드 로직 제거. sync_deposits가 봇 시작일 -7일 cutoff로 직전 입금까지
+    # 자동으로 등록하므로 별도 시드 불필요. starting_balance를 시드로 쓰면 매매 비용/시드
+    # 시점 차이로 실제 입금액과 어긋남(사용자 케이스: 100,000 → 94,998).
 
-    # 2. 업비트 입금 내역 sync
+    # 업비트 입금 내역 sync
     checker = HealthChecker(db, trader, notifier=None)
     result = checker.sync_deposits()
     logger.info("sync 결과: %s", result)

--- a/src/cryptobot/bot/health_checker.py
+++ b/src/cryptobot/bot/health_checker.py
@@ -312,6 +312,12 @@ class HealthChecker:
             logger.error("전략 일관성 체크 실패: %s", e)
             return {"status": "warning", "message": str(e)}
 
+    # #220: 봇 시작 *직전*(예: 1~3일 전) 입금이 cutoff에 걸려 누락되는 케이스가 발견됨
+    # (사용자 4/3 입금 100,000원이 4/4 첫 daily_report 기준 cutoff에 막힘). 봇 시작 며칠 전
+    # 입금까지 자본금으로 인정해야 손익 계산이 정확. 7일 여유로 풀고, 그래도 옛 입금
+    # (수년 전)은 충분히 차단.
+    DEPOSIT_SYNC_CUTOFF_BUFFER_DAYS = 7
+
     def sync_deposits(self, since: str | None = None) -> dict:
         """업비트 입금 내역을 조회해 capital_deposits 테이블에 신규 건만 등록.
 
@@ -319,8 +325,8 @@ class HealthChecker:
 
         Args:
             since: ISO datetime 문자열 (예: '2026-04-04'). 이 시각 이전 입금은 무시.
-                None이면 첫 daily_reports.date(=봇 시작일)를 자동 사용.
-                업비트 API가 수년 전 입금까지 반환하는데 그건 운영 자본과 무관하므로 cutoff 필수.
+                None이면 첫 daily_reports.date - DEPOSIT_SYNC_CUTOFF_BUFFER_DAYS 를 자동 사용.
+                봇 시작 직전 입금까지 자본금으로 잡되, 수년 전 옛 입금은 차단.
 
         Returns:
             {"status", "fetched", "new", "total_added_krw"}
@@ -334,7 +340,14 @@ class HealthChecker:
                 first = self._db.execute(
                     "SELECT date FROM daily_reports ORDER BY date ASC LIMIT 1"
                 ).fetchone()
-                since = dict(first)["date"] if first else "2000-01-01"
+                if first:
+                    base = dict(first)["date"]
+                    # base date - buffer days
+                    from datetime import datetime, timedelta
+                    base_dt = datetime.fromisoformat(str(base)[:10])
+                    since = (base_dt - timedelta(days=self.DEPOSIT_SYNC_CUTOFF_BUFFER_DAYS)).strftime("%Y-%m-%d")
+                else:
+                    since = "2000-01-01"
             since_str = str(since)[:10]  # 'YYYY-MM-DD'
 
             history = self._trader.get_deposit_history(currency="KRW", limit=100)

--- a/tests/test_capital_deposits_206.py
+++ b/tests/test_capital_deposits_206.py
@@ -147,7 +147,7 @@ def test_sync_no_trader_returns_skip(db):
 
 
 def test_sync_skips_old_deposits_via_cutoff(db):
-    """첫 daily_report.date 이전 입금은 자동 제외 (운영 자본과 무관한 옛날 입금 보호)."""
+    """봇 시작일 -7일 이전 입금은 자동 제외 (운영 자본과 무관한 옛날 입금 보호)."""
     db.execute(
         "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
         "VALUES ('2026-04-04', 95000, 95000)"
@@ -165,7 +165,35 @@ def test_sync_skips_old_deposits_via_cutoff(db):
     assert r["new"] == 1
     assert r["total_added_krw"] == 400000.0
     assert r["skipped_old"] == 1
-    assert r["since"] == "2026-04-04"
+    # #220: cutoff = 첫 daily_report.date - 7일 = 2026-03-28
+    assert r["since"] == "2026-03-28"
+
+
+def test_sync_includes_pre_bot_start_deposits_within_buffer(db):
+    """#220: 봇 시작일 직전(7일 이내) 입금도 자본금으로 포함.
+
+    사용자 케이스: 4/3 입금 100,000원이 4/4 봇 시작일 cutoff에 막혀 누락된 문제.
+    """
+    db.execute(
+        "INSERT INTO daily_reports (date, starting_balance_krw, ending_balance_krw) "
+        "VALUES ('2026-04-04', 95000, 95000)"
+    )
+    db.commit()
+
+    trader = _FakeTrader(
+        [
+            {"uuid": "preA", "amount_krw": 10000.0, "deposited_at": "2026-04-03T22:17:59+09:00"},
+            {"uuid": "preB", "amount_krw": 90000.0, "deposited_at": "2026-04-03T22:51:55+09:00"},
+            {"uuid": "post", "amount_krw": 400000.0, "deposited_at": "2026-04-19T22:06:15+09:00"},
+            {"uuid": "way_old", "amount_krw": 2000000.0, "deposited_at": "2021-12-15T07:11:13+09:00"},
+        ]
+    )
+    checker = HealthChecker(db, trader, notifier=None)
+    r = checker.sync_deposits()
+    # 4/3 두 건 + 4/19 = 3건 등록, 2021은 차단
+    assert r["new"] == 3
+    assert r["total_added_krw"] == 500000.0
+    assert r["skipped_old"] == 1
 
 
 def test_sync_explicit_since_overrides_default(db):


### PR DESCRIPTION
## Summary
- sync_deposits 기본 cutoff = 첫 daily_report.date − 7일
- 봇 시작 직전 입금까지 자본금으로 자동 포함 (사용자 4/3 입금 누락 케이스 해결)
- 옛 입금(수년 전)은 여전히 차단

## Test plan
- [x] 단위 13건 통과 (pre-bot-start 케이스 추가)
- [x] 전체 376건 통과

Related: #220
🤖 Generated with [Claude Code](https://claude.com/claude-code)