### PR TITLE
feat: 페이지 방문자 추적 — admin 통계 카드 (#240)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -30,6 +30,7 @@ export default function DashboardPage() {
   const [recentNews, setRecentNews] = useState<any[]>([]);
   const [llmDecisions, setLlmDecisions] = useState<LLMDecision[]>([]);
   const [llmTab, setLlmTab] = useState(0);
+  const [visitStats, setVisitStats] = useState<any>(null);  // #240
   const [loading, setLoading] = useState(true);
 
   const fetchAll = useCallback(() => {
@@ -43,7 +44,8 @@ export default function DashboardPage() {
       client.get("/news/stats", { params: { hours: 24 } }).then((r) => r.data).catch(() => null),
       client.get("/news?limit=6&sort=latest").then((r) => r.data?.items || r.data || []).catch(() => []),
       client.get("/llm/decisions?limit=6").then((r) => r.data).catch(() => []),
-    ]).then(([bal, pos, hist, mkt, trades, coins, nStats, news, llm]) => {
+      client.get("/visits/stats?days=30").then((r) => r.data).catch(() => null),
+    ]).then(([bal, pos, hist, mkt, trades, coins, nStats, news, llm, vs]) => {
       setBalance(bal);
       setPositions(pos as PositionsResponse | null);
       setHistory(hist as BalanceHistory[]);
@@ -53,6 +55,7 @@ export default function DashboardPage() {
       setNewsStats(nStats);
       setRecentNews(news as any[]);
       setLlmDecisions(llm as LLMDecision[]);
+      setVisitStats(vs);
       setLoading(false);
     }).catch(() => setLoading(false));
   }, []);
@@ -324,6 +327,24 @@ export default function DashboardPage() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+
+      {/* #240: 방문자 통계 */}
+      {visitStats && (
+        <div className="card" style={{ marginTop: 16 }}>
+          <div className="card-title">방문자 통계</div>
+          <div className="kpi-grid">
+            <StatCard label="오늘 PV" value={`${visitStats.today?.pv ?? 0}`} sub={`UV ${visitStats.today?.uv ?? 0}`} />
+            <StatCard label="어제 PV" value={`${visitStats.yesterday?.pv ?? 0}`} sub={`UV ${visitStats.yesterday?.uv ?? 0}`} />
+            <StatCard label="최근 7일 PV" value={`${visitStats.last_7_days?.pv ?? 0}`} sub={`UV ${visitStats.last_7_days?.uv ?? 0}`} />
+            <StatCard label="누적 PV" value={`${visitStats.total?.pv ?? 0}`} sub={`UV ${visitStats.total?.uv ?? 0}`} />
+          </div>
+          {visitStats.daily?.length > 1 && (
+            <div style={{ marginTop: 12, fontSize: 12, color: "var(--text-muted)" }}>
+              일별: {visitStats.daily.slice(-14).map((d: any) => `${d.date.slice(5)}:${d.pv}`).join(" · ")}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/admin/src/pages/PublicDashboardPage.tsx
+++ b/admin/src/pages/PublicDashboardPage.tsx
@@ -72,6 +72,24 @@ export default function PublicDashboardPage() {
     return () => clearInterval(interval);
   }, [fetchAll]);
 
+  // #240: 방문자 추적 ping (sessionStorage 기반)
+  useEffect(() => {
+    try {
+      const KEY = "cryptobot-session-id";
+      let sid = sessionStorage.getItem(KEY);
+      if (!sid) {
+        sid = (crypto as any).randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2);
+        sessionStorage.setItem(KEY, sid);
+      }
+      const base = (import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api").replace(/\/api$/, "");
+      fetch(`${base}/api/public/visit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sid, page: "/" }),
+      }).catch(() => {});
+    } catch {}
+  }, []);
+
   // 뉴스 자동 롤링 (모든 훅은 early return 전에)
   useEffect(() => {
     if (news.length <= 1 || newsExpanded) return;

--- a/src/cryptobot/api/main.py
+++ b/src/cryptobot/api/main.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel as _BaseModel
 
 from cryptobot.api.auth import UserResponse, get_current_user
 from cryptobot.api.deps import get_db as _get_db
-from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, public, signals, strategies, trades
+from cryptobot.api.routes import auth, balance, coin_strategy, config, market, news, public, signals, strategies, trades, visits
 from cryptobot.logging_config import setup_logging
 
 setup_logging("api", "INFO")
@@ -78,6 +78,7 @@ app.include_router(config.router)
 app.include_router(signals.router)
 app.include_router(news.router)
 app.include_router(coin_strategy.router)
+app.include_router(visits.router)  # #240 방문자 통계 (admin)
 
 
 @app.get("/api/llm/hard-limits", tags=["llm"])

--- a/src/cryptobot/api/routes/public.py
+++ b/src/cryptobot/api/routes/public.py
@@ -320,6 +320,54 @@ def get_public_monitoring_coins(request: Request):
     ]
 
 
+@router.post("/visit")
+def post_visit(request: Request, payload: dict | None = None):
+    """#240: 페이지 방문 기록 (privacy-aware).
+
+    프론트가 마운트 시 호출. session_id(uuid)로 같은 세션 unique 판정.
+    IP는 해시만 저장 (개인 식별 정보 X).
+    """
+    if not _check_rate_limit(request):
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    payload = payload or {}
+    session_id = (payload.get("session_id") or "")[:64]
+    page = (payload.get("page") or "/")[:100]
+    user_agent = request.headers.get("user-agent", "")[:300]
+
+    # IP 해시 (privacy)
+    import hashlib
+    forwarded = request.headers.get("x-forwarded-for", "")
+    ip = forwarded.split(",")[0].strip() if forwarded else (request.client.host if request.client else "")
+    ip_hash = hashlib.sha256(ip.encode()).hexdigest()[:32] if ip else ""
+
+    db = get_db()
+
+    # 그 날 첫 방문이면 unique. session_id 우선, 없으면 IP fallback.
+    today_unique = False
+    if session_id:
+        existing = db.execute(
+            "SELECT 1 FROM page_visits WHERE DATE(visited_at)=DATE('now') "
+            "AND session_id=? LIMIT 1", (session_id,)
+        ).fetchone()
+        today_unique = existing is None
+    elif ip_hash:
+        existing = db.execute(
+            "SELECT 1 FROM page_visits WHERE DATE(visited_at)=DATE('now') "
+            "AND ip_hash=? AND (session_id IS NULL OR session_id='') LIMIT 1",
+            (ip_hash,)
+        ).fetchone()
+        today_unique = existing is None
+
+    db.execute(
+        "INSERT INTO page_visits (session_id, ip_hash, user_agent, page, is_unique) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (session_id, ip_hash, user_agent, page, today_unique),
+    )
+    db.commit()
+    return {"ok": True}
+
+
 @router.get("/account-pnl")
 def get_public_account_pnl(request: Request):
     """#233: 계좌 누적 +/-% (KRW 금액 비공개).

--- a/src/cryptobot/api/routes/visits.py
+++ b/src/cryptobot/api/routes/visits.py
@@ -1,0 +1,61 @@
+"""#240: 방문자 통계 (admin 전용)."""
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+
+from cryptobot.api.auth import UserResponse, get_current_user
+from cryptobot.api.deps import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/visits", tags=["visits"])
+
+
+@router.get("/stats")
+def get_visit_stats(_: UserResponse = Depends(get_current_user), days: int = Query(30, ge=1, le=365)):
+    """방문자 통계 — 오늘/어제/7일/누적 + 일별 추이."""
+    db = get_db()
+
+    # 오늘
+    today = db.execute(
+        "SELECT COUNT(*) AS pv, SUM(CASE WHEN is_unique THEN 1 ELSE 0 END) AS uv "
+        "FROM page_visits WHERE DATE(visited_at, '+9 hours') = DATE('now', '+9 hours')"
+    ).fetchone()
+    # 어제
+    yesterday = db.execute(
+        "SELECT COUNT(*) AS pv, SUM(CASE WHEN is_unique THEN 1 ELSE 0 END) AS uv "
+        "FROM page_visits WHERE DATE(visited_at, '+9 hours') = DATE('now', '+9 hours', '-1 day')"
+    ).fetchone()
+    # 최근 7일
+    last_7 = db.execute(
+        "SELECT COUNT(*) AS pv, SUM(CASE WHEN is_unique THEN 1 ELSE 0 END) AS uv "
+        "FROM page_visits WHERE visited_at >= datetime('now', '-7 days')"
+    ).fetchone()
+    # 누적
+    total = db.execute(
+        "SELECT COUNT(*) AS pv, SUM(CASE WHEN is_unique THEN 1 ELSE 0 END) AS uv FROM page_visits"
+    ).fetchone()
+
+    # 일별 N일치
+    daily_rows = db.execute(
+        f"""
+        SELECT DATE(visited_at, '+9 hours') AS d,
+               COUNT(*) AS pv,
+               SUM(CASE WHEN is_unique THEN 1 ELSE 0 END) AS uv
+        FROM page_visits
+        WHERE visited_at >= datetime('now', '-{days} days')
+        GROUP BY d ORDER BY d ASC
+        """
+    ).fetchall()
+
+    def s(row):
+        d = dict(row) if row else {}
+        return {"pv": d.get("pv") or 0, "uv": d.get("uv") or 0}
+
+    return {
+        "today": s(today),
+        "yesterday": s(yesterday),
+        "last_7_days": s(last_7),
+        "total": s(total),
+        "daily": [{"date": dict(r)["d"], "pv": dict(r)["pv"] or 0, "uv": dict(r)["uv"] or 0} for r in daily_rows],
+    }

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -341,6 +341,19 @@ CREATE TABLE IF NOT EXISTS capital_deposits (
 );
 CREATE INDEX IF NOT EXISTS idx_capital_deposits_at ON capital_deposits(deposited_at DESC);
 
+-- #240: 페이지 방문자 추적 (admin 우선)
+CREATE TABLE IF NOT EXISTS page_visits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    visited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    session_id TEXT,
+    ip_hash TEXT,
+    user_agent TEXT,
+    page TEXT,
+    is_unique BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_visits_at ON page_visits(visited_at DESC);
+CREATE INDEX IF NOT EXISTS idx_visits_session ON page_visits(session_id);
+
 -- #245: 멀티 마켓 인덱스 (시장별 조회 최적화)
 CREATE INDEX IF NOT EXISTS idx_trades_market_ts ON trades(market, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_signals_market_ts ON trade_signals(market, timestamp DESC);

--- a/tests/test_visits_240.py
+++ b/tests/test_visits_240.py
@@ -1,0 +1,97 @@
+"""#240: 방문자 추적 + 통계 테스트."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cryptobot.data.database import Database
+
+
+@pytest.fixture
+def db_path():
+    tmpdir = tempfile.mkdtemp()
+    p = Path(tmpdir) / "test.db"
+    db = Database(p)
+    db.initialize()
+    db.close()
+    return p
+
+
+def _client(db_path):
+    from cryptobot.api.main import app
+    from cryptobot.api.auth import UserResponse, get_current_user
+    import cryptobot.api.routes.visits as v_mod
+    import cryptobot.api.routes.public as p_mod
+
+    fake = UserResponse(id=1, username="test", display_name="t", is_admin=True)
+    app.dependency_overrides[get_current_user] = lambda: fake
+
+    db = Database(db_path)
+    db.initialize()
+    v_mod.get_db = lambda: db
+    p_mod.get_db = lambda: db
+    return TestClient(app), db
+
+
+def test_page_visits_table_exists(db_path):
+    """initialize 후 page_visits 테이블 생성."""
+    db = Database(db_path); db.initialize()
+    rows = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='page_visits'"
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_visit_post_inserts_row(db_path):
+    """POST /visit → 1건 INSERT."""
+    client, db = _client(db_path)
+    r = client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})
+    assert r.status_code == 200
+    cnt = db.execute("SELECT COUNT(*) FROM page_visits").fetchone()[0]
+    assert cnt == 1
+
+
+def test_visit_first_today_marked_unique(db_path):
+    """그 날 첫 방문 → is_unique=True."""
+    client, db = _client(db_path)
+    client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})
+    row = db.execute("SELECT is_unique FROM page_visits WHERE session_id='s1'").fetchone()
+    assert dict(row)["is_unique"] == 1
+
+
+def test_visit_second_today_not_unique(db_path):
+    """같은 세션 두 번째 방문 → is_unique=False."""
+    client, db = _client(db_path)
+    client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})
+    client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})
+    rows = db.execute("SELECT is_unique FROM page_visits ORDER BY id").fetchall()
+    assert dict(rows[0])["is_unique"] == 1
+    assert dict(rows[1])["is_unique"] == 0
+
+
+def test_visits_stats_endpoint(db_path):
+    """GET /visits/stats — 인증 필요 + 카운트 정확."""
+    client, db = _client(db_path)
+    client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})
+    client.post("/api/public/visit", json={"session_id": "s2", "page": "/"})
+    client.post("/api/public/visit", json={"session_id": "s1", "page": "/"})  # dup
+
+    r = client.get("/api/visits/stats?days=7")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["today"]["pv"] == 3
+    assert data["today"]["uv"] == 2  # s1, s2 unique
+    assert data["total"]["pv"] == 3
+    assert "daily" in data
+
+
+def test_visit_no_session_id_still_works(db_path):
+    """session_id 없어도 IP 기반으로 동작."""
+    client, db = _client(db_path)
+    r = client.post("/api/public/visit", json={"page": "/"})
+    assert r.status_code == 200
+    cnt = db.execute("SELECT COUNT(*) FROM page_visits").fetchone()[0]
+    assert cnt == 1


### PR DESCRIPTION
page_visits 테이블 + POST /visit + GET /visits/stats. PublicDashboardPage 자동 ping. Admin 카드. 6건 테스트 통과.