### PR TITLE
improve: 종목 풀 한국어 + dim + 30종목 추가 (#313)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -612,40 +612,56 @@ export default function DashboardPage() {
               활성 {kisSymbols.filter((s: any) => s.enabled).length}/{kisSymbols.length}종목 — 봇 5분마다 풀 재로딩 (재시작 불요)
             </span>
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 6, marginTop: 8 }}>
-            {kisSymbols.map((s: any) => (
-              <label
-                key={s.ticker}
-                style={{
-                  display: "flex", alignItems: "center", gap: 8,
-                  padding: "6px 10px", borderRadius: 6,
-                  background: s.enabled ? "rgba(74,158,255,0.12)" : "var(--bg-secondary)",
-                  border: s.enabled ? "1px solid #4a9eff" : "1px solid var(--border)",
-                  cursor: "pointer", fontSize: 12,
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={!!s.enabled}
-                  onChange={async (e) => {
-                    await client.post("/kis-symbols/toggle", { ticker: s.ticker, enabled: e.target.checked });
-                    fetchAll();
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 6, marginTop: 8 }}>
+            {kisSymbols.map((s: any) => {
+              const supported = s.minute_supported !== false;
+              const disabled = !supported;
+              return (
+                <label
+                  key={s.ticker}
+                  title={disabled ? "KIS 분봉 미지원 — 활성화해도 봇이 평가 못함" : ""}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 8,
+                    padding: "6px 10px", borderRadius: 6,
+                    background: disabled
+                      ? "var(--bg-secondary)"
+                      : s.enabled ? "rgba(74,158,255,0.12)" : "var(--bg-secondary)",
+                    border: disabled
+                      ? "1px dashed var(--border)"
+                      : s.enabled ? "1px solid #4a9eff" : "1px solid var(--border)",
+                    cursor: disabled ? "not-allowed" : "pointer",
+                    fontSize: 12,
+                    opacity: disabled ? 0.4 : 1,
                   }}
-                />
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontWeight: 600 }}>
-                    {s.ticker}
-                    {s.is_integer_only ? <span style={{ fontSize: 9, marginLeft: 4, color: "#f59e0b" }}>1주</span> : null}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!!s.enabled}
+                    disabled={disabled}
+                    onChange={async (e) => {
+                      if (disabled) return;
+                      await client.post("/kis-symbols/toggle", { ticker: s.ticker, enabled: e.target.checked });
+                      fetchAll();
+                    }}
+                  />
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontWeight: 600 }}>
+                      {s.ticker}
+                      {s.is_integer_only ? <span style={{ fontSize: 9, marginLeft: 4, color: "#f59e0b" }}>1주</span> : null}
+                      {disabled ? <span style={{ fontSize: 9, marginLeft: 4, color: "#ef4444" }}>분봉 미지원</span> : null}
+                    </div>
+                    <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+                      {s.display_name}{s.note ? ` — ${s.note}` : ""}
+                    </div>
                   </div>
-                  <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
-                    {s.display_name} · {s.exchange} · {s.category}
-                  </div>
-                </div>
-              </label>
-            ))}
+                </label>
+              );
+            })}
           </div>
           <div style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
-            💡 체크하면 봇 모니터링 풀에 추가. 종목당 한도 = 100% / N (활성 종목 수). 신규 추가는 SQL/API로 (POST /api/kis-symbols).
+            💡 체크하면 봇 모니터링 풀에 추가. 종목당 한도 100% (자금 부족 시 신뢰도 높은 것 우선).
+            <br />
+            ⚠️ <span style={{ color: "#ef4444" }}>분봉 미지원</span> 종목은 KIS API 제약으로 봇이 평가 불가 (활성화 X).
           </div>
         </div>
       )}

--- a/src/cryptobot/api/routes/kis_symbols.py
+++ b/src/cryptobot/api/routes/kis_symbols.py
@@ -13,7 +13,12 @@ router = APIRouter(prefix="/api/kis-symbols", tags=["kis-symbols"])
 
 @router.get("")
 def list_symbols(_: UserResponse = Depends(get_current_user)):
