### PR TITLE
improve: bb_rsi 파라미터 최적화 + LLM 비활성 토글 (#230)

### DIFF
--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -456,7 +456,7 @@ _DEFAULT_STRATEGIES = [
         "timeframe": "1d",
         "difficulty": "medium",
         "default_params_json": (
-            '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}'
+            '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 70}'
         ),
         "is_active": True,  # #197: 신규 DB 기본 전략 (운영 의도 반영)
     },
@@ -688,6 +688,16 @@ _DEFAULT_BOT_CONFIG = [
         "display_name": "매매 허용",
         "description": "false로 설정하면 봇이 신호만 기록하고 실제 매매는 하지 않음",
     },
+    # #230: LLM 비활성 토글. 한 달 데이터(활성 -31,676 vs 비활성 +8,640)로 LLM이 수익률에
+    # 도움 안 됨 확인. 기본 false. 다시 켜려면 true + Anthropic API 결제.
+    {
+        "key": "llm_enabled",
+        "value": "false",
+        "value_type": "bool",
+        "category": "llm",
+        "display_name": "LLM 분석 활성",
+        "description": "false면 _should_run에서 즉시 차단. 호출 0건. Anthropic 비용 0.",
+    },
 ]
 
 
@@ -873,6 +883,18 @@ class Database:
                         )
                 logger.info("bot_config에 멀티코인 설정 추가")
 
+            # #230: llm_enabled 토글 마이그레이션 (기존 DB)
+            llm_e = conn.execute("SELECT key FROM bot_config WHERE key = 'llm_enabled'").fetchone()
+            if llm_e is None:
+                conn.execute(
+                    "INSERT OR IGNORE INTO bot_config "
+                    "(key, value, value_type, category, display_name, description) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    ("llm_enabled", "false", "bool", "llm", "LLM 분석 활성",
+                     "#230: false면 _should_run에서 즉시 차단. 호출 0건."),
+                )
+                logger.info("#230: llm_enabled=false 토글 추가")
+
             # #228: 화이트리스트 설정 마이그레이션 (기존 DB)
             wl_exists = conn.execute(
                 "SELECT key FROM bot_config WHERE key = 'coin_whitelist_enabled'"
@@ -961,7 +983,7 @@ class Database:
                         "sideways,bearish",
                         "1d",
                         "medium",
-                        '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 50}',
+                        '{"bb_period": 20, "bb_std": 2.0, "rsi_period": 14, "rsi_oversold": 30, "rsi_overbought": 70}',
                         False,
                         "inactive",
                     ),

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -408,6 +408,17 @@ class LLMAnalyzer:
 
     def _should_run(self, force: bool = False) -> bool:
         """분석 실행 여부 판단 (동적 주기)."""
+        # #230: LLM 비활성 토글 — 한 달 운영 데이터로 LLM이 수익률에 도움 안 됨 확인
+        # (활성 15일 -31,676원 vs 비활성 5일 +8,640원). bot_config에서 즉시 토글 가능.
+        try:
+            row = self._db.execute(
+                "SELECT value FROM bot_config WHERE key='llm_enabled'"
+            ).fetchone()
+            if row and dict(row).get("value", "true").lower() == "false":
+                return False
+        except Exception:
+            pass
+
         # 일일 호출 제한
         # KST 일 경계 기준 카운트. DB timestamp는 UTC라 +9 hours로 변환 후 DATE 비교.
         # 프로젝트 규칙: "모든 시간은 KST(Asia/Seoul)". UTC의 DATE('now')로 하면

--- a/tests/test_emergency_cooldown_190.py
+++ b/tests/test_emergency_cooldown_190.py
@@ -21,6 +21,9 @@ def db():
     tmpdir = tempfile.mkdtemp()
     db = Database(Path(tmpdir) / "test.db")
     db.initialize()
+    # #230: llm_enabled가 기본 false라 _should_run이 즉시 차단 → 테스트는 활성 가정
+    db.execute("UPDATE bot_config SET value='true' WHERE key='llm_enabled'")
+    db.commit()
     yield db
     db.close()
 


### PR DESCRIPTION
## Summary
- bb_rsi sweep 5코인 100조합 → rsi_overbought 50→70 (소폭, 평균 +10.94%)
- LLM 비활성 토글 (bot_config.llm_enabled, 기본 false)
- 한 달 데이터로 LLM 가치 부정 (활성 -31,676 vs 비활성 +8,640)
- Anthropic 비용 0, 봇 안정성 ↑

## Test plan
- [x] 397건 통과
- [x] 운영 DB 적용 + 봇 재시작 검증
- [x] 화이트리스트 8개 자동 적용 확인

Related: #230
🤖 Generated with [Claude Code](https://claude.com/claude-code)