### PR TITLE
feat: Admin 실데이터 반영 + 단타모드 임계값 자동 조정 (#287)

### DIFF
--- a/src/cryptobot/api/routes/market_universe.py
+++ b/src/cryptobot/api/routes/market_universe.py
@@ -40,13 +40,21 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
             "params_json": d.get("default_params_json"),
         }
 
-    # KIS 한국 종목 풀 (코드에 하드코딩됨 — 추후 DB로 옮길 수 있음)
+    # KIS 풀 — 미국 봇은 env 오버라이드 반영 (#285)
     from cryptobot.entrypoints.run_kis_kr import DEFAULT_KOSPI_UNIVERSE
-    from cryptobot.entrypoints.run_kis_us import DEFAULT_US_UNIVERSE
+    from cryptobot.entrypoints.run_kis_us import _build_params, _parse_universe
     from cryptobot.bot.profit_threshold import get_thresholds
 
+    us_universe = _parse_universe()  # env KIS_US_UNIVERSE 반영
+    us_params = _build_params(len(us_universe))
     kr_th = get_thresholds("kis_kr")
-    us_th = get_thresholds("kis_us")
+
+    # DB 거래 토글 상태
+    def _flag(key: str) -> bool:
+        r = db.execute("SELECT value FROM bot_config WHERE key = ?", (key,)).fetchone()
+        return str(dict(r)["value"]).lower() == "true" if r else True
+    kr_trading = _flag("kis_kr_trading_enabled")
+    us_trading = _flag("kis_us_trading_enabled")
 
     return {
         "markets": [
@@ -68,6 +76,7 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
                 "display_name": "🇰🇷 한국주식 (KIS)",
                 "symbols": list(DEFAULT_KOSPI_UNIVERSE),
                 "symbol_count": len(DEFAULT_KOSPI_UNIVERSE),
+                "trading_enabled": kr_trading,
                 "strategy": {
                     "name": "kis_conservative",
                     "display_name": "KIS 보수적 전략 (#279)",
@@ -76,9 +85,9 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
                 "rules": {
                     "type": "kis_conservative",
                     "description": (
+                        f"{'✅ 거래 ON' if kr_trading else '⏸️ 거래 OFF (DB 토글)'}. "
                         "매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK. "
-                        "매도: 손절(-3%) → 트레일링(-2%) → 추세 기반 익절. "
-                        "종목당 시드 30~40% 한도. 매수/매도 충돌은 분기로 차단."
+                        "매도: 손절(-3%) → 트레일링(-2%) → 추세 기반 익절."
                     ),
                     "take_profit_pct": kr_th.take_profit_pct,
                     "stop_loss_pct": kr_th.stop_loss_pct,
@@ -88,23 +97,30 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
             {
                 "market": "kis_us",
                 "display_name": "🇺🇸 미국주식 (KIS)",
-                "symbols": list(DEFAULT_US_UNIVERSE),
-                "symbol_count": len(DEFAULT_US_UNIVERSE),
+                "symbols": us_universe,
+                "symbol_count": len(us_universe),
+                "trading_enabled": us_trading,
                 "strategy": {
                     "name": "kis_conservative",
-                    "display_name": "KIS 보수적 전략 (#279)",
+                    "display_name": (
+                        f"KIS {'단타(데일리)' if us_params.day_trading_mode else '스윙'} 전략"
+                    ),
                     "params_json": None,
                 },
                 "rules": {
                     "type": "kis_conservative",
                     "description": (
-                        "매수: RSI≤35 AND 가격<MA20 AND 가격>MA60×0.92 AND 거래량 OK. "
-                        "매도: 손절(-3%) → 트레일링(-2%) → 추세 기반 익절. "
-                        "종목당 시드 30~40% 한도. 매수/매도 충돌은 분기로 차단."
+                        f"{'✅ 거래 ON' if us_trading else '⏸️ 거래 OFF (DB 토글)'} | "
+                        f"{'단타(마감 강제청산)' if us_params.day_trading_mode else '스윙'} | "
+                        f"매수: RSI≤{us_params.rsi_oversold:.0f} AND 가격<MA20 AND MA60×0.92 위 | "
+                        f"종목당 한도 {us_params.max_position_per_symbol_pct:.1f}% (= 100/N)"
                     ),
-                    "take_profit_pct": us_th.take_profit_pct,
-                    "stop_loss_pct": us_th.stop_loss_pct,
-                    "fee_guard_pct": us_th.fee_guard_pct,
+                    "take_profit_pct": us_params.take_profit_pct,
+                    "stop_loss_pct": us_params.stop_loss_pct,
+                    "trailing_stop_pct": us_params.trailing_stop_pct,
+                    "day_trading_mode": us_params.day_trading_mode,
+                    "no_buy_window_min": us_params.no_buy_window_minutes_before_close,
+                    "force_sell_window_min": us_params.force_sell_window_minutes_before_close,
                 },
             },
         ]

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -80,17 +80,29 @@ def _parse_universe() -> list[str]:
 
 
 def _build_params(universe_size: int) -> KISStrategyParams:
-    """env 기반 전략 파라미터 생성. 종목당 한도는 100/N로 자동."""
+    """env 기반 전략 파라미터 생성.
+
+    종목당 한도는 100/N로 자동 (N=풀 크기).
+    단타모드 ON일 때 손절/익절/트레일링 디폴트가 자동으로 단타용으로 좁아짐:
+    - 스윙: TP +10% / SL -10% / TR -3%
+    - 단타: TP +2.5% / SL -1.5% / TR -1.0% (하루 안에 발동 가능한 폭)
+    env로 명시적 오버라이드 가능 (KIS_US_TAKE_PROFIT_PCT 등).
+    """
     if universe_size <= 0:
         universe_size = 1
+    is_day_trading = os.getenv("KIS_US_DAY_TRADING", "false").lower() == "true"
+    # 모드별 디폴트
+    default_tp = "2.5" if is_day_trading else "10"
+    default_sl = "-1.5" if is_day_trading else "-10"
+    default_tr = "-1.0" if is_day_trading else "-3"
     return KISStrategyParams(
         rsi_oversold=float(os.getenv("KIS_US_RSI_OVERSOLD", "35")),
         rsi_overbought=float(os.getenv("KIS_US_RSI_OVERBOUGHT", "70")),
-        take_profit_pct=float(os.getenv("KIS_US_TAKE_PROFIT_PCT", "10")),
-        stop_loss_pct=float(os.getenv("KIS_US_STOP_LOSS_PCT", "-10")),
-        trailing_stop_pct=float(os.getenv("KIS_US_TRAILING_PCT", "-3")),
+        take_profit_pct=float(os.getenv("KIS_US_TAKE_PROFIT_PCT", default_tp)),
+        stop_loss_pct=float(os.getenv("KIS_US_STOP_LOSS_PCT", default_sl)),
+        trailing_stop_pct=float(os.getenv("KIS_US_TRAILING_PCT", default_tr)),
         max_position_per_symbol_pct=100.0 / universe_size,
-        day_trading_mode=os.getenv("KIS_US_DAY_TRADING", "false").lower() == "true",
+        day_trading_mode=is_day_trading,
         no_buy_window_minutes_before_close=int(os.getenv("KIS_US_NO_BUY_BEFORE_CLOSE_MIN", "30")),
         force_sell_window_minutes_before_close=int(os.getenv("KIS_US_FORCE_SELL_BEFORE_CLOSE_MIN", "10")),
     )

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -242,6 +242,36 @@ def test_build_params_thresholds_overridable(monkeypatch):
     assert p.trailing_stop_pct == -1.5
 
 
+def test_build_params_day_trading_thresholds_default(monkeypatch):
+    """단타모드 ON 시 디폴트가 단타용으로 좁아짐."""
+    from cryptobot.entrypoints.run_kis_us import _build_params
+
+    monkeypatch.delenv("KIS_US_TAKE_PROFIT_PCT", raising=False)
+    monkeypatch.delenv("KIS_US_STOP_LOSS_PCT", raising=False)
+    monkeypatch.delenv("KIS_US_TRAILING_PCT", raising=False)
+    monkeypatch.setenv("KIS_US_DAY_TRADING", "true")
+    p = _build_params(universe_size=1)
+    assert p.day_trading_mode is True
+    assert p.take_profit_pct == 2.5
+    assert p.stop_loss_pct == -1.5
+    assert p.trailing_stop_pct == -1.0
+
+
+def test_build_params_swing_thresholds_default(monkeypatch):
+    """스윙(디폴트) 모드는 보수 견딤 임계값."""
+    from cryptobot.entrypoints.run_kis_us import _build_params
+
+    monkeypatch.delenv("KIS_US_TAKE_PROFIT_PCT", raising=False)
+    monkeypatch.delenv("KIS_US_STOP_LOSS_PCT", raising=False)
+    monkeypatch.delenv("KIS_US_TRAILING_PCT", raising=False)
+    monkeypatch.setenv("KIS_US_DAY_TRADING", "false")
+    p = _build_params(universe_size=20)
+    assert p.day_trading_mode is False
+    assert p.take_profit_pct == 10.0
+    assert p.stop_loss_pct == -10.0
+    assert p.trailing_stop_pct == -3.0
+
+
 # ---- DB 기반 거래 토글 (#285) ----
 
 def _setup_temp_db(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Admin /api/market-universe가 env KIS_US_UNIVERSE 오버라이드 반영, DB 거래토글/단타모드 표시
- 단타모드 ON 시 디폴트 임계값 자동 좁아짐 (TP +2.5% / SL -1.5% / TR -1%)
- 스윙 모드는 기존 +10%/-10%/-3% 유지

## Test plan
- [x] 29개 kis_strategy 테스트 통과
- [x] 전체 512개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)