### PR TITLE
improve: KIS 매매 UI + 수동 거래 기록 (#325)

### DIFF
--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -270,21 +270,37 @@ export default function DashboardPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {recentTrades.map((t) => (
-                    <tr key={t.id}>
-                      <td style={{ fontSize: 10 }}>{formatDateTime(t.timestamp).replace(/\d{4}\. /, "").replace(/:(\d{2})$/, "")}</td>
-                      <td style={{ fontSize: 12 }}>{t.coin?.replace("KRW-", "")}</td>
-                      <td>
-                        <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10 }}>
-                          {t.side === "buy" ? "매수" : "매도"}
-                        </span>
-                      </td>
-                      <td style={{ fontSize: 11 }}>{formatKRW(t.total_krw)}</td>
-                      <td style={{ fontSize: 10, color: "var(--text-muted)", maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {t.trigger_reason || "-"}
-                      </td>
-                    </tr>
-                  ))}
+                  {recentTrades.map((t: any) => {
+                    const isKis = t.market === "kis_us" || t.market === "kis_kr";
+                    const marketIcon = t.market === "kis_us" ? "🇺🇸" : t.market === "kis_kr" ? "🇰🇷" : "🪙";
+                    return (
+                      <tr key={t.id}>
+                        <td style={{ fontSize: 10 }}>{formatDateTime(t.timestamp).replace(/\d{4}\. /, "").replace(/:(\d{2})$/, "")}</td>
+                        <td style={{ fontSize: 12 }}>
+                          <span style={{ marginRight: 4, fontSize: 10 }}>{marketIcon}</span>
+                          {t.coin?.replace("KRW-", "")}
+                        </td>
+                        <td>
+                          <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10 }}>
+                            {t.side === "buy" ? "매수" : "매도"}
+                          </span>
+                        </td>
+                        <td style={{ fontSize: 11 }}>
+                          {isKis && t.price
+                            ? `$${Number(t.price).toFixed(2)}`
+                            : formatKRW(t.total_krw)}
+                          {t.profit_pct != null && (
+                            <span className={t.profit_pct > 0 ? "positive" : "negative"} style={{ marginLeft: 4, fontSize: 10 }}>
+                              ({t.profit_pct > 0 ? "+" : ""}{t.profit_pct.toFixed(2)}%)
+                            </span>
+                          )}
+                        </td>
+                        <td style={{ fontSize: 10, color: "var(--text-muted)", maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {t.trigger_reason || "-"}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/admin/src/pages/TradesPage.tsx
+++ b/admin/src/pages/TradesPage.tsx
@@ -173,17 +173,27 @@ export default function TradesPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {data.items.map((t) => (
+                  {data.items.map((t: any) => {
+                    const isKis = t.market === "kis_us" || t.market === "kis_kr";
+                    const marketIcon = t.market === "kis_us" ? "🇺🇸" : t.market === "kis_kr" ? "🇰🇷" : "🪙";
+                    const priceUnit = t.market === "kis_us" ? "$" : "₩";
+                    const priceFormatted = t.market === "kis_us"
+                      ? `$${Number(t.price).toFixed(2)}`
+                      : formatKRW(t.price);
+                    return (
                     <tr key={t.id} style={{ cursor: "pointer" }} onClick={() => setSelectedTrade(t)}>
                       <td style={{ fontSize: 12 }}>{formatDateTime(t.timestamp)}</td>
-                      <td>{t.coin}</td>
+                      <td>
+                        <span style={{ marginRight: 4, fontSize: 11 }}>{marketIcon}</span>
+                        {t.coin}
+                      </td>
                       <td>
                         <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`}>
                           {t.side === "buy" ? "매수" : "매도"}
                         </span>
                       </td>
-                      <td>{formatKRW(t.price)}</td>
-                      <td>{t.amount.toFixed(8)}</td>
+                      <td>{priceFormatted}</td>
+                      <td>{isKis ? Number(t.amount).toFixed(t.amount === Math.floor(t.amount) ? 0 : 4) : t.amount.toFixed(8)}</td>
                       <td>{formatKRW(t.total_krw)}</td>
                       <td><span className="badge badge-purple">{t.strategy}</span></td>
                       <td style={{ fontSize: 12 }}>
@@ -196,7 +206,8 @@ export default function TradesPage() {
                         {t.profit_krw != null ? formatKRW(t.profit_krw) : "-"}
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## Summary
- Admin Dashboard 최근 매매에 KIS 표시 (시장 아이콘, USD 가격, 손익%)
- TradesPage 시장별 통화 분기
- 수동 테스트 거래 DB 기록 (SOXL 매수/매도)

## Test plan
- [x] Pytest OK
- [x] TS OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)