### PR TITLE
feat: DB 스키마 멀티 마켓 지원 — market 컬럼 추가 (#245)

### DIFF
--- a/src/cryptobot/data/collector.py
+++ b/src/cryptobot/data/collector.py
@@ -137,15 +137,16 @@ class DataCollector:
         cursor = self._db.execute(
             """
             INSERT INTO market_snapshots (
-                timestamp, coin, price, open_24h, high_24h, low_24h,
+                timestamp, coin, market, price, open_24h, high_24h, low_24h,
                 change_pct_24h, volume_24h, rsi_14,
                 ma_5, ma_20, ma_60,
                 bb_upper, bb_lower, atr_14, market_state
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 data["timestamp"],
                 data["coin"],
+                data.get("market", "upbit"),
                 data["price"],
                 data["open_24h"],
                 data["high_24h"],
@@ -185,6 +186,7 @@ class DataCollector:
             rows.append(
                 (
                     self._coin,
+                    "upbit",
                     date_str,
                     row["open"],
                     row["high"],
@@ -197,8 +199,8 @@ class DataCollector:
 
         self._db.executemany(
             """
-            INSERT OR REPLACE INTO ohlcv_daily (coin, date, open, high, low, close, volume, collected_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO ohlcv_daily (coin, market, date, open, high, low, close, volume, collected_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             rows,
         )
@@ -233,14 +235,14 @@ class DataCollector:
         rows = []
         for idx, row in df.iterrows():
             ts_str = idx.strftime("%Y-%m-%d %H:%M:%S") if hasattr(idx, "strftime") else str(idx)
-            rows.append((self._coin, interval_min, ts_str, row["open"], row["high"],
+            rows.append((self._coin, "upbit", interval_min, ts_str, row["open"], row["high"],
                         row["low"], row["close"], row["volume"], now_str))
 
         self._db.executemany(
             """
             INSERT OR IGNORE INTO ohlcv_minutes
-              (coin, interval_min, timestamp, open, high, low, close, volume, collected_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+              (coin, market, interval_min, timestamp, open, high, low, close, volume, collected_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             rows,
         )

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -17,6 +17,7 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS ohlcv_daily (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     coin TEXT NOT NULL,
+    market TEXT NOT NULL DEFAULT 'upbit',
     date DATE NOT NULL,
     open REAL NOT NULL,
     high REAL NOT NULL,
@@ -31,6 +32,7 @@ CREATE TABLE IF NOT EXISTS market_snapshots (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     coin TEXT NOT NULL DEFAULT 'KRW-BTC',
+    market TEXT NOT NULL DEFAULT 'upbit',
     price REAL NOT NULL,
     open_24h REAL,
     high_24h REAL,
@@ -55,6 +57,7 @@ CREATE TABLE IF NOT EXISTS trade_signals (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     coin TEXT NOT NULL,
+    market TEXT NOT NULL DEFAULT 'upbit',
     signal_type TEXT NOT NULL,
     strategy TEXT NOT NULL,
     confidence REAL,
@@ -73,6 +76,7 @@ CREATE TABLE IF NOT EXISTS trades (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     coin TEXT NOT NULL,
+    market TEXT NOT NULL DEFAULT 'upbit',
     side TEXT NOT NULL,
     price REAL NOT NULL,
     amount REAL NOT NULL,
@@ -121,7 +125,8 @@ CREATE TABLE IF NOT EXISTS strategy_params (
 
 CREATE TABLE IF NOT EXISTS daily_reports (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    date DATE NOT NULL UNIQUE,
+    date DATE NOT NULL,
+    market TEXT NOT NULL DEFAULT 'upbit',
     starting_balance_krw REAL,
     ending_balance_krw REAL,
     total_asset_value_krw REAL,
@@ -141,6 +146,7 @@ CREATE TABLE IF NOT EXISTS daily_reports (
     total_fees_krw REAL,
     active_param_id INTEGER,
     market_state TEXT,
+    UNIQUE(date, market),
     FOREIGN KEY (active_param_id) REFERENCES strategy_params(id)
 );
 
@@ -309,6 +315,7 @@ CREATE INDEX IF NOT EXISTS idx_bt_run_date ON backtest_results(run_date, strateg
 CREATE TABLE IF NOT EXISTS ohlcv_minutes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     coin TEXT NOT NULL,
+    market TEXT NOT NULL DEFAULT 'upbit',
     interval_min INTEGER NOT NULL DEFAULT 5,  -- 1, 5, 15, 60
     timestamp DATETIME NOT NULL,
     open REAL NOT NULL,
@@ -333,6 +340,12 @@ CREATE TABLE IF NOT EXISTS capital_deposits (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_capital_deposits_at ON capital_deposits(deposited_at DESC);
+
+-- #245: 멀티 마켓 인덱스 (시장별 조회 최적화)
+CREATE INDEX IF NOT EXISTS idx_trades_market_ts ON trades(market, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_signals_market_ts ON trade_signals(market, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_snapshots_market_ts ON market_snapshots(market, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_daily_reports_market ON daily_reports(market, date DESC);
 """
 
 # 기본 전략 파라미터 (최초 1회 삽입)
@@ -1036,6 +1049,71 @@ class Database:
                         ),
                     )
                 logger.info("봇 설정 기본값 삽입 완료 (%d개)", len(_DEFAULT_BOT_CONFIG))
+
+            # 마이그레이션: 멀티 마켓 market 컬럼 추가 (#245)
+            for tbl in ("trades", "trade_signals", "market_snapshots", "ohlcv_daily", "ohlcv_minutes"):
+                try:
+                    conn.execute(f"SELECT market FROM {tbl} LIMIT 1")
+                except sqlite3.OperationalError:
+                    conn.execute(f"ALTER TABLE {tbl} ADD COLUMN market TEXT NOT NULL DEFAULT 'upbit'")
+                    logger.info("%s 테이블에 market 컬럼 추가 (#245)", tbl)
+
+            # 마이그레이션: daily_reports에 market 컬럼 + UNIQUE(date, market) 적용 (#245)
+            # ALTER TABLE로 UNIQUE 제약 변경 불가 → 새 테이블 만들어 데이터 이전
+            try:
+                cols = conn.execute("PRAGMA table_info(daily_reports)").fetchall()
+                has_market = any(c[1] == "market" for c in cols)
+                if not has_market:
+                    conn.executescript(
+                        """
+                        CREATE TABLE daily_reports_new (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            date DATE NOT NULL,
+                            market TEXT NOT NULL DEFAULT 'upbit',
+                            starting_balance_krw REAL,
+                            ending_balance_krw REAL,
+                            total_asset_value_krw REAL,
+                            realized_pnl_krw REAL,
+                            unrealized_pnl_krw REAL,
+                            daily_return_pct REAL,
+                            cumulative_return_pct REAL,
+                            total_trades INTEGER,
+                            buy_trades INTEGER,
+                            sell_trades INTEGER,
+                            winning_trades INTEGER,
+                            losing_trades INTEGER,
+                            win_rate REAL,
+                            avg_profit_pct REAL,
+                            avg_loss_pct REAL,
+                            max_drawdown_pct REAL,
+                            total_fees_krw REAL,
+                            active_param_id INTEGER,
+                            market_state TEXT,
+                            UNIQUE(date, market),
+                            FOREIGN KEY (active_param_id) REFERENCES strategy_params(id)
+                        );
+                        INSERT INTO daily_reports_new (
+                            id, date, market, starting_balance_krw, ending_balance_krw,
+                            total_asset_value_krw, realized_pnl_krw, unrealized_pnl_krw,
+                            daily_return_pct, cumulative_return_pct,
+                            total_trades, buy_trades, sell_trades, winning_trades, losing_trades,
+                            win_rate, avg_profit_pct, avg_loss_pct, max_drawdown_pct,
+                            total_fees_krw, active_param_id, market_state
+                        ) SELECT
+                            id, date, 'upbit', starting_balance_krw, ending_balance_krw,
+                            total_asset_value_krw, realized_pnl_krw, unrealized_pnl_krw,
+                            daily_return_pct, cumulative_return_pct,
+                            total_trades, buy_trades, sell_trades, winning_trades, losing_trades,
+                            win_rate, avg_profit_pct, avg_loss_pct, max_drawdown_pct,
+                            total_fees_krw, active_param_id, market_state
+                        FROM daily_reports;
+                        DROP TABLE daily_reports;
+                        ALTER TABLE daily_reports_new RENAME TO daily_reports;
+                        """
+                    )
+                    logger.info("daily_reports에 market 컬럼 + UNIQUE(date, market) 적용 (#245)")
+            except sqlite3.OperationalError as e:
+                logger.warning("daily_reports market 마이그레이션 스킵: %s", e)
 
             # 인덱스 생성
             conn.execute("CREATE INDEX IF NOT EXISTS idx_snapshots_coin_id ON market_snapshots(coin, id DESC)")

--- a/src/cryptobot/data/recorder.py
+++ b/src/cryptobot/data/recorder.py
@@ -32,8 +32,12 @@ class DataRecorder:
         skip_reason: str | None = None,
         snapshot_id: int | None = None,
         strategy_params_json: str | None = None,
+        market: str = "upbit",
     ) -> int:
         """매매 신호를 기록한다 (실행 여부 관계없이).
+
+        Args:
+            market: 시장 식별자 ("upbit" / "kis_kr" / "kis_us"). 기본값 "upbit"는 코인 봇 호환성 유지.
 
         Returns:
             생성된 signal의 id
@@ -45,13 +49,14 @@ class DataRecorder:
         cursor = self._db.execute(
             """
             INSERT INTO trade_signals (
-                coin, signal_type, strategy, confidence, trigger_reason,
+                coin, market, signal_type, strategy, confidence, trigger_reason,
                 trigger_value, current_price, target_price,
                 executed, trade_id, skip_reason, snapshot_id, strategy_params_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 coin,
+                market,
                 signal_type,
                 strategy,
                 confidence,
@@ -91,6 +96,7 @@ class DataRecorder:
         profit_krw: float | None = None,
         hold_duration_minutes: int | None = None,
         order_uuid: str | None = None,
+        market: str = "upbit",
     ) -> int:
         """매매 체결을 기록한다.
 
@@ -117,16 +123,17 @@ class DataRecorder:
         cursor = self._db.execute(
             """
             INSERT INTO trades (
-                coin, side, price, amount, total_krw, fee_krw,
+                coin, market, side, price, amount, total_krw, fee_krw,
                 strategy, trigger_reason, trigger_value,
                 param_k_value, param_stop_loss, param_trailing_stop,
                 market_state_at_trade, btc_price_at_trade, rsi_at_trade,
                 buy_trade_id, profit_pct, profit_krw, hold_duration_minutes,
                 order_uuid
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 coin,
+                market,
                 side,
                 price,
                 amount,
@@ -187,6 +194,7 @@ class DataRecorder:
         trades_summary: dict,
         active_param_id: int | None = None,
         market_state: str | None = None,
+        market: str = "upbit",
     ) -> int:
         """일일 정산 리포트를 저장한다.
 
@@ -198,16 +206,17 @@ class DataRecorder:
         cursor = self._db.execute(
             """
             INSERT OR REPLACE INTO daily_reports (
-                date, starting_balance_krw, ending_balance_krw, total_asset_value_krw,
+                date, market, starting_balance_krw, ending_balance_krw, total_asset_value_krw,
                 realized_pnl_krw, unrealized_pnl_krw, daily_return_pct,
                 total_trades, buy_trades, sell_trades,
                 winning_trades, losing_trades, win_rate,
                 avg_profit_pct, avg_loss_pct, max_drawdown_pct, total_fees_krw,
                 active_param_id, market_state
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 report_date.isoformat(),
+                market,
                 starting_balance,
                 ending_balance,
                 total_asset_value,


### PR DESCRIPTION
## Summary

- 6개 매매/시세 테이블에 \`market\` 컬럼 추가 (trades, trade_signals, market_snapshots, ohlcv_daily, ohlcv_minutes, daily_reports)
- \`daily_reports\` UNIQUE 제약 \`(date)\` → \`(date, market)\`로 변경 — 시장별 동일 날짜 리포트 분리 저장
- 멀티 마켓 인덱스 4개 추가 (\`idx_trades_market_ts\` 등)
- 기존 DB 호환 마이그레이션 (idempotent, 기존 데이터는 \`'upbit'\`로 백필)
- \`recorder.py\`, \`collector.py\`의 INSERT에 market 파라미터/컬럼 추가 (기본값 \`'upbit'\`로 호환성)

## 의도

#243 Epic의 두 번째 단계. 한국·미국 주식 봇이 같은 SQLite DB에 데이터를 쓸 수 있도록 시장 식별자 추가.

## 적용된 마이그레이션

| 테이블 | 방식 | 비고 |
|---|---|---|
| trades | ALTER TABLE ADD COLUMN | 기본값 'upbit' |
| trade_signals | ALTER TABLE ADD COLUMN | |
| market_snapshots | ALTER TABLE ADD COLUMN | |
| ohlcv_daily | ALTER TABLE ADD COLUMN | |
| ohlcv_minutes | ALTER TABLE ADD COLUMN | |
| daily_reports | 테이블 재생성 + 데이터 이전 | UNIQUE 제약 변경 필요 |

## Test plan

- [x] 354개 테스트 통과 (anthropic 미설치로 인한 4건 제외 — 본 변경과 무관)
- [x] \`Recorder.record_signal/record_trade/save_daily_report\` 모두 \`market\` 파라미터 받음 (기본값 'upbit')
- [x] \`Collector\`의 3개 INSERT(market_snapshots, ohlcv_daily, ohlcv_minutes) 모두 'upbit' 명시
- [x] 마이그레이션 idempotent (재실행 가능)
- [ ] (수동) 기존 운영 DB 백업 후 마이그레이션 실행 검증
- [ ] (수동) 마이그레이션 후 봇 정상 동작 확인 (매매 기록 / 일일 리포트)

## 의존성

- 머지 순서: #248(#244 PR) 다음에 머지 권장. 단 두 PR이 변경 영역(\`exchange/\` vs \`data/\`)이 다르고 충돌 없음.
- 후속 작업(#246 한국, #247 미국)은 이 PR 머지 후 진행

Related: #243, #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)