### PR TITLE
feat: KIS 봇 실 API 잔고로 매수 (#281)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -429,11 +429,11 @@ export default function DashboardPage() {
             <thead>
               <tr>
                 <th style={{ textAlign: "left", padding: 6 }}>시장</th>
-                <th style={{ textAlign: "right", padding: 6 }}>시드</th>
+                <th style={{ textAlign: "right", padding: 6 }}>시드(장부)</th>
                 <th style={{ textAlign: "right", padding: 6 }}>실현 PnL</th>
                 <th style={{ textAlign: "right", padding: 6 }}>보유 원가</th>
-                <th style={{ textAlign: "right", padding: 6 }}>가용 예산</th>
-                <th style={{ textAlign: "right", padding: 6 }}>자체 자본</th>
+                <th style={{ textAlign: "right", padding: 6 }}>장부 가용</th>
+                <th style={{ textAlign: "right", padding: 6 }}>실제 잔고 (API)</th>
               </tr>
             </thead>
             <tbody>
@@ -447,15 +447,18 @@ export default function DashboardPage() {
                     {m.realized_pnl >= 0 ? "+" : ""}{Number(m.realized_pnl).toLocaleString()}원
                   </td>
                   <td style={{ textAlign: "right", padding: 6 }}>{Number(m.held_cost).toLocaleString()}원</td>
-                  <td style={{ textAlign: "right", padding: 6, fontWeight: 600 }}>{Number(m.available).toLocaleString()}원</td>
-                  <td style={{ textAlign: "right", padding: 6, fontWeight: 600 }}>{Number(m.current_capital).toLocaleString()}원</td>
+                  <td style={{ textAlign: "right", padding: 6 }}>{Number(m.available).toLocaleString()}원</td>
+                  <td style={{ textAlign: "right", padding: 6, fontWeight: 700, color: "var(--accent)" }}>
+                    {m.live?.available != null
+                      ? `${Number(m.live.available).toLocaleString()} ${m.live.currency || ""}`
+                      : <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>조회불가</span>}
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
           <div style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
-            💡 입금 50:50 분배: 한투 계좌에 N원 입금 → 한국/미국에 N/2씩 자동 등록.
-            이동: 시장 간 자본 재배치 (수익/손실 보정).
+            💡 <strong>실제 잔고 (API)</strong>가 봇이 매수에 쓰는 진짜 예산. 장부값은 입출금 이력 추적용.
           </div>
         </div>
       )}

--- a/src/cryptobot/api/routes/market_capital.py
+++ b/src/cryptobot/api/routes/market_capital.py
@@ -26,15 +26,57 @@ def _record(db, market: str, amount: float, source: str, note: str = "") -> int:
     return cur.lastrowid
 
 
+def _fetch_live_balance(market: str) -> dict:
+    """실제 KIS API 잔고 조회. 실패 시 None 반환 — UI가 '조회불가' 표시."""
+    from cryptobot.bot.config import config
+
+    if not config.kis.is_configured:
+        return {"available": None, "currency": None, "error": "KIS 미설정"}
+
+    try:
+        from cryptobot.exchange.kis.auth import KISTokenManager
+
+        tm = KISTokenManager(
+            app_key=config.kis.app_key,
+            app_secret=config.kis.app_secret,
+            is_paper=config.kis.is_paper,
+        )
+        if market == "kis_kr":
+            from cryptobot.exchange.kis_kr import KISKoreanExchange
+
+            ex = KISKoreanExchange(
+                token_manager=tm,
+                account_number=config.kis.account_number,
+                account_product_code=config.kis.account_product_code,
+                is_paper=config.kis.is_paper,
+            )
+            return {"available": ex.get_balance("KRW"), "currency": "KRW", "error": None}
+        if market == "kis_us":
+            from cryptobot.exchange.kis_us import KISUSExchange
+
+            ex = KISUSExchange(
+                token_manager=tm,
+                account_number=config.kis.account_number,
+                account_product_code=config.kis.account_product_code,
+                is_paper=config.kis.is_paper,
+            )
+            return {"available": ex.get_balance("USD"), "currency": "USD", "error": None}
+    except Exception as e:
+        logger.warning("실잔고 조회 실패 (%s): %s", market, e)
+        return {"available": None, "currency": None, "error": str(e)}
+    return {"available": None, "currency": None, "error": "unknown market"}
+
+
 @router.get("/status")
 def get_status(_: UserResponse = Depends(get_current_user)):
-    """시장별 시드/PnL/가용 예산."""
+    """시장별 장부(ledger) 상태 + 실제 KIS API 잔고."""
     db = get_db()
