### PR TITLE
feat: OHLCV 캐시 + DB 종목 관리 + 매 틱 판단 가시성 (#297)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -35,6 +35,8 @@ export default function DashboardPage() {
   const [marketCapital, setMarketCapital] = useState<any>(null);  // #277
   const [marketUniverse, setMarketUniverse] = useState<any>(null);  // #278
   const [tab, setTab] = useState<"all" | "coin" | "kis">("all");  // #287 탭
+  const [kisSymbols, setKisSymbols] = useState<any[]>([]);  // #297
+  const [kisEvals, setKisEvals] = useState<any[]>([]);  // #297-2
   const [loading, setLoading] = useState(true);
 
   const fetchAll = useCallback(() => {
@@ -52,7 +54,9 @@ export default function DashboardPage() {
       client.get("/market-stats").then((r) => r.data).catch(() => null),
       client.get("/market-capital/status").then((r) => r.data).catch(() => null),
       client.get("/market-universe").then((r) => r.data).catch(() => null),
-    ]).then(([bal, pos, hist, mkt, trades, coins, nStats, news, llm, vs, ms, mc, mu]) => {
+      client.get("/kis-symbols").then((r) => r.data).catch(() => []),
+      client.get("/kis-symbols/evaluations?limit=20").then((r) => r.data).catch(() => []),
+    ]).then(([bal, pos, hist, mkt, trades, coins, nStats, news, llm, vs, ms, mc, mu, ks, kev]) => {
       setBalance(bal);
       setPositions(pos as PositionsResponse | null);
       setHistory(hist as BalanceHistory[]);
@@ -66,6 +70,8 @@ export default function DashboardPage() {
       setMarketStats(ms);
       setMarketCapital(mc);
       setMarketUniverse(mu);
+      setKisSymbols((ks as any[]) || []);
+      setKisEvals((kev as any[]) || []);
       setLoading(false);
     }).catch(() => setLoading(false));
   }, []);
@@ -494,6 +500,119 @@ export default function DashboardPage() {
           </table>
           <div style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
             💡 <strong>실제 잔고 (API)</strong>가 봇이 매수에 쓰는 진짜 예산. 장부값은 입출금 이력 추적용.
+          </div>
+        </div>
+      )}
+
+      {/* #297-2: KIS 봇 틱별 매수 판단 결과 (사용자 가시성) */}
+      {(tab === "all" || tab === "kis") && kisEvals.length > 0 && (
+        <div className="card" style={{ marginTop: 16 }}>
+          <div className="card-title" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span>🔍 봇 매수 판단 (최근 20건)</span>
+            <span style={{ fontSize: 11, color: "var(--text-muted)", fontWeight: 400 }}>
+              30초마다 평가 — 매수 신호 충족하면 ✅
+            </span>
+          </div>
+          <div className="table-container" style={{ marginTop: 8 }}>
+            <table style={{ width: "100%", fontSize: 12 }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left", padding: 4 }}>시간</th>
+                  <th style={{ textAlign: "left", padding: 4 }}>종목</th>
+                  <th style={{ textAlign: "right", padding: 4 }}>가격</th>
+                  <th style={{ textAlign: "right", padding: 4 }}>RSI</th>
+                  <th style={{ textAlign: "right", padding: 4 }}>MA20</th>
+                  <th style={{ textAlign: "right", padding: 4 }}>MA60</th>
+                  <th style={{ textAlign: "center", padding: 4 }}>매수?</th>
+                  <th style={{ textAlign: "left", padding: 4 }}>사유 / 신뢰도</th>
+                </tr>
+              </thead>
+              <tbody>
+                {kisEvals.slice(0, 20).map((e: any) => (
+                  <tr key={e.id}>
+                    <td style={{ padding: 4, fontSize: 10, color: "var(--text-muted)" }}>
+                      {(e.evaluated_at || "").slice(11, 19)}
+                    </td>
+                    <td style={{ padding: 4, fontWeight: 600 }}>{e.ticker}</td>
+                    <td style={{ padding: 4, textAlign: "right" }}>
+                      {e.price != null ? `$${Number(e.price).toFixed(2)}` : "-"}
+                    </td>
+                    <td style={{
+                      padding: 4, textAlign: "right",
+                      color: e.rsi != null && e.rsi <= 35 ? "#10b981" : e.rsi != null && e.rsi >= 70 ? "#ef4444" : "var(--text-muted)",
+                      fontWeight: e.rsi != null && (e.rsi <= 35 || e.rsi >= 70) ? 700 : 400,
+                    }}>
+                      {e.rsi != null ? Number(e.rsi).toFixed(1) : "-"}
+                    </td>
+                    <td style={{ padding: 4, textAlign: "right", color: "var(--text-muted)" }}>
+                      {e.ma20 != null ? Number(e.ma20).toFixed(2) : "-"}
+                    </td>
+                    <td style={{ padding: 4, textAlign: "right", color: "var(--text-muted)" }}>
+                      {e.ma60 != null ? Number(e.ma60).toFixed(2) : "-"}
+                    </td>
+                    <td style={{ padding: 4, textAlign: "center" }}>
+                      {e.should_buy
+                        ? <span style={{ color: "#10b981", fontWeight: 700 }}>✅</span>
+                        : <span style={{ color: "var(--text-muted)" }}>-</span>}
+                    </td>
+                    <td style={{ padding: 4, fontSize: 10, color: "var(--text-secondary)" }}>
+                      {e.reason}
+                      {e.confidence > 0 ? ` (conf ${Number(e.confidence).toFixed(2)})` : ""}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div style={{ marginTop: 6, fontSize: 11, color: "var(--text-muted)" }}>
+            💡 RSI 초록(≤35) = 매수 임계 충족. 4중 조건 모두 만족해야 ✅. 미충족 사유는 "사유" 컬럼에 표시.
+          </div>
+        </div>
+      )}
+
+      {/* #297: KIS 미국주식 종목 풀 관리 */}
+      {(tab === "all" || tab === "kis") && kisSymbols.length > 0 && (
+        <div className="card" style={{ marginTop: 16 }}>
+          <div className="card-title" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span>🇺🇸 KIS 미국주식 종목 풀</span>
+            <span style={{ fontSize: 11, color: "var(--text-muted)", fontWeight: 400 }}>
+              활성 {kisSymbols.filter((s: any) => s.enabled).length}/{kisSymbols.length}종목 — 봇 5분마다 풀 재로딩 (재시작 불요)
+            </span>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 6, marginTop: 8 }}>
+            {kisSymbols.map((s: any) => (
+              <label
+                key={s.ticker}
+                style={{
+                  display: "flex", alignItems: "center", gap: 8,
+                  padding: "6px 10px", borderRadius: 6,
+                  background: s.enabled ? "rgba(74,158,255,0.12)" : "var(--bg-secondary)",
+                  border: s.enabled ? "1px solid #4a9eff" : "1px solid var(--border)",
+                  cursor: "pointer", fontSize: 12,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={!!s.enabled}
+                  onChange={async (e) => {
+                    await client.post("/kis-symbols/toggle", { ticker: s.ticker, enabled: e.target.checked });
+                    fetchAll();
+                  }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 600 }}>
+                    {s.ticker}
+                    {s.is_integer_only ? <span style={{ fontSize: 9, marginLeft: 4, color: "#f59e0b" }}>1주</span> : null}
+                  </div>
+                  <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+                    {s.display_name} · {s.exchange} · {s.category}
+                  </div>
+                </div>
+              </label>
+            ))}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
+            💡 체크하면 봇 모니터링 풀에 추가. 종목당 한도 = 100% / N (활성 종목 수). 신규 추가는 SQL/API로 (POST /api/kis-symbols).
           </div>
         </div>
       )}

--- a/src/cryptobot/api/main.py
+++ b/src/cryptobot/api/main.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel as _BaseModel
 
 from cryptobot.api.auth import UserResponse, get_current_user
 from cryptobot.api.deps import get_db as _get_db
-from cryptobot.api.routes import auth, balance, coin_strategy, config, market, market_capital, market_stats, market_universe, news, public, signals, strategies, trades, visits
+from cryptobot.api.routes import auth, balance, coin_strategy, config, kis_symbols, market, market_capital, market_stats, market_universe, news, public, signals, strategies, trades, visits
 from cryptobot.logging_config import setup_logging
 
 setup_logging("api", "INFO")
@@ -82,6 +82,7 @@ app.include_router(visits.router)  # #240 방문자 통계 (admin)
 app.include_router(market_stats.router)  # #254 6단계 시장별 PnL (admin)
 app.include_router(market_capital.router)  # #277 시장별 자본 입출금/이동 (admin)
 app.include_router(market_universe.router)  # #278 시장별 종목 풀 + 활성 전략 (admin)
+app.include_router(kis_symbols.router)  # #297 KIS 미국주식 종목 풀 관리 (admin)
 
 
 @app.get("/api/llm/hard-limits", tags=["llm"])

--- a/src/cryptobot/api/routes/kis_symbols.py
+++ b/src/cryptobot/api/routes/kis_symbols.py
@@ -1,0 +1,119 @@
+"""#297: KIS 미국주식 종목 풀 관리 (admin)."""
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from cryptobot.api.auth import UserResponse, get_current_user
+from cryptobot.api.deps import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/kis-symbols", tags=["kis-symbols"])
+
+
+@router.get("")
+def list_symbols(_: UserResponse = Depends(get_current_user)):
+    """전체 종목 목록 (활성/비활성 포함). 카테고리별 정렬."""
+    db = get_db()
+    rows = db.execute(
+        """
+        SELECT ticker, display_name, exchange, is_integer_only, category, enabled, note,
+               updated_at
+        FROM kis_us_symbols
+        ORDER BY enabled DESC, category, ticker
+        """
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@router.post("/toggle")
+def toggle_symbol(
+    payload: dict = Body(...),
+    _: UserResponse = Depends(get_current_user),
+):
+    """종목 활성/비활성 토글. body: {ticker: str, enabled: bool}"""
+    ticker = (payload.get("ticker") or "").strip().upper()
+    enabled = bool(payload.get("enabled"))
+    if not ticker:
+        raise HTTPException(400, "ticker required")
+
+    db = get_db()
+    cur = db.execute(
+        "UPDATE kis_us_symbols SET enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE ticker = ?",
+        (1 if enabled else 0, ticker),
+    )
+    db.commit()
+    if cur.rowcount == 0:
+        raise HTTPException(404, f"종목 {ticker} 없음")
+    logger.info("KIS US symbol toggle: %s = %s", ticker, enabled)
+    return {"ok": True, "ticker": ticker, "enabled": enabled}
+
+
+@router.post("")
+def add_symbol(
+    payload: dict = Body(...),
+    _: UserResponse = Depends(get_current_user),
+):
+    """종목 추가. body: {ticker, display_name?, exchange?, is_integer_only?, category?, note?}"""
+    ticker = (payload.get("ticker") or "").strip().upper()
+    if not ticker:
+        raise HTTPException(400, "ticker required")
+    exchange = (payload.get("exchange") or "NASD").strip().upper()
+    if exchange not in ("NASD", "NYSE", "AMEX"):
+        raise HTTPException(400, "exchange must be NASD/NYSE/AMEX")
+
+    db = get_db()
+    try:
+        db.execute(
+            "INSERT INTO kis_us_symbols "
+            "(ticker, display_name, exchange, is_integer_only, category, enabled, note) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                ticker,
+                payload.get("display_name") or ticker,
+                exchange,
+                1 if payload.get("is_integer_only") else 0,
+                payload.get("category") or "etc",
+                1 if payload.get("enabled") else 0,
+                payload.get("note") or "",
+            ),
+        )
+        db.commit()
+    except Exception as e:
+        raise HTTPException(409, f"이미 존재하거나 추가 실패: {e}")
+    return {"ok": True, "ticker": ticker}
+
+
+@router.get("/evaluations")
+def list_evaluations(
+    limit: int = 50,
+    ticker: str | None = None,
+    _: UserResponse = Depends(get_current_user),
+):
+    """매 틱 매수 평가 결과 (#297-2). 사용자가 봇이 어떻게 판단했는지 확인.
+
+    응답: [{evaluated_at, ticker, price, rsi, ma20, ma60, should_buy, reason, confidence}]
+    """
+    db = get_db()
+    if ticker:
+        rows = db.execute(
+            "SELECT * FROM kis_us_evaluations WHERE ticker = ? ORDER BY id DESC LIMIT ?",
+            (ticker.upper(), limit),
+        ).fetchall()
+    else:
+        rows = db.execute(
+            "SELECT * FROM kis_us_evaluations ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+@router.delete("/{ticker}")
+def delete_symbol(ticker: str, _: UserResponse = Depends(get_current_user)):
+    """종목 삭제."""
+    db = get_db()
+    cur = db.execute("DELETE FROM kis_us_symbols WHERE ticker = ?", (ticker.upper(),))
+    db.commit()
+    if cur.rowcount == 0:
+        raise HTTPException(404, f"종목 {ticker} 없음")
+    return {"ok": True, "ticker": ticker.upper()}

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -369,6 +369,24 @@ CREATE TABLE IF NOT EXISTS kis_us_symbols (
 );
 CREATE INDEX IF NOT EXISTS idx_kis_us_symbols_enabled ON kis_us_symbols(enabled);
 
+-- #297-2: 매 틱 매수 판단 결과 기록 (사용자 가시성).
+-- 봇이 30초마다 평가하는 내용을 DB에 저장하면 admin에서 "왜 아직 안 샀는지" 확인 가능.
+CREATE TABLE IF NOT EXISTS kis_us_evaluations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    evaluated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ticker TEXT NOT NULL,
+    price REAL,
+    rsi REAL,
+    ma20 REAL,
+    ma60 REAL,
+    should_buy BOOLEAN NOT NULL DEFAULT 0,
+    reason TEXT,                    -- "RSI 42.0>35" 같은 미충족 사유 또는 매수 신호 사유
+    confidence REAL DEFAULT 0,
+    holds_already BOOLEAN DEFAULT 0  -- 보유 중이라 매도 평가만 한 경우
+);
+CREATE INDEX IF NOT EXISTS idx_kis_us_eval_ts ON kis_us_evaluations(evaluated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_kis_us_eval_ticker_ts ON kis_us_evaluations(ticker, evaluated_at DESC);
+
 -- #240: 페이지 방문자 추적 (admin 우선)
 CREATE TABLE IF NOT EXISTS page_visits (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -73,8 +73,22 @@ DEFAULT_US_UNIVERSE = [
 DEFAULT_TICK_INTERVAL_SEC = 30  # #295: 단타용 빠른 반응 (기존 60→30)
 
 
-def _parse_universe() -> list[str]:
-    """env KIS_US_UNIVERSE 파싱. 미설정 시 디폴트 풀."""
+def _parse_universe(db: "Database | None" = None) -> list[str]:
+    """종목 풀 결정. 우선순위: DB(kis_us_symbols.enabled) > env KIS_US_UNIVERSE > DEFAULT.
+
+    #297: DB 기반 종목 관리 — admin에서 토글하면 봇 재시작 없이 다음 틱부터 반영.
+    DB가 비어있거나 enabled 종목 0건이면 env fallback.
+    """
+    if db is not None:
+        try:
+            rows = db.execute(
+                "SELECT ticker FROM kis_us_symbols WHERE enabled = 1 ORDER BY ticker"
+            ).fetchall()
+            if rows:
+                return [dict(r)["ticker"] for r in rows]
+        except Exception:
+            pass  # DB 조회 실패 시 env로 fallback
+
     raw = os.getenv("KIS_US_UNIVERSE", "").strip()
     if not raw:
         return list(DEFAULT_US_UNIVERSE)
@@ -137,7 +151,7 @@ class KISUSBot:
             account_product_code=config.kis.account_product_code,
             is_paper=config.kis.is_paper,
         )
-        self._universe = _parse_universe()
+        self._universe = _parse_universe(self._db)  # DB 우선
         self._params = _build_params(len(self._universe))
         self._rebuy_cooldown_sec = int(os.getenv("KIS_US_REBUY_COOLDOWN_SEC", "0"))
         self._tick_interval_sec = max(15, int(os.getenv("KIS_US_TICK_INTERVAL_SEC", str(DEFAULT_TICK_INTERVAL_SEC))))
@@ -207,12 +221,21 @@ class KISUSBot:
             logger.debug("미국 정규장 외 (%s NY). 스킵", ny)
             return
 
-        # ~5분에 한 번 살아있음 핑 (사용자 가시성용)
+        # ~5분에 한 번 살아있음 핑 + DB 종목 풀 재로딩 (admin 토글 반영, #297)
         if self._tick_count % self._heartbeat_every_n_ticks == 0:
             ny = datetime.now(NY).strftime("%H:%M")
+            new_universe = _parse_universe(self._db)
+            universe_changed = new_universe != self._universe
+            if universe_changed:
+                logger.info("종목 풀 변경: %s → %s", self._universe, new_universe)
+                self._universe = new_universe
+                self._params = _build_params(len(self._universe)) if self._universe else self._params
             try:
                 usd = self._exchange.get_balance("USD")
-                logger.info("[heartbeat] tick=%d, NY %s, USD=$%.2f", self._tick_count, ny, usd)
+                logger.info(
+                    "[heartbeat] tick=%d, NY %s, USD=$%.2f, 풀=%s",
+                    self._tick_count, ny, usd, ",".join(self._universe) or "(empty)",
+                )
             except Exception:
                 logger.info("[heartbeat] tick=%d, NY %s (잔고 조회 실패)", self._tick_count, ny)
 
@@ -296,6 +319,42 @@ class KISUSBot:
         else:
             logger.debug("%s 보유 유지: %s", symbol, signal_.reason)
 
+    def _record_evaluation(
+        self,
+        symbol: str,
+        price: float,
+        signal_,
+        df=None,
+        holds_already: bool = False,
+    ) -> None:
+        """매 틱 매수 평가 결과 DB 기록 (#297-2). 사용자 가시성용."""
+        from cryptobot.bot.kis_strategy import _calc_ma, _calc_rsi
+
+        rsi = ma20 = ma60 = None
+        if df is not None:
+            try:
+                rsi = _calc_rsi(df["close"], 14)
+                ma20 = _calc_ma(df["close"], 20)
+                ma60 = _calc_ma(df["close"], 60)
+            except Exception:
+                pass
+        try:
+            self._db.execute(
+                "INSERT INTO kis_us_evaluations "
+                "(ticker, price, rsi, ma20, ma60, should_buy, reason, confidence, holds_already) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    symbol, float(price), rsi, ma20, ma60,
+                    1 if (signal_ and getattr(signal_, "should_buy", False)) else 0,
+                    getattr(signal_, "reason", "") if signal_ else "",
+                    getattr(signal_, "confidence", 0.0) if signal_ else 0.0,
+                    1 if holds_already else 0,
+                ),
+            )
+            self._db.commit()
+        except Exception as e:
+            logger.debug("evaluation 기록 실패: %s", e)
+
     def _evaluate_buy(self, symbol: str, price_usd: float) -> None:
         # 짧은 재매수 쿨다운 (옵션) — 매도 직후 노이즈 매매 회피
         if self._rebuy_cooldown_sec > 0:
@@ -315,6 +374,8 @@ class KISUSBot:
             return
 
         signal_ = evaluate_buy(df, price_usd, self._params)
+        # 매 틱 평가 결과 DB 기록 (사용자 가시성)
+        self._record_evaluation(symbol, price_usd, signal_, df=df, holds_already=False)
         if not signal_.should_buy:
             logger.debug("%s 매수 미판정: %s", symbol, signal_.reason)
             return

--- a/src/cryptobot/exchange/kis_us.py
+++ b/src/cryptobot/exchange/kis_us.py
@@ -136,6 +136,10 @@ class KISUSExchange(Exchange):
         self._acnt_prdt_cd = account_product_code
         self._tr_ids = TR_ID_PAPER if is_paper else TR_ID_REAL
         self._is_paper = is_paper
+        # #297: OHLCV 캐시 — 일봉 RSI/MA는 일중 자주 안 바뀌니 60초 캐시
+        # rate limit (KIS 초당 5건) 회피 + dailyprice API 부하 절감
+        self._ohlcv_cache: dict[str, tuple[float, "pd.DataFrame"]] = {}
+        self._ohlcv_cache_ttl_sec = 60
 
     # ---- 메타 ----
 
@@ -218,9 +222,21 @@ class KISUSExchange(Exchange):
         interval: str = "day",
         count: int = 200,
     ) -> pd.DataFrame:
-        """OHLCV 일봉 조회 (미국 시간 기준)."""
+        """OHLCV 일봉 조회 (미국 시간 기준).
+
+        #297: 60초 캐시 — 일봉 RSI/MA 지표는 일중 미세변동만이므로 30초 폴링에
+        매번 dailyprice 호출하면 rate limit 걸림. 60초 캐시로 충분.
+        """
         if interval != "day":
             raise ValueError(f"미국주식은 day만 지원 (요청: {interval})")
+
+        # 캐시 체크 (count 무관 — 캐시는 항상 최대 행 수 유지하고 tail로 잘라줌)
+        import time as _time
+        cache_key = symbol
+        cached = self._ohlcv_cache.get(cache_key)
+        if cached and (_time.time() - cached[0]) < self._ohlcv_cache_ttl_sec:
+            df_cached = cached[1]
+            return df_cached.tail(count)
 
         excd = self._quote_exchange_code(symbol)  # 시세는 3글자
         end_date = datetime.now(NY).strftime("%Y%m%d")
@@ -262,6 +278,8 @@ class KISUSExchange(Exchange):
         df = pd.DataFrame(df_rows).sort_values("date").set_index("date")
         # KIS는 시작 날짜로부터 역순으로 응답하기도 하므로 start_date 이후만 필터
         df = df[df.index >= pd.to_datetime(start_date, format="%Y%m%d")]
+        # #297: 캐시 저장 (전체 df, count 무관)
+        self._ohlcv_cache[cache_key] = (_time.time(), df)
         return df.tail(count)
 
     # ---- 주문 ----


### PR DESCRIPTION
## Summary
- OHLCV 60초 캐시 → rate limit 회피
- DB 기반 종목 관리 (admin 토글, 5분마다 봇이 재로딩)
- kis_us_evaluations 매 틱 기록 → admin 표 노출 (RSI/MA/사유/신뢰도)

## Test plan
- [x] 513개 테스트 통과
- [x] TypeScript 빌드 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)