### PR TITLE
refactor: KIS 봇 24h 재매수 쿨다운 제거 (#283)

### DIFF
--- a/src/cryptobot/api/routes/market_universe.py
+++ b/src/cryptobot/api/routes/market_universe.py
@@ -78,7 +78,7 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
                     "description": (
                         "매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK. "
                         "매도: 손절(-3%) → 트레일링(-2%) → 추세 기반 익절. "
-                        "24h 재매수 금지, 종목당 시드 30~40% 한도."
+                        "종목당 시드 30~40% 한도. 매수/매도 충돌은 분기로 차단."
                     ),
                     "take_profit_pct": kr_th.take_profit_pct,
                     "stop_loss_pct": kr_th.stop_loss_pct,
@@ -100,7 +100,7 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
                     "description": (
                         "매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK. "
                         "매도: 손절(-3%) → 트레일링(-2%) → 추세 기반 익절. "
-                        "24h 재매수 금지, 종목당 시드 30~40% 한도."
+                        "종목당 시드 30~40% 한도. 매수/매도 충돌은 분기로 차단."
                     ),
                     "take_profit_pct": us_th.take_profit_pct,
                     "stop_loss_pct": us_th.stop_loss_pct,

--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -20,8 +20,10 @@
   - 시드 × max_position_per_symbol_pct (기본 30%)
   - → 3종목 분산. 한 종목 망해도 시드의 30% 한도
 
-매수 cooldown:
-  - 같은 종목 24h 내 재매수 X (체결 직후 변동 노이즈 회피)
+매도 ↔ 매수 충돌 방지:
+  - 봇은 종목별로 보유 여부에 따라 분기 (보유 중→매도판단 / 미보유→매수판단)
+  - 즉 같은 틱 안에서 매도 직후 매수가 일어나지 않음 (구조적으로 보장)
+  - 다음 틱 (60초 후) 부터는 정상 평가 — 별도 쿨다운 없음
 """
 
 from __future__ import annotations
@@ -63,7 +65,6 @@ class KISStrategyParams:
     stop_loss_pct: float = -3.0         # 손절 임계
     trailing_stop_pct: float = -2.0     # 고점 대비 트레일링 (수익 중일 때만)
     max_position_per_symbol_pct: float = 30.0  # 종목당 시드 % (분산)
-    rebuy_cooldown_hours: int = 24       # 같은 종목 재매수 금지 시간
 
 
 def calc_position_size(

--- a/src/cryptobot/entrypoints/run_kis_kr.py
+++ b/src/cryptobot/entrypoints/run_kis_kr.py
@@ -6,7 +6,7 @@ KIS 한국주식 어댑터 + 코스피 우량주 풀 + 보수적 매매 룰 (#27
 매매 룰 (`bot.kis_strategy` 모듈):
 - 매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK
 - 매도: 손절(-3%) → 트레일링 스탑(-2% from peak) → 추세 기반 익절
-- 종목당 시드의 30% 한도 (1주 단위, 우량주). 24h 재매수 금지.
+- 종목당 시드의 30% 한도 (1주 단위, 우량주). 매수/매도 충돌은 분기 구조로 방지.
 
 사용법:
     python -m cryptobot.entrypoints.run_kis_kr
@@ -20,7 +20,7 @@ import logging
 import signal
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from cryptobot.bot.config import config
@@ -65,7 +65,6 @@ KR_PARAMS = KISStrategyParams(
     stop_loss_pct=-3.0,
     trailing_stop_pct=-2.0,
     max_position_per_symbol_pct=40.0,  # 작은 시드 + 우량주 가격대 고려
-    rebuy_cooldown_hours=24,
 )
 
 
@@ -75,7 +74,7 @@ class KISKoreanBot:
     각 종목 60초마다 폴링 → kis_strategy 룰 매매.
     - 매수: 보수적 4중 조건. 시드의 max_position_per_symbol_pct% 한도, 1주 단위.
     - 매도: 손절/트레일링/추세 기반 익절.
-    - 24h 재매수 금지로 같은 종목 노이즈 회피.
+    - 매수/매도 충돌은 분기(`if holdings > 0`)로 구조적 차단 — 같은 틱에 양쪽 평가 X.
     """
 
     def __init__(self) -> None:
@@ -184,9 +183,6 @@ class KISKoreanBot:
             logger.debug("%s 보유 유지: %s", symbol, signal_.reason)
 
     def _evaluate_buy(self, symbol: str, price: float) -> None:
-        if self._is_in_rebuy_cooldown(symbol):
-            return
-
         try:
             df = self._exchange.get_ohlcv(symbol, count=80)
         except APIError as e:
@@ -223,31 +219,6 @@ class KISKoreanBot:
             size_reason,
         )
         self._buy(symbol, qty, price, signal_.reason)
