### PR TITLE
feat: 메이저 코인 화이트리스트 — 알트 손실 차단 (#228)

### DIFF
--- a/src/cryptobot/bot/coin_manager.py
+++ b/src/cryptobot/bot/coin_manager.py
@@ -12,7 +12,19 @@ logger = logging.getLogger(__name__)
 class CoinManager:
     """멀티코인 선별 + DataCollector 관리."""
 
-    CORE_COINS = ["KRW-BTC", "KRW-ETH", "KRW-XRP"]
+    # #228: SOL 추가 (글로벌 시총 5위, "이더리움 킬러", 업비트 거래량 상위)
+    CORE_COINS = ["KRW-BTC", "KRW-ETH", "KRW-XRP", "KRW-SOL"]
+
+    # #228: 메이저 화이트리스트 — 잡쓰레기 알트(NEWT 등) 자동 제외용 보호 리스트.
+    # 한 달 운영(33일) 통계: 알트 NEWT 한 종목으로 -31,056원 (한 달 손해의 1.5배).
+    # bb_rsi 백테스트는 메이저(BTC/ETH/XRP)에선 +7.45% 성과.
+    # 진짜 적자 원인은 알트 마구잡이 매매로 판명 → 화이트리스트로 직접 차단.
+    # 티어 1 (필수): BTC, ETH, XRP, SOL (글로벌 시총 상위 4, 스테이블 제외)
+    # 티어 2 (선택): ADA, DOGE, AVAX, LINK (시총 5~15위, 업비트 거래량 큼)
+    DEFAULT_WHITELIST = [
+        "KRW-BTC", "KRW-ETH", "KRW-XRP", "KRW-SOL",  # 티어 1
+        "KRW-ADA", "KRW-DOGE", "KRW-AVAX", "KRW-LINK",  # 티어 2
+    ]
 
     def __init__(self, db, config_manager) -> None:
         self._db = db
@@ -21,6 +33,14 @@ class CoinManager:
         self.collectors: dict[str, DataCollector] = {}
         self._last_refresh: str = ""
         self._init_collectors()
+
+    def _get_whitelist(self) -> list[str] | None:
+        """#228: 활성 화이트리스트 반환. None이면 화이트리스트 미사용 (기존 동작)."""
+        if not self._config.get_bool("coin_whitelist_enabled", True):
+            return None
+        raw = self._config.get("coin_whitelist", ",".join(self.DEFAULT_WHITELIST))
+        coins = [c.strip() for c in raw.split(",") if c.strip()]
+        return coins if coins else None
 
     def _init_collectors(self) -> None:
         """활성 코인별 DataCollector 초기화 + 불필요한 collector 정리."""
@@ -40,6 +60,18 @@ class CoinManager:
             elapsed = now_ts - float(self._last_refresh)
             if elapsed < interval * 60:
                 return
+
+        # #228: 화이트리스트 모드 — scanner 우회, 화이트리스트만 매매
+        whitelist = self._get_whitelist()
+        if whitelist is not None:
+            held = self._get_held_coins()
+            new_coins = list(whitelist) + [c for c in held if c not in whitelist]
+            if set(new_coins) != set(self.active_coins):
+                logger.info("화이트리스트 코인 적용: %s → %s", self.active_coins, new_coins)
+                self.active_coins = new_coins
+                self._init_collectors()
+            self._last_refresh = str(now_ts)
+            return
 
         if not self._config.get_bool("multi_coin_enabled", True):
             self.active_coins = list(self.CORE_COINS)

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -621,6 +621,25 @@ _DEFAULT_BOT_CONFIG = [
         "display_name": "코인 목록 갱신 주기 (분)",
         "description": "자동 선별 코인 목록을 갱신하는 주기.",
     },
+    # #228: 메이저 화이트리스트 — 알트(NEWT 등) 마구잡이 매매로 인한 큰 손실 차단.
+    # 실측 데이터: NEWT 한 종목만 -31,056원 (한 달 손해의 1.5배).
+    # 기본 ON. 끄면 기존 scanner + LLM add 동작.
+    {
+        "key": "coin_whitelist_enabled",
+        "value": "true",
+        "value_type": "bool",
+        "category": "coin",
+        "display_name": "코인 화이트리스트 모드",
+        "description": "ON: 화이트리스트 코인만 매매. OFF: scanner + LLM 자동 선별 (기존).",
+    },
+    {
+        "key": "coin_whitelist",
+        "value": "KRW-BTC,KRW-ETH,KRW-XRP,KRW-SOL,KRW-ADA,KRW-DOGE,KRW-AVAX,KRW-LINK",
+        "value_type": "string",
+        "category": "coin",
+        "display_name": "화이트리스트 코인 (CSV)",
+        "description": "화이트리스트 모드에서 매매 허용 코인. T1: BTC/ETH/XRP/SOL, T2: ADA/DOGE/AVAX/LINK. 백테스트 +10.94%.",
+    },
     {
         "key": "min_volume_krw",
         "value": "1000000000",
@@ -853,6 +872,24 @@ class Database:
                             ),
                         )
                 logger.info("bot_config에 멀티코인 설정 추가")