-    """전체 종목 목록 (활성/비활성 포함). 카테고리별 정렬."""
+    """전체 종목 목록 (활성/비활성 포함). 카테고리별 정렬.
+
+    #311: minute_supported 필드 추가 — KIS 분봉 미지원 종목은 admin UI에서 dim 처리.
+    """
+    from cryptobot.exchange.kis_us import KIS_MINUTE_UNSUPPORTED
+
     db = get_db()
     rows = db.execute(
         """
@@ -23,7 +28,12 @@ def list_symbols(_: UserResponse = Depends(get_current_user)):
         ORDER BY enabled DESC, category, ticker
         """
     ).fetchall()
-    return [dict(r) for r in rows]
+    result = []
+    for r in rows:
+        d = dict(r)
+        d["minute_supported"] = d["ticker"] not in KIS_MINUTE_UNSUPPORTED
+        result.append(d)
+    return result
 
 
 @router.post("/toggle")

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -1076,6 +1076,79 @@ class Database:
                     row,
                 )
 
+            # #311: 추가 종목 (idempotent) + display_name 한국어로 update
+            _additional = [
+                # 반도체 추가
+                ("MU",   "마이크론",          "NASD", 0, "semi",    0, "메모리 반도체"),
+                ("INTC", "인텔",              "NASD", 0, "semi",    0, "x86 반도체"),
+                ("QCOM", "퀄컴",              "NASD", 0, "semi",    0, "모바일 칩셋"),
+                ("AMAT", "어플라이드머티리얼", "NASD", 0, "semi",    0, "반도체 장비"),
+                # 빅테크 추가
+                ("CRM",  "세일즈포스",        "NYSE", 0, "bigtech", 0, "SaaS 1위"),
+                ("ORCL", "오라클",            "NYSE", 0, "bigtech", 0, "DB/클라우드"),
+                ("NOW",  "서비스나우",        "NYSE", 0, "bigtech", 0, "SaaS 워크플로우"),
+                ("ADBE", "어도비",            "NASD", 0, "bigtech", 0, "디자인 SW"),
+                # 바이오/헬스
+                ("LLY",  "일라이릴리",        "NYSE", 0, "bio",     0, "비만치료제 1위"),
+                ("UNH",  "유나이티드헬스",    "NYSE", 0, "bio",     0, "보험 1위"),
+                # 금융
+                ("JPM",  "JP모건",            "NYSE", 0, "finance", 0, "최대 은행"),
+                ("BAC",  "뱅크오브아메리카",  "NYSE", 0, "finance", 0, "은행"),
+                ("V",    "비자",              "NYSE", 0, "finance", 0, "결제 1위"),
+                ("MA",   "마스터카드",        "NYSE", 0, "finance", 0, "결제 2위"),
+                # 소비재
+                ("WMT",  "월마트",            "NYSE", 0, "consumer", 0, "유통 1위"),
+                ("COST", "코스트코",          "NASD", 0, "consumer", 0, "회원제 마트"),
+                ("MCD",  "맥도날드",          "NYSE", 0, "consumer", 0, "패스트푸드"),
+                ("KO",   "코카콜라",          "NYSE", 0, "consumer", 0, "음료"),
+                # 에너지
+                ("XOM",  "엑손모빌",          "NYSE", 0, "energy",  0, "정유"),
+                ("CVX",  "쉐브론",            "NYSE", 0, "energy",  0, "정유"),
+                # ETF (1X 시장 노출)
+                ("SOXX", "iShares 반도체 ETF","NASD", 0, "etf",     0, "반도체 1X"),
+                ("SMH",  "VanEck 반도체 ETF", "NASD", 0, "etf",     0, "반도체 1X"),
+                ("ARKK", "ARK 혁신 ETF",      "AMEX", 0, "etf",     0, "성장주 ETF"),
+                ("XLK",  "기술 섹터 ETF",     "AMEX", 0, "etf",     0, "기술 섹터"),
+                ("XLF",  "금융 섹터 ETF",     "AMEX", 0, "etf",     0, "금융 섹터"),
+                ("XLV",  "헬스케어 섹터 ETF", "AMEX", 0, "etf",     0, "헬스 섹터"),
+                ("IWM",  "Russell 2000 ETF", "AMEX", 0, "etf",     0, "소형주"),
+                # 인기 단타 종목
+                ("ABNB", "에어비앤비",        "NASD", 0, "ai",      0, "여행/숙박"),
+                ("UBER", "우버",              "NYSE", 0, "ai",      0, "라이드쉐어"),
+                ("SHOP", "쇼피파이",          "NYSE", 0, "ai",      0, "이커머스 SaaS"),
+                ("DIS",  "디즈니",            "NYSE", 0, "consumer", 0, "엔터테인먼트"),
+            ]
+            for row in _additional:
+                conn.execute(
+                    "INSERT OR IGNORE INTO kis_us_symbols "
+                    "(ticker, display_name, exchange, is_integer_only, category, enabled, note) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    row,
+                )
+
+            # #311: 기존 영문 display_name 한국어로 update (한 번만)
+            _korean_names = {
+                "AAPL": "애플", "MSFT": "마이크로소프트", "GOOGL": "구글(알파벳)",
+                "AMZN": "아마존", "META": "메타(페이스북)",
+                "NVDA": "엔비디아", "AMD": "AMD", "TSM": "TSMC", "AVGO": "브로드컴",
+                "ASML": "ASML", "SNDK": "샌디스크",
+                "SOXL": "반도체 강세 3X", "SOXS": "반도체 약세 3X",
+                "TQQQ": "나스닥 강세 3X", "SQQQ": "나스닥 약세 3X",
+                "USD": "반도체 강세 2X", "TECL": "기술주 강세 3X",
+                "NVDL": "엔비디아 강세 2X", "SNXX": "샌디스크 강세 2X",
+                "SPXL": "S&P500 강세 3X", "SPXS": "S&P500 약세 3X",
+                "TSLL": "테슬라 강세 2X", "LABU": "바이오 강세 3X", "LABD": "바이오 약세 3X",
+                "COIN": "코인베이스", "MSTR": "마이크로스트래티지", "HOOD": "로빈후드",
+                "TSLA": "테슬라", "RIVN": "리비안",
+                "PLTR": "팔란티어", "ARM": "암 홀딩스", "NFLX": "넷플릭스",
+                "QQQ": "나스닥100 ETF", "SPY": "S&P500 ETF", "VOO": "뱅가드 S&P500",
+            }
+            for ticker, korean in _korean_names.items():
+                conn.execute(
+                    "UPDATE kis_us_symbols SET display_name = ? WHERE ticker = ? AND display_name != ?",
+                    (korean, ticker, korean),
+                )
+
             # 코인 카테고리별 전략 기본값
             row = conn.execute("SELECT COUNT(*) FROM coin_strategy_config").fetchone()
             if row[0] == 0:

--- a/src/cryptobot/exchange/kis_us.py
+++ b/src/cryptobot/exchange/kis_us.py
@@ -109,6 +109,12 @@ INTEGER_ONLY_TICKERS: set[str] = {
     "SPXL", "SPXS", "TSLL", "LABU", "LABD",
 }
 
+# #311: KIS 분봉 미지원 종목 (HHDFS76950200 응답 빈 결과)
+# 활성화해도 OHLCV 조회 실패로 평가 불가. Admin UI에서 dim 처리.
+KIS_MINUTE_UNSUPPORTED: set[str] = {
+    "TQQQ", "SQQQ", "NVDL", "TSLL", "BIB", "QLD",
+}
+
 
 class KISUSExchange(Exchange):
     """KIS 미국주식 어댑터.


### PR DESCRIPTION
## Summary
- 분봉 미지원 종목 dim (KIS_MINUTE_UNSUPPORTED set + minute_supported 필드)
- display_name + note 한국어
- 종목 32→62개 (반도체/빅테크/바이오/금융/ETF 추가)

## Test plan
- [x] 524 테스트 통과
- [x] TS OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)