-    return {
-        "markets": [
-            {**get_market_budget_status(db, m)} for m in VALID_KIS_MARKETS
-        ]
-    }
+    markets = []
+    for m in VALID_KIS_MARKETS:
+        ledger = get_market_budget_status(db, m)
+        live = _fetch_live_balance(m)
+        markets.append({**ledger, "live": live})
+    return {"markets": markets}
 
 
 @router.get("/history")

--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -67,45 +67,45 @@ class KISStrategyParams:
 
 
 def calc_position_size(
-    available_budget_krw: float,
-    current_price_krw: float,
+    available_budget: float,
+    current_price: float,
     fractional: bool,
     params: KISStrategyParams = KISStrategyParams(),
 ) -> tuple[float, str]:
-    """매수 수량 계산.
+    """매수 수량 계산. 통화 무관 — budget/price만 같은 통화로 들어오면 OK.
 
     Args:
-        available_budget_krw: 시장 가용 예산 (KRW)
-        current_price_krw: 현재가 (KRW 환산. US는 USD×환율)
+        available_budget: 시장 가용 예산 (KR=KRW, US=USD)
+        current_price: 현재가 (KR=KRW, US=USD)
         fractional: True=소수점 매수 가능 (미국주식), False=1주 단위 (한국주식)
 
     Returns:
         (qty, reason). qty=0 이면 매수 불가, reason은 사유.
 
     설계:
