### PR TITLE
feat: VWAP + ORB + 거래량 spike 단타 전략 (#303)

### DIFF
--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -74,6 +74,12 @@ class KISStrategyParams:
     day_trading_mode: bool = False
     no_buy_window_minutes_before_close: int = 30   # 마감 N분 전부터 신규 매수 X
     force_sell_window_minutes_before_close: int = 10  # 마감 N분 전 강제 매도
+    # #303 VWAP+ORB+거래량 spike 전략 파라미터
+    # 학술 근거: Zarattini & Aziz (2023) QQQ 5분 ORB → 누적 +1,484%/8년. TQQQ/SOXL 등 3X ETF 권장.
+    # 표준: RVOL 2~3x, R:R 1:2~1:3, 시간대 10:00~12:00 EST 가장 강함.
+    orb_minutes: int = 30                # ORB 형성 시간 (학술: 5~30분, 30분=노이즈 균형)
+    volume_spike_multiplier: float = 2.0 # 평균 거래량 × N 이상이면 spike (학술 권고 2~3x)
+    vwap_proximity_pct: float = 1.0      # 가격이 VWAP 위 N% 이내면 풀백 진입 가능
 
 
 def calc_position_size(
@@ -134,6 +140,114 @@ def _calc_ma(prices: pd.Series, period: int) -> float | None:
     if len(prices) < period:
         return None
     return float(prices.iloc[-period:].mean())
+
+
+def calc_vwap(df: pd.DataFrame) -> float | None:
+    """오늘 분봉 데이터로 VWAP (거래량 가중 평균가) 계산.
+
+    VWAP = Σ(Typical_Price × Volume) / Σ(Volume)
+    Typical_Price = (High + Low + Close) / 3
+
+    df는 오늘 봉만 들어와야 함 (호출자가 필터링).
+    """
+    if df is None or len(df) == 0:
+        return None
+    typical = (df["high"] + df["low"] + df["close"]) / 3
+    vol = df["volume"]
+    total_vol = vol.sum()
+    if total_vol <= 0:
+        return None
+    return float((typical * vol).sum() / total_vol)
+
+
+def calc_orb(df: pd.DataFrame, orb_minutes: int = 30, bar_minutes: int = 5) -> tuple[float, float] | None:
+    """ORB (Opening Range Breakout) 형성: 장 시작 후 N분의 고저점.
+
+    Args:
+        df: 오늘 분봉 데이터 (호출자가 NY 09:30 이후로 필터링)
+        orb_minutes: ORB 형성 시간 (기본 30분)
+        bar_minutes: 봉 단위 (기본 5분)
+
+    Returns:
+        (or_high, or_low) 또는 None (데이터 부족)
+    """
+    bars_needed = max(1, orb_minutes // bar_minutes)
+    if df is None or len(df) < bars_needed:
+        return None
+    or_window = df.iloc[:bars_needed]
+    return float(or_window["high"].max()), float(or_window["low"].min())
+
+
+def evaluate_buy_breakout(
+    df_today: pd.DataFrame,
+    current_price: float,
+    bar_minutes: int = 5,
+    params: KISStrategyParams = KISStrategyParams(),
+) -> KISBuySignal:
+    """#303 VWAP + ORB + 거래량 spike 단타 매수 평가.
+
+    매수 조건 (모두 충족):
+      1. ORB 돌파: 가격 > ORB 고점 (장 시작 후 N분 고점)
+      2. VWAP 강세: 가격 > VWAP (당일 거래량 가중 평균)
+      3. 거래량 spike: 직전 봉 거래량 > 평균 × multiplier
+      4. ORB 형성 완료 (장 시작 후 N분 경과)
+
+    Args:
+        df_today: 오늘 분봉 데이터 (NY 09:30 이후만)
+        current_price: 현재가
+        bar_minutes: 봉 단위 분 (5분봉 디폴트)
+        params: 전략 파라미터
+
+    Returns:
+        KISBuySignal
+    """
+    bars_needed = max(1, params.orb_minutes // bar_minutes)
+    if df_today is None or len(df_today) < bars_needed + 1:
+        return KISBuySignal(False, f"ORB 형성 중 (현재 {len(df_today) if df_today is not None else 0}/{bars_needed + 1}봉)")
+
+    orb = calc_orb(df_today, params.orb_minutes, bar_minutes)
+    if orb is None:
+        return KISBuySignal(False, "ORB 계산 불가")
+    or_high, or_low = orb
+
+    vwap = calc_vwap(df_today)
+    if vwap is None:
+        return KISBuySignal(False, "VWAP 계산 불가")
+
+    # 거래량 spike — 직전 봉 vs 평균
+    last_vol = float(df_today["volume"].iloc[-1])
+    avg_vol = float(df_today["volume"].mean())
+    spike_ratio = last_vol / avg_vol if avg_vol > 0 else 0.0
+
+    cond_orb = current_price > or_high
+    cond_vwap = current_price > vwap
+    cond_volume = spike_ratio >= params.volume_spike_multiplier
+
+    if not (cond_orb and cond_vwap and cond_volume):
+        miss = []
+        if not cond_orb:
+            miss.append(f"ORB 미돌파 (현재 ${current_price:.2f} ≤ OR고점 ${or_high:.2f})")
+        if not cond_vwap:
+            miss.append(f"VWAP 아래 (가격 ${current_price:.2f} < VWAP ${vwap:.2f})")
+        if not cond_volume:
+            miss.append(f"거래량 spike 없음 ({spike_ratio:.2f}x < {params.volume_spike_multiplier}x)")
+        return KISBuySignal(False, "조건 미충족: " + ", ".join(miss))
+
+    # 신뢰도: ORB 돌파폭 + VWAP 거리 + 거래량 spike
+    breakout_strength = (current_price - or_high) / or_high  # ORB 위 얼마나
+    vwap_strength = (current_price - vwap) / vwap            # VWAP 위 얼마나
+    conf = round(min(0.95,
+                     min(breakout_strength * 50, 0.4) +    # ORB 돌파 폭 0~0.4
+                     min(vwap_strength * 30, 0.3) +         # VWAP 위 0~0.3
+                     min((spike_ratio - 1) * 0.15, 0.25)),  # 거래량 spike 0~0.25
+                 2)
+
+    return KISBuySignal(
+        True,
+        f"ORB↑ ${or_high:.2f}→${current_price:.2f} (+{breakout_strength*100:.2f}%) | "
+        f"VWAP ${vwap:.2f} (+{vwap_strength*100:.2f}%) | 거래량 {spike_ratio:.1f}x",
+        confidence=max(conf, 0.3),
+    )
 
 
 def evaluate_buy(

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -23,8 +23,11 @@ USD 기반 거래:
   단타 노이즈 매매 회피용. 0이면 다음 틱부터 즉시 재매수 가능.
 - KIS_US_TICK_INTERVAL_SEC (기본 30). 봇 폴링 주기. 단타는 빠른 반응(30초)이 적절.
   너무 짧으면(<15초) KIS rate limit 우려.
-- KIS_US_OHLCV_INTERVAL (기본: 단타→"15min", 스윙→"day"). RSI/MA 계산용 봉 단위.
-  단타에 일봉 RSI는 시간 단위 mismatch — 15분봉이 적절.
+- KIS_US_OHLCV_INTERVAL (기본: 단타+breakout→"5min", 단타+meanrev→"15min", 스윙→"day").
+  RSI/MA/ORB/VWAP 계산용 봉 단위. ORB 5분봉 표준.
+- KIS_US_STRATEGY (기본: 단타→"breakout", 스윙→"mean_reversion").
+  - "breakout": VWAP + ORB(30분) + 거래량 spike (#303). 강세장 추세 추종.
+  - "mean_reversion": RSI≤35 + 가격<MA20 (#279). 횡보장 반등 잡기.
 
 사용법:
     python -m cryptobot.entrypoints.run_kis_us
@@ -47,6 +50,7 @@ from cryptobot.bot.kis_strategy import (
     KISStrategyParams,
     calc_position_size,
     evaluate_buy,
+    evaluate_buy_breakout,
     evaluate_sell,
 )
 from cryptobot.data.database import Database
@@ -161,8 +165,16 @@ class KISUSBot:
         self._tick_interval_sec = max(15, int(os.getenv("KIS_US_TICK_INTERVAL_SEC", str(DEFAULT_TICK_INTERVAL_SEC))))
         self._heartbeat_every_n_ticks = max(1, 300 // self._tick_interval_sec)  # ~5분에 한 번 살아있음 핑
         self._tick_count = 0
-        # #299: OHLCV 봉 단위 — 단타면 디폴트 15분봉, 스윙은 일봉
-        default_interval = "15min" if self._params.day_trading_mode else "day"
+        # #303 전략 선택 — 단타 디폴트 "breakout" (VWAP+ORB+거래량 spike)
+        default_strategy = "breakout" if self._params.day_trading_mode else "mean_reversion"
+        self._strategy = os.getenv("KIS_US_STRATEGY", default_strategy).strip().lower()
+        # OHLCV 봉 단위 — breakout은 5분봉 표준, meanrev는 15분봉, 스윙은 일봉
+        if self._strategy == "breakout":
+            default_interval = "5min"
+        elif self._params.day_trading_mode:
+            default_interval = "15min"
+        else:
+            default_interval = "day"
         self._ohlcv_interval = os.getenv("KIS_US_OHLCV_INTERVAL", default_interval).strip()
         self._running = False
         self._last_buy_price: dict[str, float] = {}  # USD 기준
@@ -193,6 +205,7 @@ class KISUSBot:
             )
         logger.info("폴링 주기: %d초", self._tick_interval_sec)
         logger.info("OHLCV 봉 단위: %s", self._ohlcv_interval)
+        logger.info("매수 전략: %s", self._strategy)
 
         if self._notifier.is_configured:
             self._notifier.notify_bot_status(f"[KIS_US] 미국주식 봇 시작 ({mode})")
@@ -381,7 +394,19 @@ class KISUSBot:
             logger.warning("%s OHLCV 조회 실패 — 매수 판단 스킵: %s", symbol, e)
             return
 
-        signal_ = evaluate_buy(df, price_usd, self._params)
+        # #303 전략 분기 — breakout (VWAP+ORB+거래량) vs mean_reversion (RSI)
+        if self._strategy == "breakout":
+            # 오늘 봉만 필터 (NY 09:30 이후) — VWAP/ORB는 당일 데이터 사용
+            ny_today = datetime.now(NY).date()
+            df_today = df[df.index.date == ny_today] if hasattr(df.index, "date") else df
+            try:
+                bar_min = int(self._ohlcv_interval.replace("min", ""))
+            except ValueError:
+                bar_min = 5
+            signal_ = evaluate_buy_breakout(df_today, price_usd, bar_minutes=bar_min, params=self._params)
+        else:
+            signal_ = evaluate_buy(df, price_usd, self._params)
+
         # 매 틱 평가 결과 DB 기록 (사용자 가시성)
         self._record_evaluation(symbol, price_usd, signal_, df=df, holds_already=False)
         if not signal_.should_buy:

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -336,3 +336,104 @@ def test_day_trading_custom_windows():
     )
     assert p.force_sell_window_minutes_before_close == 5
     assert p.no_buy_window_minutes_before_close == 15
+
+
+# ---- #303 VWAP + ORB + 거래량 spike ----
+
+def _make_minute_df(prices_with_vol, base_dt="2026-05-08 09:30"):
+    """분봉 더미 DF 생성. prices_with_vol = [(open, high, low, close, vol), ...]"""
+    rows = []
+    ts = pd.Timestamp(base_dt)
+    for i, (o, h, l, c, v) in enumerate(prices_with_vol):
+        rows.append({"date": ts + pd.Timedelta(minutes=5 * i),
+                     "open": o, "high": h, "low": l, "close": c, "volume": v})
+    return pd.DataFrame(rows).set_index("date")
+
+
+def test_calc_vwap_basic():
+    from cryptobot.bot.kis_strategy import calc_vwap
+    df = _make_minute_df([(100, 102, 99, 101, 1000), (101, 103, 100, 102, 2000)])
+    vwap = calc_vwap(df)
+    # typical1 = (102+99+101)/3 = 100.67, typical2 = (103+100+102)/3 = 101.67
+    # vwap = (100.67×1000 + 101.67×2000) / 3000 = 101.34
+    assert abs(vwap - 101.33) < 0.05
+
+
+def test_calc_orb_returns_high_low():
+    from cryptobot.bot.kis_strategy import calc_orb
+    # 6봉 (5분 × 6 = 30분)
+    df = _make_minute_df([
+        (100, 102, 99, 101, 1000),
+        (101, 105, 100, 104, 2000),  # 고점 105
+        (104, 106, 102, 103, 1500),  # 고점 106
+        (103, 104, 100, 101, 1000),  # 저점 100
+        (101, 103, 99, 102, 1500),   # 저점 99
+        (102, 104, 101, 103, 1500),
+        (103, 107, 102, 106, 2000),  # 7번째 봉 (ORB 외)
+    ])
+    orb = calc_orb(df, orb_minutes=30, bar_minutes=5)
+    assert orb is not None
+    or_high, or_low = orb
+    assert or_high == 106  # 첫 6봉 고점
+    assert or_low == 99    # 첫 6봉 저점
+
+
+def test_evaluate_buy_breakout_signal():
+    from cryptobot.bot.kis_strategy import evaluate_buy_breakout, KISStrategyParams
+    # ORB 형성 후 돌파 + VWAP 위 + 거래량 spike
+    df = _make_minute_df([
+        (100, 102, 99, 101, 1000),
+        (101, 103, 100, 102, 1000),
+        (102, 104, 101, 103, 1000),
+        (103, 105, 102, 104, 1000),
+        (104, 106, 103, 105, 1000),
+        (105, 107, 104, 106, 1000),  # ORB 6봉 끝, OR_high = 107
+        (106, 108, 105, 107, 3000),  # 거래량 spike 3000 (avg 1285)
+    ])
+    sig = evaluate_buy_breakout(df, current_price=108.0, bar_minutes=5,
+                                params=KISStrategyParams(orb_minutes=30, volume_spike_multiplier=2.0))
+    assert sig.should_buy is True
+    assert "ORB↑" in sig.reason
+    assert sig.confidence > 0
+
+
+def test_evaluate_buy_breakout_below_orb():
+    from cryptobot.bot.kis_strategy import evaluate_buy_breakout, KISStrategyParams
+    df = _make_minute_df([
+        (100, 105, 99, 101, 1000),
+        (101, 105, 100, 102, 1000),
+        (102, 106, 101, 103, 1000),
+        (103, 107, 102, 104, 1000),  # OR_high = 107
+        (104, 105, 103, 104, 1000),
+        (104, 105, 102, 103, 1000),
+        (103, 104, 102, 103, 3000),  # 거래량 spike 있어도 ORB 아래
+    ])
+    sig = evaluate_buy_breakout(df, current_price=104.0, bar_minutes=5,
+                                params=KISStrategyParams(orb_minutes=30, volume_spike_multiplier=2.0))
+    assert sig.should_buy is False
+    assert "ORB 미돌파" in sig.reason
+
+
+def test_evaluate_buy_breakout_no_volume_spike():
+    from cryptobot.bot.kis_strategy import evaluate_buy_breakout, KISStrategyParams
+    df = _make_minute_df([
+        (100, 102, 99, 101, 1000),
+        (101, 103, 100, 102, 1000),
+        (102, 104, 101, 103, 1000),
+        (103, 105, 102, 104, 1000),
+        (104, 106, 103, 105, 1000),
+        (105, 107, 104, 106, 1000),
+        (106, 108, 105, 107, 1100),  # 약간 spike 1.1x 만 — 임계 미충족
+    ])
+    sig = evaluate_buy_breakout(df, current_price=108.0, bar_minutes=5,
+                                params=KISStrategyParams(orb_minutes=30, volume_spike_multiplier=2.0))
+    assert sig.should_buy is False
+    assert "거래량 spike 없음" in sig.reason
+
+
+def test_strategy_default_breakout_in_day_trading_mode():
+    """단타 모드 ON 시 디폴트 전략은 'breakout'."""
+    p = KISStrategyParams()
+    # 디폴트 파라미터 — orb_minutes/volume_spike 검증
+    assert p.orb_minutes == 30
+    assert p.volume_spike_multiplier == 2.0


### PR DESCRIPTION
## Summary
Zarattini 2023 학술 검증 단타 전략 (QQQ 5분 ORB +1,484%/8년) 도입.

매수 4중 조건:
1. ORB 돌파 (30분)
2. VWAP 강세
3. 거래량 spike 2x
4. ORB 형성 완료

KIS_US_STRATEGY env로 mean_reversion과 토글 가능.

## Test plan
- [x] 519개 테스트 통과
- [x] VWAP/ORB/breakout 평가 6건 신규 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)