### PR TITLE
fix: KIS 시세 EXCD 3글자 분리 + DB 종목 풀 (#293)

### DIFF
--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -354,6 +354,21 @@ CREATE TABLE IF NOT EXISTS market_capital_deposits (
 );
 CREATE INDEX IF NOT EXISTS idx_market_capital_market_at ON market_capital_deposits(market, deposited_at DESC);
 
+-- #293: KIS 미국주식 종목 풀 (DB 기반, admin 관리 가능).
+-- enabled=TRUE 종목만 봇이 모니터링/매매. 후보는 enabled=FALSE로 유지.
+CREATE TABLE IF NOT EXISTS kis_us_symbols (
+    ticker TEXT PRIMARY KEY,
+    display_name TEXT,
+    exchange TEXT NOT NULL DEFAULT 'NASD',          -- NASD/NYSE/AMEX
+    is_integer_only BOOLEAN NOT NULL DEFAULT FALSE, -- 정수 매매만 (레버리지 ETF 등)
+    category TEXT,                                   -- bigtech/semi/leveraged/crypto/ev/ai/etf
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,          -- 활성 (모니터링 풀 포함 여부)
+    note TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_kis_us_symbols_enabled ON kis_us_symbols(enabled);
+
 -- #240: 페이지 방문자 추적 (admin 우선)
 CREATE TABLE IF NOT EXISTS page_visits (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -966,6 +981,61 @@ class Database:
                         (k, default_val, dn, desc),
                     )
                     logger.info("#285: bot_config %s=%s 추가", k, default_val)
+
+            # #293: KIS 미국 종목 풀 시드 (오늘 세션에서 선정된 후보들)
+            # SOXL만 enabled=TRUE (사용자 첫날 단타 종목), 나머지는 후보로 비활성
+            count = conn.execute("SELECT COUNT(*) FROM kis_us_symbols").fetchone()[0]
+            if count == 0:
+                _seed = [
+                    # ticker, display_name, exchange, integer_only, category, enabled, note
+                    # 빅테크
+                    ("AAPL",  "Apple",          "NASD", 0, "bigtech", 0, ""),
+                    ("MSFT",  "Microsoft",      "NASD", 0, "bigtech", 0, ""),
+                    ("GOOGL", "Alphabet",       "NASD", 0, "bigtech", 0, ""),
+                    ("AMZN",  "Amazon",         "NASD", 0, "bigtech", 0, ""),
+                    ("META",  "Meta",           "NASD", 0, "bigtech", 0, ""),
+                    # 반도체
+                    ("NVDA",  "Nvidia",         "NASD", 0, "semi",    0, ""),
+                    ("AMD",   "AMD",            "NASD", 0, "semi",    0, ""),
+                    ("TSM",   "TSMC",           "NYSE", 0, "semi",    0, ""),
+                    ("AVGO",  "Broadcom",       "NASD", 0, "semi",    0, ""),
+                    ("ASML",  "ASML",           "NASD", 0, "semi",    0, ""),
+                    ("SNDK",  "SanDisk",        "NASD", 0, "semi",    0, "2025년 WDC 분사"),
+                    # 레버리지 ETF (정수 매매)
+                    ("SOXL",  "Direxion Semi Bull 3X",        "AMEX", 1, "leveraged", 1, "기본 활성 — 첫날 단타"),
+                    ("SOXS",  "Direxion Semi Bear 3X",        "AMEX", 1, "leveraged", 0, "반도체 하락 베팅"),
+                    ("TQQQ",  "ProShares UltraPro QQQ 3X",    "AMEX", 1, "leveraged", 0, "나스닥100 3X"),
+                    ("SQQQ",  "ProShares UltraPro Short 3X",  "AMEX", 1, "leveraged", 0, "나스닥100 -3X"),
+                    ("USD",   "ProShares Ultra Semi 2X",      "AMEX", 1, "leveraged", 0, "반도체 2X"),
+                    ("TECL",  "Direxion Tech Bull 3X",        "AMEX", 1, "leveraged", 0, "기술주 3X"),
+                    ("NVDL",  "GraniteShares NVDA 2X",        "AMEX", 1, "leveraged", 0, "엔비디아 2X"),
+                    ("SNXX",  "Tradr 2X Long SNDK",           "AMEX", 1, "leveraged", 0, "SanDisk 2X"),
+                    # 크립토 노출
+                    ("COIN",  "Coinbase",       "NASD", 0, "crypto",  0, ""),
+                    ("MSTR",  "MicroStrategy",  "NASD", 0, "crypto",  0, "BTC 보유"),
+                    ("HOOD",  "Robinhood",      "NASD", 0, "crypto",  0, ""),
+                    # EV / 모빌리티
+                    ("TSLA",  "Tesla",          "NASD", 0, "ev",      0, ""),
+                    ("RIVN",  "Rivian",         "NASD", 0, "ev",      0, ""),
+                    # AI / 소프트웨어
+                    ("PLTR",  "Palantir",       "NASD", 0, "ai",      0, ""),
+                    ("ARM",   "ARM Holdings",   "NASD", 0, "ai",      0, ""),
+                    ("NFLX",  "Netflix",        "NASD", 0, "ai",      0, ""),
+                    # ETF (1X — 시장 노출용, 변동성 낮아 RSI 신호 적음)
+                    ("QQQ",   "Nasdaq 100",     "NASD", 0, "etf",     0, ""),
+                    ("SPY",   "S&P 500",        "AMEX", 0, "etf",     0, ""),
+                    ("VOO",   "Vanguard S&P 500","AMEX", 0, "etf",     0, ""),
+                    ("SOXX",  "iShares Semi",   "NASD", 0, "etf",     0, ""),
+                    ("SMH",   "VanEck Semi",    "NASD", 0, "etf",     0, ""),
+                ]
+                for row in _seed:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO kis_us_symbols "
+                        "(ticker, display_name, exchange, is_integer_only, category, enabled, note) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        row,
+                    )
+                logger.info("#293: kis_us_symbols 시드 %d종목 (SOXL 활성)", len(_seed))
 
             # 코인 카테고리별 전략 기본값
             row = conn.execute("SELECT COUNT(*) FROM coin_strategy_config").fetchone()

--- a/src/cryptobot/exchange/kis_us.py
+++ b/src/cryptobot/exchange/kis_us.py
@@ -196,7 +196,7 @@ class KISUSExchange(Exchange):
         Args:
             symbol: ticker (예: "NVDA"). 거래소는 자동 매핑.
         """
-        excd = self._exchange_code(symbol)
+        excd = self._quote_exchange_code(symbol)  # 시세는 3글자
         data = self._client.get(
             "/uapi/overseas-price/v1/quotations/price",
             tr_id=self._tr_ids["current_price"],
@@ -222,7 +222,7 @@ class KISUSExchange(Exchange):
         if interval != "day":
             raise ValueError(f"미국주식은 day만 지원 (요청: {interval})")
 
-        excd = self._exchange_code(symbol)
+        excd = self._quote_exchange_code(symbol)  # 시세는 3글자
         end_date = datetime.now(NY).strftime("%Y%m%d")
         from datetime import timedelta as _td
 
@@ -433,11 +433,21 @@ class KISUSExchange(Exchange):
     # ---- 내부 ----
 
     def _exchange_code(self, symbol: str) -> str:
-        """ticker → 거래소 코드 매핑.
+        """ticker → 주문/잔고용 거래소 코드 (4글자: NASD/NYSE/AMEX).
 
         풀에 없으면 NASDAQ 기본값. 추후 종목 마스터 도입 시 정확화.
         """
         return DEFAULT_EXCHANGE_BY_TICKER.get(symbol, "NASD")
+
+    def _quote_exchange_code(self, symbol: str) -> str:
+        """ticker → 시세 API용 거래소 코드 (3글자: NAS/NYS/AMS).
+
+        KIS는 시세 API와 주문 API가 거래소 코드 체계가 다름:
+        - 시세 (/quotations/price, /quotations/dailyprice): EXCD 3글자
+        - 주문/잔고 (/trading/order, /inquire-balance): OVRS_EXCG_CD 4글자
+        """
+        order_code = DEFAULT_EXCHANGE_BY_TICKER.get(symbol, "NASD")
+        return {"NASD": "NAS", "NYSE": "NYS", "AMEX": "AMS"}.get(order_code, "NAS")
 
     def _inquire_balance(self) -> dict:
         return self._client.get(


### PR DESCRIPTION
## Summary
- 시세 API EXCD 3글자 (NAS/NYS/AMS) 분리 — SOXL/AMEX 시세 INVALID 해결
- kis_us_symbols 테이블 신설, 32종목 시드 (SOXL 활성, 나머지 후보)

## 검증
- SOXL @ AMS: $166.87 ✓
- NVDA @ NAS: $216.70 ✓
- TSM @ NYS: $415.94 ✓

## Test plan
- [x] 42개 kis_us/kis_strategy 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)