+
+            # #228: 화이트리스트 설정 마이그레이션 (기존 DB)
+            wl_exists = conn.execute(
+                "SELECT key FROM bot_config WHERE key = 'coin_whitelist_enabled'"
+            ).fetchone()
+            if wl_exists is None:
+                for cfg in _DEFAULT_BOT_CONFIG:
+                    if cfg["key"] in ("coin_whitelist_enabled", "coin_whitelist"):
+                        conn.execute(
+                            "INSERT OR IGNORE INTO bot_config "
+                            "(key, value, value_type, category, display_name, description) "
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            (
+                                cfg["key"], cfg["value"], cfg["value_type"],
+                                cfg["category"], cfg["display_name"], cfg["description"],
+                            ),
+                        )
+                logger.info("#228: 메이저 코인 화이트리스트 설정 추가")
 
             # 코인 카테고리별 전략 기본값
             row = conn.execute("SELECT COUNT(*) FROM coin_strategy_config").fetchone()

--- a/tests/test_coin_whitelist_228.py
+++ b/tests/test_coin_whitelist_228.py
@@ -1,0 +1,122 @@
+"""#228: 메이저 코인 화이트리스트 테스트.
+
+진짜 레버: 알트(NEWT 등) 자동 제외로 큰 손실 차단.
+한 달 운영 통계: NEWT 한 종목만 -31,056원 (한 달 손해의 1.5배).
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cryptobot.bot.coin_manager import CoinManager
+from cryptobot.bot.config_manager import ConfigManager
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _make_mgr(db, **config_overrides):
+    """CoinManager + ConfigManager — 옵션은 bot_config에 직접 UPDATE."""
+    for key, value in config_overrides.items():
+        # 기존 행 UPDATE (display_name 등 NOT NULL 제약 충족)
+        cur = db.execute("UPDATE bot_config SET value=? WHERE key=?", (value, key)).rowcount
+        if cur == 0:
+            db.execute(
+                "INSERT INTO bot_config (key, value, value_type, category, display_name, description) "
+                "VALUES (?, ?, 'string', 'test', 'test', 'test')",
+                (key, value),
+            )
+    db.commit()
+    cm = ConfigManager(db)
+    return CoinManager(db, cm)
+
+
+# ===================================================================
+# 기본 화이트리스트
+# ===================================================================
+
+
+def test_default_whitelist_includes_all_8_majors():
+    """티어 1+2 = 8개 코인."""
+    expected = {"KRW-BTC", "KRW-ETH", "KRW-XRP", "KRW-SOL",
+                "KRW-ADA", "KRW-DOGE", "KRW-AVAX", "KRW-LINK"}
+    assert set(CoinManager.DEFAULT_WHITELIST) == expected
+
+
+def test_core_coins_includes_sol():
+    """#228: SOL 추가 (글로벌 시총 5위)."""
+    assert "KRW-SOL" in CoinManager.CORE_COINS
+
+
+def test_whitelist_seeded_in_db(db):
+    """initialize 시 coin_whitelist_enabled / coin_whitelist 시드."""
+    enabled = db.execute("SELECT value FROM bot_config WHERE key='coin_whitelist_enabled'").fetchone()
+    coins = db.execute("SELECT value FROM bot_config WHERE key='coin_whitelist'").fetchone()
+    assert enabled is not None
+    assert coins is not None
+    assert "KRW-BTC" in dict(coins)["value"]
+    assert "KRW-SOL" in dict(coins)["value"]
+
+
+# ===================================================================
+# 동작
+# ===================================================================
+
+
+def test_whitelist_mode_active_uses_only_whitelist(db):
+    """화이트리스트 모드 ON → active_coins는 화이트리스트뿐."""
+    mgr = _make_mgr(db)  # 기본값 ON
+    mgr.refresh()
+    # 보유 코인 없으면 화이트리스트 그대로
+    assert set(mgr.active_coins) == set(CoinManager.DEFAULT_WHITELIST)
+
+
+def test_held_coins_protected_outside_whitelist(db):
+    """화이트리스트 밖 코인 보유 중이면 active_coins에 유지 (강제 청산 방지)."""
+    db.execute(
+        "INSERT INTO trades (timestamp, coin, side, price, amount, total_krw, fee_krw, strategy, trigger_reason) "
+        "VALUES (datetime('now'), 'KRW-NEWT', 'buy', 100, 1, 100, 0.05, 'test', 'seed')"
+    )
+    db.commit()
+    mgr = _make_mgr(db)
+    mgr.refresh()
+    assert "KRW-NEWT" in mgr.active_coins  # 보유 중이라 보존
+    # 그러나 화이트리스트 코인은 모두 포함
+    for c in CoinManager.DEFAULT_WHITELIST:
+        assert c in mgr.active_coins
+
+
+def test_whitelist_mode_disabled_falls_back_to_scanner(db):
+    """ON=False → 기존 scanner/CORE_COINS 동작."""
+    mgr = _make_mgr(db, coin_whitelist_enabled="false")
+    # 화이트리스트 없으면 _get_whitelist는 None 반환
+    assert mgr._get_whitelist() is None
+
+
+def test_custom_whitelist_csv(db):
+    """coin_whitelist 직접 변경 — 사용자 토글."""
+    mgr = _make_mgr(db, coin_whitelist="KRW-BTC,KRW-ETH")
+    wl = mgr._get_whitelist()
+    assert wl == ["KRW-BTC", "KRW-ETH"]
+
+
+def test_whitespace_trimmed_in_whitelist(db):
+    """CSV 공백/탭 자동 제거."""
+    mgr = _make_mgr(db, coin_whitelist="KRW-BTC , KRW-ETH ,KRW-XRP")
+    wl = mgr._get_whitelist()
+    assert wl == ["KRW-BTC", "KRW-ETH", "KRW-XRP"]
+
+
+def test_empty_whitelist_returns_none(db):
+    """빈 문자열 → None (화이트리스트 미사용 효과)."""
+    mgr = _make_mgr(db, coin_whitelist="")
+    assert mgr._get_whitelist() is None


### PR DESCRIPTION
## Summary
- #226 진단: 적자 원인은 알트(NEWT 등) 마구잡이 매매. bb_rsi 자체는 메이저에선 흑자
- 백테스트 (122일 약세장): 티어 1+2 평균 **+10.94%** vs Buy&Hold -21.24%
- 화이트리스트 8개 (BTC/ETH/XRP/SOL + ADA/DOGE/AVAX/LINK), 기본 ON
- 사용자 토글 가능, 보유 중 코인은 강제 청산 방지

## Test plan
- [x] 9건 단위 테스트
- [x] 전체 397건 통과
- [x] 백테스트 sweep 검증

Related: #228
🤖 Generated with [Claude Code](https://claude.com/claude-code)