-
-    def _is_in_rebuy_cooldown(self, symbol: str) -> bool:
-        cutoff = datetime.now(KST) - timedelta(hours=KR_PARAMS.rebuy_cooldown_hours)
-        row = self._db.execute(
-            "SELECT MAX(timestamp) AS ts FROM trades "
-            "WHERE coin = ? AND market = 'kis_kr' AND side = 'buy'",
-            (symbol,),
-        ).fetchone()
-        if not row:
-            return False
-        last_ts = dict(row).get("ts")
-        if not last_ts:
-            return False
-        try:
-            last_dt = datetime.fromisoformat(str(last_ts).replace("Z", "+00:00"))
-            if last_dt.tzinfo is None:
-                last_dt = last_dt.replace(tzinfo=KST)
-        except (TypeError, ValueError):
-            return False
-        if last_dt > cutoff:
-            logger.debug(
-                "%s 24h 재매수 쿨다운 (마지막 %s)", symbol, last_dt.strftime("%Y-%m-%d %H:%M")
-            )
-            return True
-        return False
 
     def _buy(self, symbol: str, qty: float, price: float, reason: str) -> None:
         result = self._exchange.buy_market(symbol, qty)

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -6,7 +6,7 @@ NY 정규장 09:30~16:00 (KST 22:30~06:00, 서머타임 23:30~06:00) 동작.
 매매 룰 (`bot.kis_strategy` 모듈):
 - 매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK
 - 매도: 손절(-3%) → 트레일링 스탑(-2%) → 추세 기반 익절
-- 종목당 시드의 30% 한도 (소수점 매수 가능). 24h 재매수 금지.
+- 종목당 시드의 30% 한도 (소수점 매수 가능). 매수/매도 충돌은 분기 구조로 방지.
 
 사용법:
     python -m cryptobot.entrypoints.run_kis_us
@@ -20,7 +20,7 @@ import logging
 import signal
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from cryptobot.bot.config import config
@@ -65,7 +65,6 @@ US_PARAMS = KISStrategyParams(
     stop_loss_pct=-3.0,
     trailing_stop_pct=-2.0,
     max_position_per_symbol_pct=30.0,
-    rebuy_cooldown_hours=24,
 )
 
 
@@ -183,9 +182,6 @@ class KISUSBot:
             logger.debug("%s 보유 유지: %s", symbol, signal_.reason)
 
     def _evaluate_buy(self, symbol: str, price_usd: float) -> None:
-        if self._is_in_rebuy_cooldown(symbol):
-            return
-
         try:
             df = self._exchange.get_ohlcv(symbol, count=80)
         except APIError as e:
@@ -222,31 +218,6 @@ class KISUSBot:
             size_reason,
         )
         self._buy(symbol, qty, price_usd, signal_.reason)
-
-    def _is_in_rebuy_cooldown(self, symbol: str) -> bool:
-        cutoff = datetime.now(KST) - timedelta(hours=US_PARAMS.rebuy_cooldown_hours)
-        row = self._db.execute(
-            "SELECT MAX(timestamp) AS ts FROM trades "
-            "WHERE coin = ? AND market = 'kis_us' AND side = 'buy'",
-            (symbol,),
-        ).fetchone()
-        if not row:
-            return False
-        last_ts = dict(row).get("ts")
-        if not last_ts:
-            return False
-        try:
-            last_dt = datetime.fromisoformat(str(last_ts).replace("Z", "+00:00"))
-            if last_dt.tzinfo is None:
-                last_dt = last_dt.replace(tzinfo=KST)
-        except (TypeError, ValueError):
-            return False
-        if last_dt > cutoff:
-            logger.debug(
-                "%s 24h 재매수 쿨다운 (마지막 %s)", symbol, last_dt.strftime("%Y-%m-%d %H:%M")
-            )
-            return True
-        return False
 
     def _buy(self, symbol: str, qty: float, price_usd: float, reason: str) -> None:
         result = self._exchange.buy_market(symbol, qty)

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -179,4 +179,3 @@ def test_default_params_match_doc():
     assert p.stop_loss_pct == -3.0
     assert p.trailing_stop_pct == -2.0
     assert p.max_position_per_symbol_pct == 30.0
-    assert p.rebuy_cooldown_hours == 24


### PR DESCRIPTION
## Summary
- KIS 봇의 `rebuy_cooldown_hours=24` 제거. 사용자 의도(같은 틱 매수/매도 충돌 방지)는 이미 if/else 분기로 보장됨
- 종목별 한 틱당 매수 or 매도 중 하나만 평가되므로 추가 쿨다운 불필요
- 정상 매매 기회(반등 진입) 차단 회피

## Test plan
- [x] 전체 499개 테스트 통과
- [x] `_is_in_rebuy_cooldown` 메서드 + import 정리

Related: #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)