### PR TITLE
fix: market-universe DB 우선 + OHLCV 실패 가시성 (#311)

### DIFF
--- a/src/cryptobot/api/routes/market_universe.py
+++ b/src/cryptobot/api/routes/market_universe.py
@@ -45,7 +45,7 @@ def get_market_universe(_: UserResponse = Depends(get_current_user)):
     from cryptobot.entrypoints.run_kis_us import _build_params, _parse_universe
     from cryptobot.bot.profit_threshold import get_thresholds
 
-    us_universe = _parse_universe()  # env KIS_US_UNIVERSE 반영
+    us_universe = _parse_universe(db)  # #311: DB의 enabled 종목 우선 (env는 fallback)
     us_params = _build_params(len(us_universe))
     kr_th = get_thresholds("kis_kr")
 

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -414,6 +414,18 @@ class KISUSBot:
             df = self._exchange.get_ohlcv(symbol, interval=self._ohlcv_interval, count=80)
         except APIError as e:
             logger.warning("%s OHLCV 조회 실패 — 매수 판단 스킵: %s", symbol, e)
+            # #311: 사용자 가시성 — OHLCV 실패도 평가 기록 (KIS 분봉 미지원 종목 식별용)
+            err_msg = str(e)[:120]
+            try:
+                self._db.execute(
+                    "INSERT INTO kis_us_evaluations "
+                    "(ticker, price, rsi, ma20, ma60, should_buy, reason, confidence, holds_already) "
+                    "VALUES (?, ?, NULL, NULL, NULL, 0, ?, 0, 0)",
+                    (symbol, float(price_usd), f"OHLCV 조회 실패: {err_msg}"),
+                )
+                self._db.commit()
+            except Exception:
+                pass
             return None, None
 
         # #303 전략 분기 — breakout (VWAP+ORB+거래량) vs mean_reversion (RSI)


### PR DESCRIPTION
## Summary
- market_universe API가 DB enabled 종목 정확히 반영
- OHLCV 조회 실패도 평가 기록 (KIS 분봉 미지원 종목 식별)

## Test plan
- [x] 524개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)