### PR TITLE
feat: PublicDashboardPage 인라인 스타일 추가 마이그레이션 (#351)

### DIFF
--- a/admin/src/pages/PublicDashboardPage.tsx
+++ b/admin/src/pages/PublicDashboardPage.tsx
@@ -115,26 +115,26 @@ export default function PublicDashboardPage() {
     <div className="public-wrap">
       <div className="public-header">
         <div className="public-header-brand">
-          <div className="skel" style={{ width: 36, height: 36, borderRadius: 10 }} />
+          <div className="skel w-9 h-9 rounded-[10px]" />
           <div>
-            <div className="skel skel-line" style={{ width: 100 }} />
-            <div className="skel skel-line" style={{ width: 140, height: 11 }} />
+            <div className="skel skel-line w-[100px]" />
+            <div className="skel skel-line w-[140px] h-[11px]" />
           </div>
         </div>
-        <div className="skel" style={{ width: 70, height: 28, borderRadius: 20 }} />
+        <div className="skel w-[70px] h-7 rounded-[20px]" />
       </div>
-      <div className="skel" style={{ height: 320, marginBottom: 24, borderRadius: 20 }} />
-      <div className="kpi-grid-public" style={{ gridTemplateColumns: "repeat(6, 1fr)" }}>
+      <div className="skel h-80 mb-6 rounded-[20px]" />
+      <div className="kpi-grid-public grid-cols-6">
         {[...Array(6)].map((_, i) => (<div key={i} className="skel skel-card" />))}
       </div>
     </div>
   );
 
   if (!summary && !loading) return (
-    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "60vh", gap: 12 }}>
-      <div style={{ fontSize: 36, animation: "pulse 2s ease-in-out infinite" }}>📡</div>
-      <span style={{ color: "var(--text-secondary)", fontSize: 16, fontWeight: 600 }}>서버와 연결 중입니다</span>
-      <span style={{ color: "var(--text-muted)", fontSize: 13 }}>잠시만 기다려주세요 — 곧 실시간 데이터가 표시됩니다</span>
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-3">
+      <div className="text-4xl" style={{ animation: "pulse 2s ease-in-out infinite" }}>📡</div>
+      <span className="text-base font-semibold" style={{ color: "var(--text-secondary)" }}>서버와 연결 중입니다</span>
+      <span className="text-[13px]" style={{ color: "var(--text-muted)" }}>잠시만 기다려주세요 — 곧 실시간 데이터가 표시됩니다</span>
       <style>{`@keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.15); } }`}</style>
     </div>
   );
