### PR TITLE
improve: Admin/Public UI 정리 (#307)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -129,18 +129,40 @@ export default function DashboardPage() {
         const totalCost = pos.reduce((s: number, p: any) => s + (p.total_krw || 0), 0);
         const totalValue = pos.reduce((s: number, p: any) => s + (p.amount || 0) * (p.current_price || 0), 0);
         const totalAsset = (balance?.krw_balance || 0) + totalValue;
-        // #218: 시작 금액은 capital_deposits 누적 합산 (백엔드에서 계산). 추가 입금 시 자동 반영.
-        // API에서 못 받아오면(레거시 등) 100,000 fallback — 그래도 손익 부호는 의미 있음.
+        // #218 + #307: 누적 입금 (capital_deposits 합산, 출금 -감산). 0이면 손익 계산 불가.
         const totalDeposits = balance?.total_deposits_krw && balance.total_deposits_krw > 0
           ? balance.total_deposits_krw
-          : 100000;
-        const totalPnl = totalAsset - totalDeposits;
+          : null;
+        const totalPnl = totalDeposits !== null ? totalAsset - totalDeposits : null;
+        const pnlPct = totalDeposits && totalDeposits > 0 && totalPnl !== null ? (totalPnl / totalDeposits) * 100 : null;
         return (
           <div className="kpi-grid">
-            <StatCard label="총 보유 자산" value={balance ? formatKRW(totalAsset) : "-"} sub={`KRW ${formatKRW(balance?.krw_balance || 0)} + 코인 ${formatKRW(totalValue)}`} />
-            <StatCard label="총 손익" value={`${formatKRW(totalPnl)} (${formatPercent(totalDeposits > 0 ? totalPnl / totalDeposits * 100 : 0)})`} valueClass={totalPnl >= 0 ? "positive" : "negative"} sub={`누적 입금 ₩${totalDeposits.toLocaleString()} 기준`} />
-            <StatCard label="매수 금액" value={formatKRW(totalCost)} sub={`${pos.length}종목 보유`} />
-            <StatCard label="평가 금액" value={formatKRW(totalValue)} valueClass={totalValue >= totalCost ? "positive" : "negative"} sub={totalCost > 0 ? `${formatPercent((totalValue - totalCost) / totalCost * 100)} 수익률` : ""} />
+            <StatCard
+              label="총 보유 자산 (코인 봇)"
+              value={balance ? formatKRW(totalAsset) : "-"}
+              sub={`KRW ${formatKRW(balance?.krw_balance || 0)} + 코인 ${formatKRW(totalValue)}`}
+            />
+            <StatCard
+              label="총 손익 (코인)"
+              value={totalPnl !== null && pnlPct !== null
+                ? `${formatKRW(totalPnl)} (${formatPercent(pnlPct)})`
+                : "기준 미설정"}
+              valueClass={totalPnl !== null ? (totalPnl >= 0 ? "positive" : "negative") : ""}
+              sub={totalDeposits !== null
+                ? `누적 입금 ₩${totalDeposits.toLocaleString()} 기준`
+                : "입금 이력 없음"}
+            />
+            <StatCard
+              label="매수 금액"
+              value={formatKRW(totalCost)}
+              sub={pos.length > 0 ? `${pos.length}종목 보유` : "보유 없음"}
+            />
+            <StatCard
+              label="평가 금액"
+              value={formatKRW(totalValue)}
+              valueClass={totalValue > totalCost ? "positive" : totalValue < totalCost ? "negative" : ""}
+              sub={totalCost > 0 ? `${formatPercent((totalValue - totalCost) / totalCost * 100)} 수익률` : "포지션 없음"}
+            />
           </div>
         );
       })()}
