### PR TITLE
fix: KIS 잔고 API 수정 + 대시보드 탭 분리 (#289)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -34,6 +34,7 @@ export default function DashboardPage() {
   const [marketStats, setMarketStats] = useState<any>(null);  // #254 6단계
   const [marketCapital, setMarketCapital] = useState<any>(null);  // #277
   const [marketUniverse, setMarketUniverse] = useState<any>(null);  // #278
+  const [tab, setTab] = useState<"all" | "coin" | "kis">("all");  // #287 탭
   const [loading, setLoading] = useState(true);
 
   const fetchAll = useCallback(() => {
@@ -91,6 +92,31 @@ export default function DashboardPage() {
         </button>
       </div>
 
+      {/* #287 탭: 전체 / 코인 / KIS */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 16, borderBottom: "1px solid var(--border)" }}>
+        {([
+          { id: "all", label: "전체" },
+          { id: "coin", label: "🪙 코인 (Upbit)" },
+          { id: "kis", label: "📈 KIS 주식" },
+        ] as const).map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            style={{
+              padding: "8px 16px", border: "none", cursor: "pointer", fontSize: 13,
+              fontWeight: tab === t.id ? 700 : 400,
+              borderBottom: tab === t.id ? "2px solid #4a9eff" : "2px solid transparent",
+              background: "transparent",
+              color: tab === t.id ? "#4a9eff" : "var(--text-secondary)",
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* === 코인 섹션 === */}
+      {(tab === "all" || tab === "coin") && <>
       {/* KPI Cards */}
       {(() => {
         const pos = positions?.positions || [];
@@ -339,12 +365,21 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* #278: 시장별 모니터링 종목 + 활성 전략 */}
+      {/* 코인 섹션 끝 */}
+      </>}
+
+      {/* === KIS/공통: 시장별 모니터링 카드 (탭별 필터) === */}
       {marketUniverse?.markets?.length > 0 && (
         <div className="card" style={{ marginTop: 16 }}>
-          <div className="card-title">시장별 모니터링 + 전략</div>
+          <div className="card-title">
+            {tab === "coin" ? "코인 전략" : tab === "kis" ? "KIS 주식 전략" : "시장별 모니터링 + 전략"}
+          </div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: 12 }}>
-            {marketUniverse.markets.map((m: any) => (
+            {marketUniverse.markets.filter((m: any) => {
+              if (tab === "coin") return m.market === "upbit";
+              if (tab === "kis") return m.market === "kis_kr" || m.market === "kis_us";
+              return true;
+            }).map((m: any) => (
               <div key={m.market} style={{ border: "1px solid var(--border)", borderRadius: 10, padding: 14 }}>
                 <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 8 }}>{m.display_name}</div>
                 <div style={{ fontSize: 12, color: "var(--text-secondary)", marginBottom: 6 }}>
@@ -384,8 +419,8 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* #277: KIS 시장별 시드/자본 */}
-      {marketCapital?.markets?.length > 0 && (
+      {/* === KIS 섹션: 자본 + 단타모드 표시 === */}
+      {(tab === "all" || tab === "kis") && marketCapital?.markets?.length > 0 && (
         <div className="card" style={{ marginTop: 16 }}>
           <div className="card-title" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span>KIS 시장별 자본</span>

--- a/admin/src/pages/PublicDashboardPage.tsx
+++ b/admin/src/pages/PublicDashboardPage.tsx
@@ -40,6 +40,8 @@ export default function PublicDashboardPage() {
   const [newsIndex, setNewsIndex] = useState(0);
   const [analysisIndex, setAnalysisIndex] = useState(0);
   const [showAllStrategies, setShowAllStrategies] = useState(false);
+  // #287 탭 (코인/KIS 분리)
+  const [tab, setTab] = useState<"coin" | "kis">("coin");
 
   const fetchAll = useCallback(() => {
     const base = API.replace(/\/api$/, "");
@@ -184,6 +186,41 @@ export default function PublicDashboardPage() {
         </div>
       </div>
 
+      {/* #287 탭 — 코인 / KIS */}
+      <div style={{ display: "flex", gap: 4, margin: "12px 0 16px", borderBottom: "1px solid var(--border-color, #ddd)" }}>
+        {([
+          { id: "coin", label: "🪙 코인 (Upbit)" },
+          { id: "kis", label: "📈 KIS 미국주식" },
+        ] as const).map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            style={{
+              padding: "10px 18px", border: "none", cursor: "pointer", fontSize: 14,
+              fontWeight: tab === t.id ? 700 : 500,
+              borderBottom: tab === t.id ? "2px solid #4a9eff" : "2px solid transparent",
+              background: "transparent",
+              color: tab === t.id ? "#4a9eff" : "var(--text-secondary, #666)",
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "kis" && (
+        <div style={{ padding: 32, textAlign: "center", border: "1px dashed var(--border-color, #ccc)", borderRadius: 12 }}>
+          <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>📈 KIS 미국주식 봇</div>
+          <div style={{ fontSize: 13, color: "var(--text-secondary, #666)", marginBottom: 16 }}>
+            단타(데일리) 모드 운영 중. 누적 손익률 + 매매 내역 곧 추가 예정.
+          </div>
+          <div style={{ fontSize: 12, color: "var(--text-secondary, #888)" }}>
+            현재는 admin 대시보드(KIS 탭)에서 확인 가능합니다.
+          </div>
+        </div>
+      )}
+
+      {tab === "coin" && <>
       {/* #237 Hero: 누적 손익률 + 큰 차트 (전체 폭) */}
       <div className="pnl-hero">
         <div className="pnl-hero-top">
@@ -758,6 +795,7 @@ export default function PublicDashboardPage() {
           </div>
         </div>
       )}
+      </>}
 
       {/* 면책 조항 + 푸터 */}
       <div style={{ textAlign: "center", padding: "48px 24px 24px", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.8 }}>

--- a/src/cryptobot/exchange/kis_us.py
+++ b/src/cryptobot/exchange/kis_us.py
@@ -148,19 +148,27 @@ class KISUSExchange(Exchange):
         """자산별 잔고.
 
         Args:
-            asset: "USD"(예수금) / "KRW"(원화 예수금) / 종목 ticker (예: "NVDA")
-        """
-        data = self._inquire_balance()
+            asset: "USD"(외화예수금) / "KRW"(원화예수금) / 종목 ticker (예: "NVDA")
 
-        if asset in ("USD", "KRW"):
-            output2 = data.get("output2", {})
-            if asset == "USD":
-                # frcr_dncl_amt1 = 외화예수금
-                return float(output2.get("frcr_dncl_amt1", 0))
-            # KRW 예수금
-            return float(output2.get("krw_dncl_amt", 0))
+        USD/KRW 예수금은 inquire-present-balance API의 output2/output3에서 조회.
+        - output2: 통화별 외화 잔고 (USD 단위 frcr_dncl_amt_2)
+        - output3.tot_dncl_amt: 원화예수금 (KRW)
+        종목 보유는 inquire-balance API의 output1.
+        """
+        if asset == "USD":
+            present = self._inquire_present_balance()
+            for row in present.get("output2") or []:
+                if row.get("crcy_cd") == "USD":
+                    return float(row.get("frcr_dncl_amt_2", 0))
+            return 0.0
+
+        if asset == "KRW":
+            present = self._inquire_present_balance()
+            output3 = present.get("output3") or {}
+            return float(output3.get("tot_dncl_amt", 0))
 
         # 종목별 보유 수량 (소수점 가능)
+        data = self._inquire_balance()
         for row in data.get("output1", []):
             if row.get("ovrs_pdno") == asset:
                 return float(row.get("ovrs_cblc_qty", 0))
@@ -424,3 +432,47 @@ class KISUSExchange(Exchange):
                 "CTX_AREA_NK200": "",
             },
         )
+
+    def _inquire_present_balance(self) -> dict:
+        """해외주식 현재잔고 조회 — 외화예수금/원화예수금/환율 포함.
+
+        TR_ID: CTRP6504R (실전 전용. 모의 미지원).
+
+        응답 구조:
+        - output2[]: 통화별 외화 잔고
+            * crcy_cd: USD
+            * frcr_dncl_amt_2: 외화예수금 (USD 단위)
+            * frst_bltn_exrt: 환율 (KRW/USD)
+            * frcr_drwg_psbl_amt_1: 외화 출금가능금액
+        - output3: 계좌 요약
+            * tot_dncl_amt: 원화예수금
+            * tot_asst_amt: 총자산 (KRW)
+            * frcr_evlu_tota: 외화평가총액 (KRW 환산)
+        """
+        if self._is_paper:
+            # 모의는 CTRP6504R 미지원 — 빈 응답 반환
+            return {"output2": [], "output3": {}}
+        return self._client.get(
+            "/uapi/overseas-stock/v1/trading/inquire-present-balance",
+            tr_id="CTRP6504R",
+            params={
+                "CANO": self._cano,
+                "ACNT_PRDT_CD": self._acnt_prdt_cd,
+                "WCRC_FRCR_DVSN_CD": "02",  # 02=외화 기준
+                "NATN_CD": "840",            # 840=미국
+                "TR_MKET_CD": "00",
+                "INQR_DVSN_CD": "00",
+            },
+        )
+
+    def get_fx_rate_krw_per_usd(self) -> float | None:
+        """현재 KRW/USD 환율 (KIS 잔고 응답의 frst_bltn_exrt). 조회 실패 시 None."""
+        try:
+            present = self._inquire_present_balance()
+            for row in present.get("output2") or []:
+                if row.get("crcy_cd") == "USD":
+                    rate = float(row.get("frst_bltn_exrt", 0))
+                    return rate if rate > 0 else None
+        except Exception as e:
+            logger.warning("FX rate 조회 실패: %s", e)
+        return None

--- a/tests/test_kis_us.py
+++ b/tests/test_kis_us.py
@@ -88,11 +88,16 @@ def test_get_current_price(tmp_path: Path):
 
 
 def test_get_balance_usd(tmp_path: Path):
+    """#287 변경: USD/KRW는 inquire-present-balance(CTRP6504R) 응답 사용."""
     ex = _build(tmp_path)
+    # inquire-present-balance 응답 — output2는 통화별 list, output3는 요약 dict
     fake = _mock_resp(
         {
             "output1": [],
-            "output2": {"frcr_dncl_amt1": "150.50", "krw_dncl_amt": "200000"},
+            "output2": [
+                {"crcy_cd": "USD", "frcr_dncl_amt_2": "150.50", "frst_bltn_exrt": "1450.80"}
+            ],
+            "output3": {"tot_dncl_amt": "200000", "frcr_evlu_tota": "218400"},
         }
     )
     with patch("requests.get", return_value=fake):


### PR DESCRIPTION
## Summary
- KIS USD/KRW 잔고 정확히 조회 (inquire-present-balance API)
- 환율(KRW/USD) 헬퍼 추가
- Admin 대시보드 탭 (전체/코인/KIS)
- Public 대시보드 탭 (코인/KIS)
- 코인 봇 손익 보정 (40만원 출금 반영)

## 검증 결과 (실 API)
- USD 잔고: $273.24 ✓
- KRW 잔고: 1원 ✓
- 환율: 1450.8 ✓

## Test plan
- [x] 12개 kis_us 테스트 통과 (mock 응답 새 구조 반영)
- [x] 전체 512개 테스트 통과
- [x] TypeScript 빌드 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)