@@ -187,7 +187,7 @@ export default function PublicDashboardPage() {
       </div>
 
       {/* #287 탭 — 코인 / KIS */}
-      <div style={{ display: "flex", gap: 4, margin: "12px 0 16px", borderBottom: "1px solid var(--border-color, #ddd)" }}>
+      <div className="flex gap-1 mt-3 mb-4 border-b" style={{ borderColor: "var(--border-color, #ddd)" }}>
         {([
           { id: "coin", label: "🪙 코인 (Upbit)" },
           { id: "kis", label: "📈 KIS 미국주식" },
@@ -195,11 +195,10 @@ export default function PublicDashboardPage() {
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
+            className="px-[18px] py-2.5 border-none cursor-pointer text-sm bg-transparent"
             style={{
-              padding: "10px 18px", border: "none", cursor: "pointer", fontSize: 14,
               fontWeight: tab === t.id ? 700 : 500,
               borderBottom: tab === t.id ? "2px solid #4a9eff" : "2px solid transparent",
-              background: "transparent",
               color: tab === t.id ? "#4a9eff" : "var(--text-secondary, #666)",
             }}
           >
@@ -252,18 +251,18 @@ export default function PublicDashboardPage() {
             <div className="card mt-4">
               <div className="card-title">KIS 매매 내역 (최근 30건)</div>
               {kisTrades.length === 0 ? (
-                <div className="empty-state" style={{ padding: 32, textAlign: "center", color: "var(--text-muted, #888)" }}>
+                <div className="empty-state p-8 text-center" style={{ color: "var(--text-muted, #888)" }}>
                   아직 매매 없음. 봇이 ORB 돌파 + VWAP + 거래량 spike 신호 대기 중.
                 </div>
               ) : (
                 <div className="table-container">
                   <table>
                     <colgroup>
-                      <col style={{ width: "20%" }} />
-                      <col style={{ width: "18%" }} />
-                      <col style={{ width: "12%" }} />
-                      <col style={{ width: "15%" }} />
-                      <col style={{ width: "35%" }} />
+                      <col className="w-[20%]" />
+                      <col className="w-[18%]" />
+                      <col className="w-[12%]" />
+                      <col className="w-[15%]" />
+                      <col className="w-[35%]" />
                     </colgroup>
                     <thead>
                       <tr>
@@ -277,10 +276,10 @@ export default function PublicDashboardPage() {
                     <tbody>
                       {kisTrades.slice(0, 30).map((t: any, i: number) => (
                         <tr key={t.id || i}>
-                          <td style={{ fontSize: 11 }}>{formatDateTime(t.timestamp).replace(/\d{4}\. /, "")}</td>
+                          <td className="text-[11px]">{formatDateTime(t.timestamp).replace(/\d{4}\. /, "")}</td>
                           <td className="font-semibold">{t.coin}</td>
                           <td>
-                            <span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10 }}>
+                            <span className={`badge text-[10px] ${t.side === "buy" ? "badge-green" : "badge-red"}`}>
                               {t.side === "buy" ? "매수" : "매도"}
                             </span>
                           </td>
@@ -298,7 +297,7 @@ export default function PublicDashboardPage() {
               )}
             </div>
 
-            <div style={{ padding: 16, marginTop: 16, fontSize: 12, color: "var(--text-muted, #888)", textAlign: "center" }}>
+            <div className="p-4 mt-4 text-xs text-center" style={{ color: "var(--text-muted, #888)" }}>
               📚 학술 근거: Zarattini & Aziz (2023) "Can Day Trading Really Be Profitable?"
               <br />
               QQQ 5분 ORB → 8년 누적 +1,484%. 현재 SOXL로 검증 진행 중.
@@ -317,7 +316,7 @@ export default function PublicDashboardPage() {
               {isPos ? "+" : ""}{totalPct.toFixed(2)}%
             </div>
             <div className="pnl-hero-sub">
-              오늘 변동 <span style={{ color: todayPct >= 0 ? "#34d399" : "#f87171", fontWeight: 700 }}>
+              오늘 변동 <span className="font-bold" style={{ color: todayPct >= 0 ? "#34d399" : "#f87171" }}>
                 {todayPct >= 0 ? "+" : ""}{todayPct.toFixed(2)}%
               </span>
             </div>
@@ -332,9 +331,9 @@ export default function PublicDashboardPage() {
               <strong>{monitoringCoins.length}개 코인</strong>
             </div>
             {fg && (
-              <div className="pnl-hero-meta-item" style={{ minWidth: 140 }}>
+              <div className="pnl-hero-meta-item min-w-[140px]">
                 <span>공포/탐욕 · {fgLabel}</span>
-                <strong style={{ color: fgColor, fontSize: 18 }}>{fg.value}<span style={{ fontSize: 11, opacity: 0.6 }}>/100</span></strong>
+                <strong className="text-lg" style={{ color: fgColor }}>{fg.value}<span className="text-[11px] opacity-60">/100</span></strong>
                 <div className="fg-gauge">
                   <div className="fg-gauge-track">
                     <div className="fg-gauge-marker" style={{ left: `${fg.value}%` }} />
@@ -350,14 +349,14 @@ export default function PublicDashboardPage() {
 
         {/* #241: 일별 추이 + BTC HODL 벤치마크 */}
         {pnlHistory.length > 1 && (
-          <div style={{ marginTop: 24, height: 240 }}>
-            <div style={{ display: "flex", gap: 18, fontSize: 11, marginBottom: 6, opacity: 0.85 }}>
-              <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span style={{ width: 14, height: 2.5, background: accentColor, display: "inline-block", borderRadius: 2 }} />
+          <div className="mt-6 h-60">
+            <div className="flex gap-4 text-[11px] mb-1.5 opacity-85">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 h-[2.5px] rounded-sm" style={{ background: accentColor }} />
                 내 봇
               </span>
-              <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span style={{ width: 14, borderTop: "2px dashed #fbbf24", display: "inline-block" }} />
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3.5 border-t-2 border-dashed" style={{ borderColor: "#fbbf24" }} />
                 BTC 단순 보유
               </span>
             </div>
@@ -382,7 +381,7 @@ export default function PublicDashboardPage() {
 
       {/* #237/#239 KPI 그리드 — Hero 아래 (6개로 확장) */}
       {summary && (
-        <div className="kpi-grid-public" style={{ gridTemplateColumns: "repeat(6, 1fr)" }}>
+        <div className="kpi-grid-public grid-cols-6">
           <div className="kpi-card-public">
             <div className="kpi-label-public">전체 승률</div>
             <div className="kpi-value-public" style={{ color: summary.win_rate >= 50 ? "#10b981" : "#ef4444" }}>
@@ -433,15 +432,15 @@ export default function PublicDashboardPage() {
         const flat = dailyData.length - wins - losses;
         return (
           <div className="card mb-6">
-            <div className="section-title-row" style={{ margin: "0 0 12px" }}>
+            <div className="section-title-row mb-3 mt-0 mx-0">
               <h2>일별 손익</h2>
               <span className="section-meta">
                 <span style={{ color: "#10b981" }}>이익 {wins}일</span> ·
-                <span style={{ color: "#ef4444", marginLeft: 6 }}>손실 {losses}일</span>
-                {flat > 0 && <span style={{ color: "var(--text-muted)", marginLeft: 6 }}>· 보합 {flat}일</span>}
+                <span className="ml-1.5" style={{ color: "#ef4444" }}>손실 {losses}일</span>
+                {flat > 0 && <span className="ml-1.5" style={{ color: "var(--text-muted)" }}>· 보합 {flat}일</span>}
               </span>
             </div>
-            <div style={{ height: 180 }}>
+            <div className="h-[180px]">
               <ResponsiveContainer>
                 <BarChart data={dailyData} margin={{ top: 5, right: 8, left: -16, bottom: 0 }}>
                   <CartesianGrid stroke="var(--border)" vertical={false} strokeDasharray="3 3" />
@@ -466,7 +465,7 @@ export default function PublicDashboardPage() {
 
       {/* 뉴스 티커 */}
       {news.length > 0 && (
-        <div style={{ marginBottom: 12, position: "relative" }}>
+        <div className="mb-3 relative">
           <style>{`
             @keyframes slideUp { from { transform: translateY(100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
             .news-item { animation: slideUp 0.5s ease-out; }
@@ -479,51 +478,41 @@ export default function PublicDashboardPage() {
           `}</style>
 
           {/* 한줄 티커 — 고정 높이, 연한 블루 배경 */}
-          <div style={{
-            display: "flex", alignItems: "center", gap: 10,
-            padding: "10px 16px", borderRadius: 10,
+          <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-[10px] h-[42px] overflow-hidden transition-colors duration-500" style={{
             background: news[newsIndex]?.sentiment_keyword === "positive" ? "#f0fdf4" : news[newsIndex]?.sentiment_keyword === "negative" ? "#fef2f2" : "#fffbeb",
             border: `1px solid ${news[newsIndex]?.sentiment_keyword === "positive" ? "#bbf7d0" : news[newsIndex]?.sentiment_keyword === "negative" ? "#fecaca" : "#fde68a"}`,
-            transition: "background 0.5s, border-color 0.5s",
-            height: 42, overflow: "hidden",
           }}>
-            <span className={`badge ${(news[newsIndex]?.sentiment_keyword === "positive" ? "badge-green" : news[newsIndex]?.sentiment_keyword === "negative" ? "badge-red" : "badge-yellow")}`} style={{ fontSize: 9, flexShrink: 0 }}>
+            <span className={`badge text-[9px] shrink-0 ${(news[newsIndex]?.sentiment_keyword === "positive" ? "badge-green" : news[newsIndex]?.sentiment_keyword === "negative" ? "badge-red" : "badge-yellow")}`}>
               {news[newsIndex]?.sentiment_keyword === "positive" ? "긍정" : news[newsIndex]?.sentiment_keyword === "negative" ? "부정" : "중립"}
             </span>
-            <span key={newsIndex} className="news-item" style={{ fontSize: 13, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            <span key={newsIndex} className="news-item text-[13px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
               {news[newsIndex]?.title}
             </span>
-            <span style={{ fontSize: 10, color: "var(--text-muted)", flexShrink: 0, marginRight: 8 }}>{news[newsIndex]?.source}</span>
-            <button onClick={() => setNewsExpanded(!newsExpanded)} style={{
-              background: "none", border: "none", cursor: "pointer",
-              fontSize: 22, color: "#6b7fa3", flexShrink: 0,
+            <span className="text-[10px] shrink-0 mr-2" style={{ color: "var(--text-muted)" }}>{news[newsIndex]?.source}</span>
+            <button onClick={() => setNewsExpanded(!newsExpanded)} className="bg-none border-none cursor-pointer text-[22px] shrink-0 px-1 py-0 leading-none transition-transform duration-300" style={{
+              color: "#6b7fa3",
               transform: newsExpanded ? "rotate(-90deg)" : "rotate(90deg)",
-              transition: "transform 0.3s",
-              padding: "0 4px", lineHeight: 1,
             }}>›</button>
           </div>
 
           {/* 펼침 오버레이 — position absolute, 아래로 덮기 */}
           {newsExpanded && (
-            <div style={{
-              position: "absolute", top: 44, left: 0, right: 0, zIndex: 20,
-              background: "#ffffff", border: "1px solid var(--border)", borderRadius: 12,
+            <div className="absolute top-11 left-0 right-0 z-20 rounded-xl" style={{
+              background: "#ffffff",
+              border: "1px solid var(--border)",
               boxShadow: "0 12px 40px rgba(0,0,0,0.12)",
             }}>
               {news.slice(0, 10).map((n: any, i: number) => (
-                <a key={i} href={n.url} target="_blank" rel="noopener noreferrer" style={{
-                  display: "flex", alignItems: "flex-start", gap: 10,
-                  padding: "10px 16px", textDecoration: "none", color: "inherit",
+                <a key={i} href={n.url} target="_blank" rel="noopener noreferrer" className="flex items-start gap-2.5 px-4 py-2.5 no-underline text-inherit transition-colors duration-150" style={{
                   borderBottom: i < Math.min(news.length, 10) - 1 ? "1px solid var(--border)" : "none",
-                  transition: "background 0.15s",
                 }} onMouseEnter={(e) => (e.currentTarget.style.background = "#f8fafc")}
                    onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <span className={`badge ${n.sentiment_keyword === "positive" ? "badge-green" : n.sentiment_keyword === "negative" ? "badge-red" : "badge-yellow"}`} style={{ fontSize: 9, flexShrink: 0, marginTop: 2 }}>
+                  <span className={`badge text-[9px] shrink-0 mt-0.5 ${n.sentiment_keyword === "positive" ? "badge-green" : n.sentiment_keyword === "negative" ? "badge-red" : "badge-yellow"}`}>
                     {n.sentiment_keyword === "positive" ? "긍정" : n.sentiment_keyword === "negative" ? "부정" : "중립"}
                   </span>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 13, lineHeight: 1.5 }}>{n.title}</div>
-                    <div style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 2 }}>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[13px] leading-normal">{n.title}</div>
+                    <div className="text-[10px] mt-0.5" style={{ color: "var(--text-muted)" }}>
                       {n.source} · {formatDateTime(n.published_at).replace(/\d{4}\. /, "")}
                     </div>
                   </div>
@@ -534,12 +523,12 @@ export default function PublicDashboardPage() {
         </div>
       )}
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 24, alignItems: "stretch" }}>
+      <div className="grid grid-cols-2 gap-4 mb-6 items-stretch">
         {/* AI 분석 — 1번 고정 + 2~3번 롤링, 시장 상태 배경색 */}
-        <div className="card" style={{ display: "flex", flexDirection: "column" }}>
+        <div className="card flex flex-col">
           <div className="card-title">AI 시장 분석</div>
           {analysis.length > 0 ? (
-            <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+            <div className="flex flex-col flex-1">
               {(() => {
                 const slots = [analysis[0]];
                 if (analysis.length > 1) {
@@ -554,28 +543,23 @@ export default function PublicDashboardPage() {
                 const stateBorder = (state: string) =>
                   state === "bullish" ? "#bbf7d0" : state === "bearish" ? "#fecaca" : "#fde68a";
                 return slots.map((a: any, i: number) => (
-                  <div key={`${i}-${a?.timestamp}`} className={i === 1 ? "analysis-enter-1" : i === 2 ? "analysis-enter-2" : ""} style={{
-                    borderRadius: 10, overflow: "hidden", marginBottom: i < slots.length - 1 ? 10 : 0,
+                  <div key={`${i}-${a?.timestamp}`} className={`rounded-[10px] overflow-hidden ${i < slots.length - 1 ? "mb-2.5" : ""} ${i === 1 ? "analysis-enter-1" : i === 2 ? "analysis-enter-2" : ""}`} style={{
                     border: `1px solid ${stateBorder(a.market_state)}`,
                   }}>
                     {/* 제목 한줄 — 시장 상태 배경색 */}
-                    <div style={{
-                      display: "flex", justifyContent: "space-between", alignItems: "center",
-                      padding: "8px 12px",
+                    <div className="flex justify-between items-center px-3 py-2" style={{
                       background: stateColor(a.market_state),
                     }}>
-                      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                      <div className="flex gap-1.5 items-center">
                         <span className={`badge ${a.market_state === "bullish" ? "badge-green" : a.market_state === "bearish" ? "badge-red" : "badge-yellow"}`}>
                           {getMarketStateKR(a.market_state)}
                         </span>
-                        {i === 0 && <span style={{ fontSize: 9, color: "var(--accent-blue)", fontWeight: 700 }}>LATEST</span>}
+                        {i === 0 && <span className="text-[9px] font-bold" style={{ color: "var(--accent-blue)" }}>LATEST</span>}
                       </div>
-                      <span style={{ fontSize: 10, color: "var(--text-muted)" }}>{formatDateTime(a.timestamp)}</span>
+                      <span className="text-[10px]" style={{ color: "var(--text-muted)" }}>{formatDateTime(a.timestamp)}</span>
                     </div>
                     {/* 본문 */}
-                    <div style={{
-                      padding: "10px 12px", background: "#ffffff",
-                      fontSize: 13, lineHeight: 1.7,
+                    <div className="px-3 py-2.5 text-[13px] leading-[1.7] bg-white" style={{
                       fontWeight: i === 0 ? 600 : 400,
                       color: i === 0 ? "var(--text-primary)" : "var(--text-muted)",
                     }}>{a.summary}</div>
@@ -587,9 +571,9 @@ export default function PublicDashboardPage() {
         </div>
 
         {/* 오른쪽: 포트폴리오 + 모니터링 — AI분석과 높이 맞춤 */}
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, minHeight: 0 }}>
+        <div className="flex flex-col gap-4 min-h-0">
           {/* 포트폴리오 비중 — 도넛 차트 */}
-          <div className="card" style={{ flex: 1 }}>
+          <div className="card flex-1">
             <div className="card-title">포트폴리오 비중</div>
             {portfolio.length > 0 ? (
               <div className="flex items-center gap-2">
@@ -599,7 +583,7 @@ export default function PublicDashboardPage() {
                       data={portfolio.map((p: any) => ({ name: p.coin?.replace("KRW-", ""), value: p.weight_pct }))}
                       cx="50%" cy="50%" innerRadius={40} outerRadius={68} dataKey="value"
                       label={({ name, value }: any) => value >= 5 ? `${name}` : ""}
-                      labelLine={false} style={{ fontSize: 10 }}
+                      labelLine={false} className="text-[10px]"
                     >
                       {portfolio.map((_: any, i: number) => (
                         <Cell key={i} fill={["#94a3b8", "#2563eb", "#7c3aed", "#059669", "#d97706", "#dc2626", "#8b5cf6", "#ec4899", "#0891b2"][i % 9]} />
@@ -608,10 +592,10 @@ export default function PublicDashboardPage() {
                     <Tooltip formatter={(value: any) => [`${value}%`, "비중"]} />
                   </PieChart>
                 </ResponsiveContainer>
-                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <div className="flex flex-col gap-1">
                   {portfolio.map((p: any, i: number) => (
-                    <div key={p.coin} style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11 }}>
-                      <div style={{ width: 8, height: 8, borderRadius: 2, flexShrink: 0, background: ["#94a3b8", "#2563eb", "#7c3aed", "#059669", "#d97706", "#dc2626", "#8b5cf6", "#ec4899", "#0891b2"][i % 9] }} />
+                    <div key={p.coin} className="flex items-center gap-1.5 text-[11px]">
+                      <div className="w-2 h-2 rounded-sm shrink-0" style={{ background: ["#94a3b8", "#2563eb", "#7c3aed", "#059669", "#d97706", "#dc2626", "#8b5cf6", "#ec4899", "#0891b2"][i % 9] }} />
                       <span className="font-semibold">{p.coin?.replace("KRW-", "")}</span>
                       <span className="text-muted-foreground">{p.weight_pct}%</span>
                     </div>
@@ -623,17 +607,16 @@ export default function PublicDashboardPage() {
 
           {/* 모니터링 코인 */}
           {monitoringCoins.length > 0 && (
-            <div className="card" style={{ flex: 1 }}>
+            <div className="card flex-1">
               <div className="card-title">모니터링 중 ({monitoringCoins.length}개)</div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              <div className="flex flex-wrap gap-1.5">
                 {monitoringCoins.map((c: any) => (
-                  <div key={c.coin} style={{
-                    padding: "5px 10px", borderRadius: 8, fontSize: 11,
+                  <div key={c.coin} className="px-2.5 py-1 rounded-lg text-[11px]" style={{
                     background: c.market_state === "bullish" ? "#ecfdf5" : c.market_state === "bearish" ? "#fef2f2" : "#f8fafc",
                     border: `1px solid ${c.market_state === "bullish" ? "#a7f3d0" : c.market_state === "bearish" ? "#fecaca" : "var(--border)"}`,
                   }}>
                     <span className="font-semibold">{c.coin.replace("KRW-", "")}</span>
-                    {c.rsi && <span style={{ marginLeft: 3, color: "var(--text-muted)", fontSize: 10 }}>RSI {c.rsi}</span>}
+                    {c.rsi && <span className="ml-[3px] text-[10px]" style={{ color: "var(--text-muted)" }}>RSI {c.rsi}</span>}
                   </div>
                 ))}
               </div>
@@ -643,23 +626,19 @@ export default function PublicDashboardPage() {
       </div>
 
       {/* 블로그 배너 */}
-      <a href="https://seung-min.tistory.com/61" target="_blank" rel="noopener noreferrer" style={{
-        display: "block", marginBottom: 24, padding: "18px 24px", borderRadius: 12,
+      <a href="https://seung-min.tistory.com/61" target="_blank" rel="noopener noreferrer" className="block mb-6 px-6 py-[18px] rounded-xl text-white no-underline" style={{
         background: "linear-gradient(135deg, #059669 0%, #0d9488 50%, #0891b2 100%)",
-        color: "#ffffff", textDecoration: "none",
         boxShadow: "0 4px 16px rgba(5, 150, 105, 0.15)",
       }}>
         <div className="flex justify-between items-center">
           <div>
-            <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>개발 과정이 궁금하다면?</div>
-            <div style={{ fontSize: 12, color: "rgba(255,255,255,0.6)" }}>
+            <div className="text-base font-bold mb-1">개발 과정이 궁금하다면?</div>
+            <div className="text-xs" style={{ color: "rgba(255,255,255,0.6)" }}>
               AI 트레이딩 봇을 만들면서 겪은 시행착오, 버그 수정, 수익률 개선기를 블로그에 기록합니다
             </div>
           </div>
-          <div style={{
-            padding: "8px 20px", borderRadius: 8, fontSize: 13, fontWeight: 600,
+          <div className="px-5 py-2 rounded-lg text-[13px] font-semibold whitespace-nowrap" style={{
             background: "rgba(255,255,255,0.15)", border: "1px solid rgba(255,255,255,0.25)",
-            whiteSpace: "nowrap",
           }}>Blog →</div>
         </div>
       </a>
@@ -670,39 +649,37 @@ export default function PublicDashboardPage() {
           <div className="flex items-center gap-2">
             <span>최근 매매</span>
             {tradeFilter && (
-              <span style={{ fontSize: 11, color: "var(--accent-blue)", fontWeight: 600, cursor: "pointer" }}
+              <span className="text-[11px] font-semibold cursor-pointer" style={{ color: "var(--accent-blue)" }}
                 onClick={() => setTradeFilter(null)}>
                 {tradeFilter.replace("KRW-", "")} ✕
               </span>
             )}
             {sideFilter && (
-              <span style={{ fontSize: 11, fontWeight: 600, cursor: "pointer" }}
-                className={sideFilter === "buy" ? "positive" : "negative"}
+              <span
+                className={`text-[11px] font-semibold cursor-pointer ${sideFilter === "buy" ? "positive" : "negative"}`}
                 onClick={() => setSideFilter(null)}>
                 {sideFilter === "buy" ? "매수" : "매도"} ✕
               </span>
             )}
           </div>
           {trades.length > 5 && (
-            <button onClick={() => setShowAllTrades(!showAllTrades)} style={{
-              background: "none", border: "none", cursor: "pointer",
-              fontSize: 22, color: "#6b7fa3", lineHeight: 1,
+            <button onClick={() => setShowAllTrades(!showAllTrades)} className="bg-none border-none cursor-pointer text-[22px] leading-none transition-transform duration-300" style={{
+              color: "#6b7fa3",
               transform: showAllTrades ? "rotate(-90deg)" : "rotate(90deg)",
-              transition: "transform 0.3s",
             }}>›</button>
           )}
         </div>
         {trades.length > 0 ? (
-          <div style={{ overflowY: showAllTrades ? "auto" : "hidden", maxHeight: showAllTrades ? 240 : 240, overflowX: "hidden" }}>
-            <table style={{ width: "100%", tableLayout: "fixed" }}>
+          <div className={`max-h-60 overflow-x-hidden ${showAllTrades ? "overflow-y-auto" : "overflow-y-hidden"}`}>
+            <table className="w-full table-fixed">
               <colgroup>
-                <col style={{ width: "18%" }} />
-                <col style={{ width: "10%" }} />
-                <col style={{ width: "8%" }} />
-                <col style={{ width: "14%" }} />
-                <col style={{ width: "14%" }} />
-                <col style={{ width: "12%" }} />
-                <col style={{ width: "10%" }} />
+                <col className="w-[18%]" />
+                <col className="w-[10%]" />
+                <col className="w-[8%]" />
+                <col className="w-[14%]" />
+                <col className="w-[14%]" />
+                <col className="w-[12%]" />
+                <col className="w-[10%]" />
               </colgroup>
               <thead><tr><th>시간</th><th>종목</th><th>방향</th><th>전략</th><th>단가</th><th>수익률</th><th>보유</th></tr></thead>
               <tbody>
@@ -713,12 +690,12 @@ export default function PublicDashboardPage() {
                   return (showAllTrades ? filtered.slice(0, 50) : filtered.slice(0, 5)).map((t: any, i: number) => (
                   <tr key={i}>
                     <td className="text-xs text-muted-foreground">{formatDateTime(t.timestamp).replace(/\d{4}\. /, "")}</td>
-                    <td style={{ fontWeight: 600, cursor: "pointer", color: tradeFilter === t.coin ? "var(--accent-blue)" : "inherit" }}
+                    <td className="font-semibold cursor-pointer" style={{ color: tradeFilter === t.coin ? "var(--accent-blue)" : "inherit" }}
                       onClick={() => setTradeFilter(tradeFilter === t.coin ? null : t.coin)}>{t.coin?.replace("KRW-", "")}</td>
-                    <td><span className={`badge ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ fontSize: 10, cursor: "pointer", opacity: sideFilter && sideFilter !== t.side ? 0.4 : 1 }}
+                    <td><span className={`badge text-[10px] cursor-pointer ${t.side === "buy" ? "badge-green" : "badge-red"}`} style={{ opacity: sideFilter && sideFilter !== t.side ? 0.4 : 1 }}
                       onClick={() => setSideFilter(sideFilter === t.side ? null : t.side)}>{t.side === "buy" ? "매수" : "매도"}</span></td>
-                    <td style={{ fontSize: 11, color: "var(--text-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.strategy?.replace(/_/g, " ")}</td>
-                    <td style={{ fontSize: 11 }}>{t.price ? Number(t.price).toLocaleString() : "-"}</td>
+                    <td className="text-[11px] overflow-hidden text-ellipsis whitespace-nowrap" style={{ color: "var(--text-muted)" }}>{t.strategy?.replace(/_/g, " ")}</td>
+                    <td className="text-[11px]">{t.price ? Number(t.price).toLocaleString() : "-"}</td>
                     <td className={`font-semibold ${t.profit_pct != null ? (t.profit_pct >= 0 ? "positive" : "negative") : ""}`}>{t.profit_pct != null ? formatPercent(t.profit_pct) : "-"}</td>
                     <td className="text-xs text-muted-foreground">{t.hold_minutes != null ? `${t.hold_minutes}분` : "-"}</td>
                   </tr>
@@ -731,23 +708,19 @@ export default function PublicDashboardPage() {
       </div>
 
       {/* GitHub 배너 */}
-      <a href="https://github.com/SeungMinK/tradingbot" target="_blank" rel="noopener noreferrer" style={{
-        display: "block", marginBottom: 24, padding: "18px 24px", borderRadius: 12,
+      <a href="https://github.com/SeungMinK/tradingbot" target="_blank" rel="noopener noreferrer" className="block mb-6 px-6 py-[18px] rounded-xl text-white no-underline" style={{
         background: "linear-gradient(135deg, #0f172a 0%, #1e3a5f 50%, #312e81 100%)",
-        color: "#ffffff", textDecoration: "none",
         boxShadow: "0 4px 16px rgba(15, 23, 42, 0.15)",
       }}>
         <div className="flex justify-between items-center">
           <div>
-            <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>100% 오픈소스 · 직접 만든 AI 트레이딩 봇</div>
-            <div style={{ fontSize: 12, color: "rgba(255,255,255,0.55)" }}>
+            <div className="text-base font-bold mb-1">100% 오픈소스 · 직접 만든 AI 트레이딩 봇</div>
+            <div className="text-xs" style={{ color: "rgba(255,255,255,0.55)" }}>
               Claude AI 시장분석 · {strategies.length}개 매매 전략 · 실시간 파라미터 자동 조절 · Python + React
             </div>
           </div>
-          <div style={{
-            padding: "8px 20px", borderRadius: 8, fontSize: 13, fontWeight: 600,
+          <div className="px-5 py-2 rounded-lg text-[13px] font-semibold whitespace-nowrap" style={{
             background: "rgba(255,255,255,0.12)", border: "1px solid rgba(255,255,255,0.2)",
-            whiteSpace: "nowrap",
           }}>GitHub →</div>
         </div>
       </a>
@@ -761,11 +734,9 @@ export default function PublicDashboardPage() {
             <div className="card-title flex justify-between items-center">
               <span>매매 전략</span>
               {others.length > 0 && (
-                <button onClick={() => setShowAllStrategies(!showAllStrategies)} style={{
-                  background: "none", border: "none", cursor: "pointer",
-                  fontSize: 22, color: "#6b7fa3", lineHeight: 1,
+                <button onClick={() => setShowAllStrategies(!showAllStrategies)} className="bg-none border-none cursor-pointer text-[22px] leading-none transition-transform duration-300" style={{
+                  color: "#6b7fa3",
                   transform: showAllStrategies ? "rotate(-90deg)" : "rotate(90deg)",
-                  transition: "transform 0.3s",
                 }}>›</button>
               )}
             </div>
@@ -774,25 +745,24 @@ export default function PublicDashboardPage() {
             {actives.map((active: any) => {
               const activeStat = strategyStats.find((ss: any) => ss.strategy === active.name);
               return (
-              <div style={{
-                padding: 16, borderRadius: 12, marginBottom: 16,
+              <div className="p-4 rounded-xl mb-4" style={{
                 background: "linear-gradient(135deg, #eff6ff 0%, #f0fdf4 100%)",
                 border: "1px solid #bfdbfe",
               }}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+                <div className="flex justify-between items-center mb-2">
                   <div className="flex items-center gap-2">
-                    <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#22c55e", boxShadow: "0 0 6px rgba(34,197,94,0.5)" }} />
-                    <span style={{ fontWeight: 700, fontSize: 16 }}>{active.display_name}</span>
-                    <span style={{ fontSize: 10, color: "#22c55e", fontWeight: 600 }}>운영 중</span>
+                    <div className="w-2 h-2 rounded-full" style={{ background: "#22c55e", boxShadow: "0 0 6px rgba(34,197,94,0.5)" }} />
+                    <span className="font-bold text-base">{active.display_name}</span>
+                    <span className="text-[10px] font-semibold" style={{ color: "#22c55e" }}>운영 중</span>
                   </div>
-                  <div style={{ display: "flex", gap: 4 }}>
-                    <span className="badge badge-purple" style={{ fontSize: 9 }}>{active.category}</span>
-                    <span className="badge badge-yellow" style={{ fontSize: 9 }}>{active.difficulty}</span>
+                  <div className="flex gap-1">
+                    <span className="badge badge-purple text-[9px]">{active.category}</span>
+                    <span className="badge badge-yellow text-[9px]">{active.difficulty}</span>
                   </div>
                 </div>
-                <div style={{ fontSize: 13, color: "var(--text-secondary)", lineHeight: 1.6, marginBottom: 10 }}>{active.description}</div>
+                <div className="text-[13px] leading-relaxed mb-2.5" style={{ color: "var(--text-secondary)" }}>{active.description}</div>
                 {activeStat && (
-                  <div style={{ display: "flex", gap: 20, fontSize: 13 }}>
+                  <div className="flex gap-5 text-[13px]">
                     <div>
                       <span className="text-xs text-muted-foreground">거래 </span>
                       <span className="font-bold">{activeStat.trades}건</span>
@@ -813,17 +783,16 @@ export default function PublicDashboardPage() {
 
             {/* 나머지 전략 — 전체보기 시만 표시 */}
             {showAllStrategies && (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8, marginTop: 12 }}>
+            <div className="grid gap-2 mt-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))" }}>
               {others.map((s: any) => {
                 const stat = strategyStats.find((ss: any) => ss.strategy === s.name);
                 return (
-                  <div key={s.name} style={{
-                    padding: "10px 12px", borderRadius: 8,
+                  <div key={s.name} className="px-3 py-2.5 rounded-lg" style={{
                     background: "#f8fafc", border: "1px solid var(--border)",
                   }}>
-                    <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 3 }}>{s.display_name}</div>
-                    <div style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 6 }}>{s.description.slice(0, 40)}{s.description.length > 40 ? "..." : ""}</div>
-                    <div style={{ display: "flex", gap: 8, fontSize: 11 }}>
+                    <div className="font-semibold text-[13px] mb-[3px]">{s.display_name}</div>
+                    <div className="text-[10px] mb-1.5" style={{ color: "var(--text-muted)" }}>{s.description.slice(0, 40)}{s.description.length > 40 ? "..." : ""}</div>
+                    <div className="flex gap-2 text-[11px]">
                       {stat ? (
                         <>
                           <span>{stat.trades}건</span>
@@ -832,7 +801,7 @@ export default function PublicDashboardPage() {
                       ) : (
                         <span className="text-muted-foreground">대기 중</span>
                       )}
-                      <span className="badge badge-purple" style={{ fontSize: 8 }}>{s.category}</span>
+                      <span className="badge badge-purple text-[8px]">{s.category}</span>
                     </div>
                   </div>
                 );
@@ -849,22 +818,20 @@ export default function PublicDashboardPage() {
           <div className="card-title flex justify-between items-center">
             <span>일별 성과</span>
             {dailyReturns.length > 3 && (
-              <button onClick={() => setShowAllDaily(!showAllDaily)} style={{
-                background: "none", border: "none", cursor: "pointer",
-                fontSize: 22, color: "#6b7fa3", lineHeight: 1,
+              <button onClick={() => setShowAllDaily(!showAllDaily)} className="bg-none border-none cursor-pointer text-[22px] leading-none transition-transform duration-300" style={{
+                color: "#6b7fa3",
                 transform: showAllDaily ? "rotate(-90deg)" : "rotate(90deg)",
-                transition: "transform 0.3s",
               }}>›</button>
             )}
           </div>
-          <div style={{ overflowY: showAllDaily ? "auto" : "hidden", maxHeight: 200, overflowX: "hidden" }}>
-            <table style={{ width: "100%", tableLayout: "fixed" }}>
+          <div className={`max-h-[200px] overflow-x-hidden ${showAllDaily ? "overflow-y-auto" : "overflow-y-hidden"}`}>
+            <table className="w-full table-fixed">
               <colgroup>
-                <col style={{ width: "30%" }} />
-                <col style={{ width: "15%" }} />
-                <col style={{ width: "18%" }} />
-                <col style={{ width: "20%" }} />
-                <col style={{ width: "17%" }} />
+                <col className="w-[30%]" />
+                <col className="w-[15%]" />
+                <col className="w-[18%]" />
+                <col className="w-[20%]" />
+                <col className="w-[17%]" />
               </colgroup>
               <thead><tr><th>날짜</th><th>거래</th><th>승률</th><th>수익률</th><th>손익비</th></tr></thead>
               <tbody>
@@ -885,19 +852,19 @@ export default function PublicDashboardPage() {
       </>}
 
       {/* 면책 조항 + 푸터 */}
-      <div style={{ textAlign: "center", padding: "48px 24px 24px", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.8 }}>
-        <div style={{ borderTop: "1px solid var(--border)", paddingTop: 24, marginBottom: 16 }}>
-          <p style={{ margin: "0 0 8px", fontWeight: 600, fontSize: 12, color: "var(--text-secondary)", letterSpacing: 1 }}>
+      <div className="text-center pt-12 px-6 pb-6 text-[11px] leading-[1.8]" style={{ color: "var(--text-muted)" }}>
+        <div className="pt-6 mb-4 border-t" style={{ borderColor: "var(--border)" }}>
+          <p className="m-0 mb-2 font-semibold text-xs tracking-wider" style={{ color: "var(--text-secondary)" }}>
             Disclaimer
           </p>
-          <p style={{ margin: 0, maxWidth: 700, marginInline: "auto" }}>
+          <p className="m-0 max-w-[700px] mx-auto">
             본 서비스는 학습·포트폴리오 목적으로 제작된 자동매매 실험 프로젝트이며,
             투자 조언이나 특정 자산의 매수·매도를 권유하지 않습니다.<br />
             모든 투자 판단과 그에 따른 손익의 책임은 이용자 본인에게 있으며,
             개발자는 본 서비스 이용으로 발생한 어떠한 손실에도 책임을 지지 않습니다.
           </p>
         </div>
-        <div style={{ marginTop: 8 }}>
+        <div className="mt-2">
           Powered by Claude AI + {strategies.length} Trading Strategies
         </div>
       </div>


### PR DESCRIPTION
## Summary

- #352 후속. 인라인 `style={{...}}` **127 → 57개** (70개 변환)
- 섹션별 수동 Edit으로 신중하게 진행, 빌드 검증 통과
- 잔존 57개는 동적 색상/CSS 변수/그라디언트/Recharts 옵션 — className 변환이 부적절한 케이스

## 변환 대상 섹션

- 로딩 스켈레톤, 빈 상태 화면, 탭 (코인/KIS)
- Hero PnL, BTC HODL 차트 범례
- 뉴스 티커 + 펼침 오버레이
- AI 분석 카드 (3-슬롯 롤링)
- 포트폴리오 도넛 + 모니터링 코인 칩
- 블로그/GitHub 배너
- 최근 매매 테이블, 일별 성과 테이블
- 푸터/면책 조항

## Test plan

- [x] `npm run build` 성공
- [x] 중복 className/style 0건 (`grep -nE 'className=(\{[^}]*\}|"[^"]*") className='`)
- [ ] dev 서버 시각 확인 — 모든 섹션 정상 렌더링

## 베이스 브랜치

#352 위에 스택. #352 머지 후 main으로 rebase 됨.

Related: #351, #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)