@@ -470,36 +492,47 @@ export default function DashboardPage() {
             <thead>
               <tr>
                 <th style={{ textAlign: "left", padding: 6 }}>시장</th>
-                <th style={{ textAlign: "right", padding: 6 }}>시드(장부)</th>
-                <th style={{ textAlign: "right", padding: 6 }}>실현 PnL</th>
+                <th style={{ textAlign: "right", padding: 6 }}>실 잔고 (API)</th>
+                <th style={{ textAlign: "right", padding: 6 }}>실현 손익</th>
                 <th style={{ textAlign: "right", padding: 6 }}>보유 원가</th>
-                <th style={{ textAlign: "right", padding: 6 }}>장부 가용</th>
-                <th style={{ textAlign: "right", padding: 6 }}>실제 잔고 (API)</th>
+                <th style={{ textAlign: "left", padding: 6 }}>봇 상태</th>
               </tr>
             </thead>
             <tbody>
-              {marketCapital.markets.map((m: any) => (
-                <tr key={m.market}>
-                  <td style={{ padding: 6, fontWeight: 600 }}>
-                    {m.market === "kis_kr" ? "🇰🇷 한국주식" : "🇺🇸 미국주식"}
-                  </td>
-                  <td style={{ textAlign: "right", padding: 6 }}>{Number(m.seed).toLocaleString()}원</td>
-                  <td style={{ textAlign: "right", padding: 6 }} className={m.realized_pnl >= 0 ? "positive" : "negative"}>
-                    {m.realized_pnl >= 0 ? "+" : ""}{Number(m.realized_pnl).toLocaleString()}원
-                  </td>
-                  <td style={{ textAlign: "right", padding: 6 }}>{Number(m.held_cost).toLocaleString()}원</td>
-                  <td style={{ textAlign: "right", padding: 6 }}>{Number(m.available).toLocaleString()}원</td>
-                  <td style={{ textAlign: "right", padding: 6, fontWeight: 700, color: "var(--accent)" }}>
-                    {m.live?.available != null
-                      ? `${Number(m.live.available).toLocaleString()} ${m.live.currency || ""}`
-                      : <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>조회불가</span>}
-                  </td>
-                </tr>
-              ))}
+              {marketCapital.markets.map((m: any) => {
+                const tradingEnabled = m.market === "kis_us"; // TODO: market-universe API에서 실제 토글 가져오기
+                return (
+                  <tr key={m.market} style={{ opacity: tradingEnabled ? 1 : 0.6 }}>
+                    <td style={{ padding: 6, fontWeight: 600 }}>
+                      {m.market === "kis_kr" ? "🇰🇷 한국주식" : "🇺🇸 미국주식"}
+                    </td>
+                    <td style={{ textAlign: "right", padding: 6, fontWeight: 700, color: "var(--accent)" }}>
+                      {m.live?.available != null
+                        ? `${Number(m.live.available).toLocaleString(undefined, { maximumFractionDigits: 2 })} ${m.live.currency || ""}`
+                        : <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>조회불가</span>}
+                    </td>
+                    <td style={{ textAlign: "right", padding: 6 }} className={m.realized_pnl > 0 ? "positive" : m.realized_pnl < 0 ? "negative" : ""}>
+                      {m.realized_pnl !== 0
+                        ? `${m.realized_pnl > 0 ? "+" : ""}${Number(m.realized_pnl).toLocaleString()}원`
+                        : <span style={{ color: "var(--text-muted)" }}>-</span>}
+                    </td>
+                    <td style={{ textAlign: "right", padding: 6 }}>
+                      {m.held_cost > 0
+                        ? `${Number(m.held_cost).toLocaleString()}원`
+                        : <span style={{ color: "var(--text-muted)" }}>-</span>}
+                    </td>
+                    <td style={{ padding: 6, fontSize: 11 }}>
+                      {tradingEnabled
+                        ? <span style={{ color: "#10b981" }}>✅ 봇 거래 활성</span>
+                        : <span style={{ color: "var(--text-muted)" }}>⏸️ 거래 OFF</span>}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           <div style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
-            💡 <strong>실제 잔고 (API)</strong>가 봇이 매수에 쓰는 진짜 예산. 장부값은 입출금 이력 추적용.
+            💡 <strong>실 잔고 (API)</strong>가 봇이 매수에 쓰는 예산. 입출금 이력은 위 버튼으로 기록.
           </div>
         </div>
       )}

--- a/admin/src/pages/PublicDashboardPage.tsx
+++ b/admin/src/pages/PublicDashboardPage.tsx
@@ -208,17 +208,104 @@ export default function PublicDashboardPage() {
         ))}
       </div>
 
-      {tab === "kis" && (
-        <div style={{ padding: 32, textAlign: "center", border: "1px dashed var(--border-color, #ccc)", borderRadius: 12 }}>
-          <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>📈 KIS 미국주식 봇</div>
-          <div style={{ fontSize: 13, color: "var(--text-secondary, #666)", marginBottom: 16 }}>
-            단타(데일리) 모드 운영 중. 누적 손익률 + 매매 내역 곧 추가 예정.
+      {tab === "kis" && (() => {
+        const kisTrades = trades.filter((t: any) => t.market === "kis_us" || t.market === "kis_kr");
+        const kisSells = kisTrades.filter((t: any) => t.side === "sell" && t.profit_pct != null);
+        const totalKisPct = kisSells.reduce((s: number, t: any) => s + (t.profit_pct || 0), 0);
+        const winCount = kisSells.filter((t: any) => (t.profit_pct || 0) > 0).length;
+        const lossCount = kisSells.filter((t: any) => (t.profit_pct || 0) < 0).length;
+        const winRate = kisSells.length > 0 ? (winCount / kisSells.length) * 100 : 0;
+        return (
+          <div>
+            {/* KIS 손익 요약 */}
+            <div className="pnl-hero">
+              <div className="pnl-hero-top">
+                <div>
+                  <div className="pnl-hero-title">KIS 미국주식 — 누적 손익률 (단타/EOD)</div>
+                  <div className="pnl-hero-value" style={{ color: totalKisPct > 0 ? "#34d399" : totalKisPct < 0 ? "#f87171" : "var(--text-secondary)" }}>
+                    {kisSells.length > 0
+                      ? `${totalKisPct >= 0 ? "+" : ""}${totalKisPct.toFixed(2)}%`
+                      : <span style={{ fontSize: 24 }}>매매 대기 중</span>}
+                  </div>
+                  <div className="pnl-hero-sub">
+                    체결 {kisSells.length}건 · 승률 {winRate.toFixed(0)}% (승 {winCount} / 패 {lossCount})
+                  </div>
+                </div>
+                <div className="pnl-hero-meta">
+                  <div className="pnl-hero-meta-item">
+                    <span>전략</span>
+                    <strong>Zarattini ORB</strong>
+                  </div>
+                  <div className="pnl-hero-meta-item">
+                    <span>봉 단위</span>
+                    <strong>5분봉</strong>
+                  </div>
+                  <div className="pnl-hero-meta-item">
+                    <span>모드</span>
+                    <strong>단타 (EOD 청산)</strong>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* KIS 매매 내역 */}
+            <div className="card" style={{ marginTop: 16 }}>
+              <div className="card-title">KIS 매매 내역 (최근 30건)</div>
+              {kisTrades.length === 0 ? (
+                <div className="empty-state" style={{ padding: 32, textAlign: "center", color: "var(--text-muted, #888)" }}>
+                  아직 매매 없음. 봇이 ORB 돌파 + VWAP + 거래량 spike 신호 대기 중.
+                </div>
+              ) : (
+                <div className="table-container">
+                  <table>
+                    <colgroup>
+                      <col style={{ width: "20%" }} />
+                      <col style={{ width: "18%" }} />
+                      <col style={{ width: "12%" }} />
+                      <col style={{ width: "15%" }} />
+                      <col style={{ width: "35%" }} />
+                    </colgroup>
+                    <thead>
+                      <tr>
+                        <th>시간 (KST)</th>
+                        <th>종목</th>
+                        <th>방향</th>
+                        <th>수익률</th>
+                        <th>사유</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {kisTrades.slice(0, 30).map((t: any, i: number) => (
+                        <tr key={t.id || i}>
+                          <td style={{ fontSize: 11 }}>{formatDateTime(t.timestamp).replace(/\d{4}\. /, "")}</td>
+                          <td style={{ fontWeight: 600 }}>{t.coin}</td>
+                          <td>
+                            <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10 }}>
+                              {t.side === "buy" ? "매수" : "매도"}
+                            </span>
+                          </td>
+                          <td className={t.profit_pct > 0 ? "positive" : t.profit_pct < 0 ? "negative" : ""}>
+                            {t.profit_pct != null ? `${t.profit_pct > 0 ? "+" : ""}${t.profit_pct.toFixed(2)}%` : "-"}
+                          </td>
+                          <td style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                            {(t.trigger_reason || "").slice(0, 80)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            <div style={{ padding: 16, marginTop: 16, fontSize: 12, color: "var(--text-muted, #888)", textAlign: "center" }}>
+              📚 학술 근거: Zarattini & Aziz (2023) "Can Day Trading Really Be Profitable?"
+              <br />
+              QQQ 5분 ORB → 8년 누적 +1,484%. 현재 SOXL로 검증 진행 중.
+            </div>
           </div>
-          <div style={{ fontSize: 12, color: "var(--text-secondary, #888)" }}>
-            현재는 admin 대시보드(KIS 탭)에서 확인 가능합니다.
-          </div>
-        </div>
-      )}
+        );
+      })()}
 
       {tab === "coin" && <>
       {/* #237 Hero: 누적 손익률 + 큰 차트 (전체 폭) */}


### PR DESCRIPTION
## Summary
- KIS 자본 카드: 시드(장부)/장부 가용 제거, 실 잔고 메인
- KPI: 100,000 fallback 제거, null 케이스 명확
- Public KIS 탭: placeholder → 실데이터 (매매 내역 + 손익률 + Zarattini 근거)

## Test plan
- [x] TypeScript OK
- [x] Pytest 523 통과 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)