### PR TITLE
fix: Slack notify_trade 시그니처 (#329)

### DIFF
--- a/src/cryptobot/entrypoints/run_kis_kr.py
+++ b/src/cryptobot/entrypoints/run_kis_kr.py
@@ -253,7 +253,7 @@ class KISKoreanBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
-            self._notifier.notify_trade(
+            self._notifier.notify_trade_message(
                 f"[KIS_KR][매수] {symbol} {result.amount:.0f}주 @ {result.price:,.0f}원 — {reason}"
             )
 
@@ -277,7 +277,7 @@ class KISKoreanBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
-            self._notifier.notify_trade(
+            self._notifier.notify_trade_message(
                 f"[KIS_KR][매도] {symbol} {result.amount:.0f}주 "
                 f"@ {result.price:,.0f}원 ({pnl_pct:+.2f}%) — {reason}"
             )

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -538,7 +538,7 @@ class KISUSBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
-            self._notifier.notify_trade(
+            self._notifier.notify_trade_message(
                 f"[KIS_US][매수] {symbol} {result.amount:.4f}주 @ ${result.price:.2f} — {reason}"
             )
 
@@ -566,7 +566,7 @@ class KISUSBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
-            self._notifier.notify_trade(
+            self._notifier.notify_trade_message(
                 f"[KIS_US][매도] {symbol} {result.amount:.4f}주 @ ${result.price:.2f} ({pnl_pct:+.2f}%) — {reason}"
             )
         self._last_buy_price.pop(symbol, None)

--- a/src/cryptobot/notifier/slack.py
+++ b/src/cryptobot/notifier/slack.py
@@ -101,8 +101,16 @@ class SlackNotifier:
             logger.error("Slack Webhook 전송 에러: %s", e)
             return False
 
+    def notify_trade_message(self, message: str) -> bool:
+        """#329: 자유형식 매매 알림 (KIS 봇 등 시장별 통화 다른 경우용).
+
+        호출자가 이미 formatted string 갖고 있을 때 사용.
+        예: "[KIS_US][매수] SOXL 1주 @ $171.50 — ORB↑..."
+        """
+        return self.send(message)
+
     def notify_trade(self, side: str, coin: str, price: float, amount: float, total_krw: float) -> bool:
-        """매매 체결 알림 (#197: 가독성 강화)."""
+        """매매 체결 알림 (#197: 가독성 강화). 코인 봇 KRW 전용."""
         emoji = "🟢" if side == "buy" else "🔴"
         side_kr = "매수" if side == "buy" else "매도"
         sym = coin.replace("KRW-", "")

--- a/src/cryptobot/strategies/vwap_orb_breakout.py
+++ b/src/cryptobot/strategies/vwap_orb_breakout.py
@@ -34,9 +34,14 @@ from cryptobot.strategies.base import BaseStrategy, Signal, StrategyInfo
 logger = logging.getLogger(__name__)
 KST = ZoneInfo("Asia/Seoul")
 
-# EOD = 매일 KST 09시 (사용자 정의 가능, env COIN_EOD_HOUR_KST)
-# 추천: 자정 ORB와 가까운 23시 (사이클 23시간 활용) 또는 09시 (사용자 일어남 직후 결과 확인)
-EOD_HOUR_KST = int(os.getenv("COIN_EOD_HOUR_KST", "9"))
+# EOD = 매일 KST N시 (사용자 정의 가능, env COIN_EOD_HOUR_KST)
+# 추천: 0시(자정, 사이클 24h) / 23시 / 9시. 호출 시점 평가 (env 변경 후 봇 재시작만 하면 반영).
+EOD_HOUR_KST = 9  # 디폴트 (테스트용 상수)
+
+
+def _eod_hour() -> int:
+    """현재 EOD 시간 (env 우선)."""
+    return int(os.getenv("COIN_EOD_HOUR_KST", str(EOD_HOUR_KST)))
 
 
 class VwapOrbBreakout(BaseStrategy):
@@ -144,7 +149,7 @@ def is_eod_window(now: datetime | None = None, window_minutes: int = 5) -> bool:
         now = datetime.now(KST)
     elif now.tzinfo is None:
         now = now.replace(tzinfo=KST)
-    eod = now.replace(hour=EOD_HOUR_KST, minute=0, second=0, microsecond=0)
+    eod = now.replace(hour=_eod_hour(), minute=0, second=0, microsecond=0)
     delta = abs((now - eod).total_seconds())
     return delta <= window_minutes * 60
 

--- a/tests/test_vwap_orb_breakout.py
+++ b/tests/test_vwap_orb_breakout.py
@@ -86,18 +86,21 @@ def test_check_buy_orb_forming():
     assert "ORB 형성 중" in sig.reason
 
 
-def test_is_eod_window_at_9am():
+def test_is_eod_window_at_9am(monkeypatch):
     """KST 09:00 정각 → EOD."""
+    monkeypatch.setenv("COIN_EOD_HOUR_KST", "9")
     assert is_eod_window(datetime(2026, 5, 9, 9, 0, 0, tzinfo=KST)) is True
 
 
-def test_is_eod_window_at_904():
+def test_is_eod_window_at_904(monkeypatch):
     """KST 09:04 → EOD 윈도우 안 (5분 윈도우)."""
+    monkeypatch.setenv("COIN_EOD_HOUR_KST", "9")
     assert is_eod_window(datetime(2026, 5, 9, 9, 4, 0, tzinfo=KST)) is True
 
 
-def test_is_eod_window_outside():
+def test_is_eod_window_outside(monkeypatch):
     """KST 09:10 → 윈도우 밖."""
+    monkeypatch.setenv("COIN_EOD_HOUR_KST", "9")
     assert is_eod_window(datetime(2026, 5, 9, 9, 10, 0, tzinfo=KST)) is False
     assert is_eod_window(datetime(2026, 5, 9, 8, 0, 0, tzinfo=KST)) is False
     assert is_eod_window(datetime(2026, 5, 9, 12, 0, 0, tzinfo=KST)) is False
@@ -127,5 +130,5 @@ def test_strategy_info():
 
 
 def test_eod_hour_constant():
-    """EOD 시간 상수 = KST 09:00."""
-    assert EOD_HOUR_KST == 9
+    """EOD 시간 디폴트 상수 = KST 09:00 (env 미설정 시)."""
+    assert EOD_HOUR_KST == 9  # 모듈 디폴트 — env로 오버라이드 가능


### PR DESCRIPTION
KIS 봇 4곳 string 1개 전달 → notify_trade_message 새 메서드로 분리. EOD_HOUR 동적 평가 부수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)