-    - 종목당 한도: 시드 × max_position_per_symbol_pct / 100
+    - 종목당 한도: 가용예산 × max_position_per_symbol_pct / 100
     - 한국주식(1주 단위): qty = floor(한도 / 가격). 0이면 skip
     - 미국주식(소수점): qty = 한도 / 가격 (소수점 4자리)
     """
-    if available_budget_krw <= 0:
+    if available_budget <= 0:
         return 0.0, "가용 예산 없음"
-    if current_price_krw <= 0:
+    if current_price <= 0:
         return 0.0, "가격 정보 없음"
 
-    target = available_budget_krw * (params.max_position_per_symbol_pct / 100.0)
+    target = available_budget * (params.max_position_per_symbol_pct / 100.0)
 
     if not fractional:
-        qty = int(target // current_price_krw)
+        qty = int(target // current_price)
         if qty < 1:
             return 0.0, (
-                f"예산 부족 (한도 {target:,.0f} < 1주 가격 {current_price_krw:,.0f})"
+                f"예산 부족 (한도 {target:,.0f} < 1주 가격 {current_price:,.0f})"
             )
-        return float(qty), f"{qty}주 (한도 {target:,.0f}원)"
+        return float(qty), f"{qty}주 (한도 {target:,.0f})"
 
-    qty = round(target / current_price_krw, 4)
+    qty = round(target / current_price, 4)
     if qty < 0.001:
         return 0.0, "수량 < 0.001 (소수점 한도)"
-    return qty, f"{qty:.4f}주 (한도 {target:,.0f}원)"
+    return qty, f"{qty:.4f}주 (한도 {target:,.2f})"
 
 
 def _calc_rsi(prices: pd.Series, period: int = 14) -> float | None:

--- a/src/cryptobot/entrypoints/run_kis_kr.py
+++ b/src/cryptobot/entrypoints/run_kis_kr.py
@@ -30,7 +30,6 @@ from cryptobot.bot.kis_strategy import (
     evaluate_buy,
     evaluate_sell,
 )
-from cryptobot.bot.market_budget import get_available_budget
 from cryptobot.data.database import Database
 from cryptobot.data.recorder import DataRecorder
 from cryptobot.exceptions import APIError, ConfigError
@@ -199,15 +198,20 @@ class KISKoreanBot:
             logger.debug("%s 매수 미판정: %s", symbol, signal_.reason)
             return
 
-        budget = get_available_budget(self._db, "kis_kr")
+        # 실제 KIS API 잔고 사용 (#279 후속): 가정된 시드가 아닌 실잔고 기준
+        try:
+            budget = self._exchange.get_balance("KRW")
+        except APIError as e:
+            logger.warning("KRW 예수금 조회 실패 — 매수 스킵: %s", e)
+            return
         qty, size_reason = calc_position_size(
-            available_budget_krw=budget,
-            current_price_krw=price,
+            available_budget=budget,
+            current_price=price,
             fractional=False,
             params=KR_PARAMS,
         )
         if qty <= 0:
-            logger.info("%s 매수 신호이나 사이즈 0 (%s) — 스킵", symbol, size_reason)
+            logger.info("%s 매수 신호이나 사이즈 0 (잔고=%.0f원, %s) — 스킵", symbol, budget, size_reason)
             return
 
         logger.info(

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -30,7 +30,6 @@ from cryptobot.bot.kis_strategy import (
     evaluate_buy,
     evaluate_sell,
 )
-from cryptobot.bot.market_budget import get_available_budget
 from cryptobot.data.database import Database
 from cryptobot.data.recorder import DataRecorder
 from cryptobot.exceptions import APIError, ConfigError
@@ -58,7 +57,6 @@ DEFAULT_US_UNIVERSE = [
 ]
 
 TICK_INTERVAL_SEC = 60
-FX_RATE_KRW_PER_USD = 1380.0  # 추정 환율 (정확한 값은 잔고 reconcile로 보정)
 
 # 미국주식 보수적 파라미터 (소수점 매수 가능 → 30% 그대로)
 US_PARAMS = KISStrategyParams(
@@ -199,17 +197,20 @@ class KISUSBot:
             logger.debug("%s 매수 미판정: %s", symbol, signal_.reason)
             return
 
-        budget_krw = get_available_budget(self._db, "kis_us")
-        # KRW 환산하여 사이즈 계산 (전략 모듈은 단위 무관 — 동일 통화면 OK)
-        price_krw = price_usd * FX_RATE_KRW_PER_USD
+        # 실제 KIS API USD 예수금 사용 (#279 후속): 환율 고정값 제거
+        try:
+            budget_usd = self._exchange.get_balance("USD")
+        except APIError as e:
+            logger.warning("USD 예수금 조회 실패 — 매수 스킵: %s", e)
+            return
         qty, size_reason = calc_position_size(
-            available_budget_krw=budget_krw,
-            current_price_krw=price_krw,
+            available_budget=budget_usd,
+            current_price=price_usd,
             fractional=True,
             params=US_PARAMS,
         )
         if qty <= 0:
-            logger.info("%s 매수 신호이나 사이즈 0 (%s) — 스킵", symbol, size_reason)
+            logger.info("%s 매수 신호이나 사이즈 0 ($%.2f USD, %s) — 스킵", symbol, budget_usd, size_reason)
             return
 
         logger.info(

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -115,8 +115,8 @@ def test_sell_holds_when_trend_alive():
 
 def test_position_size_kr_integer_shares():
     qty, reason = calc_position_size(
-        available_budget_krw=200_000,
-        current_price_krw=70_000,
+        available_budget=200_000,
+        current_price=70_000,
         fractional=False,
         params=KISStrategyParams(max_position_per_symbol_pct=40.0),
     )
@@ -127,8 +127,8 @@ def test_position_size_kr_integer_shares():
 
 def test_position_size_kr_skip_when_too_expensive():
     qty, reason = calc_position_size(
-        available_budget_krw=200_000,
-        current_price_krw=300_000,  # 1주 < 한도
+        available_budget=200_000,
+        current_price=300_000,  # 1주 < 한도
         fractional=False,
         params=KISStrategyParams(max_position_per_symbol_pct=30.0),
     )
@@ -138,8 +138,8 @@ def test_position_size_kr_skip_when_too_expensive():
 
 def test_position_size_us_fractional():
     qty, reason = calc_position_size(
-        available_budget_krw=200_000,
-        current_price_krw=100_000,  # USD price × FX rate
+        available_budget=200_000,
+        current_price=100_000,  # USD price × FX rate
         fractional=True,
         params=KISStrategyParams(max_position_per_symbol_pct=30.0),
     )
@@ -150,8 +150,8 @@ def test_position_size_us_fractional():
 
 def test_position_size_zero_budget():
     qty, reason = calc_position_size(
-        available_budget_krw=0,
-        current_price_krw=100,
+        available_budget=0,
+        current_price=100,
         fractional=True,
     )
     assert qty == 0.0
@@ -161,8 +161,8 @@ def test_position_size_zero_budget():
 def test_position_size_us_skip_when_dust():
     # 가격이 너무 비싸서 0.001주 미만 — skip
     qty, reason = calc_position_size(
-        available_budget_krw=1_000,
-        current_price_krw=10_000_000,
+        available_budget=1_000,
+        current_price=10_000_000,
         fractional=True,
         params=KISStrategyParams(max_position_per_symbol_pct=30.0),
     )


### PR DESCRIPTION
## Summary
- KR/US 봇이 환경변수 시드 대신 KIS API 실 예수금(`get_balance("KRW"/"USD")`)으로 매수 결정
- 환율 고정값 1380 제거 — US 봇은 USD 예산/USD 가격으로 직접 계산
- Admin 대시보드에 "실제 잔고 (API)" 컬럼 추가, 장부값은 추적용으로 유지

## 동작
- KR 봇: KRW 예수금이 한도 미만이면 자동 skip (1주 가격 > 한도면 매수 안함)
- US 봇: USD 예수금 0이면 매수 skip — 사용자가 KIS HTS에서 KRW→USD 환전 후 매수 가능

## Test plan
- [x] `tests/test_kis_strategy.py` 16개 통과 (파라미터 리네이밍 반영)
- [x] 전체 499개 테스트 통과
- [x] TypeScript 빌드 OK

Related: #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)