### PR TITLE
perf: KIS rate limit endpoint group별 차등 throttle (#325)

### DIFF
--- a/src/cryptobot/exchange/kis/client.py
+++ b/src/cryptobot/exchange/kis/client.py
@@ -19,24 +19,58 @@ from cryptobot.exchange.kis.auth import KISTokenManager
 
 logger = logging.getLogger(__name__)
 
-# KIS API rate limit (#326):
+# KIS API rate limit (#326, #325):
 # - 공식 한도 1초 20건이지만 endpoint별 차등 (분봉/잔고는 1초 1회 수준)
 # - 0.25초(4건/초)도 분봉 API에서 자주 터짐
-# - 0.5초(2건/초)로 더 보수적, 캐시 강화로 호출 빈도 자체 줄임
-DEFAULT_MIN_INTERVAL_SEC = 0.5  # 1초 2건 (분봉 endpoint 한도 + 마진)
-PAPER_MIN_INTERVAL_SEC = 0.5
+# - endpoint group별 차등 throttle로 분봉만 보수적, 나머지는 빠르게
+DEFAULT_MIN_INTERVAL_SEC = 0.25  # 1초 4건 (가격/일봉/주문 등 일반 endpoint)
+PAPER_MIN_INTERVAL_SEC = 0.25
+
+# endpoint group별 최소 간격 (실전 기준)
+# - minute_chart: 분봉 API는 1초 1회 수준 (가장 보수적)
+# - balance: 잔고 조회도 종종 throttle, 0.5s 마진
+# - order: 주문은 신중히, 0.4s
+# - default: 일반 조회 (현재가, 일봉)
+ENDPOINT_INTERVALS_SEC: dict[str, float] = {
+    "minute_chart": 1.0,
+    "balance": 0.5,
+    "order": 0.4,
+    "default": DEFAULT_MIN_INTERVAL_SEC,
+}
+
+
+def classify_endpoint(path: str) -> str:
+    """API 경로를 endpoint group으로 분류.
+
+    Args:
+        path: KIS API 경로 (예: /uapi/overseas-price/v1/quotations/inquire-time-itemchartprice)
+
+    Returns:
+        endpoint group 이름 (minute_chart / balance / order / default)
+    """
+    if "inquire-time-itemchartprice" in path:
+        return "minute_chart"
+    if "inquire-balance" in path or "inquire-present-balance" in path:
+        return "balance"
+    if "/trading/order" in path:
+        return "order"
+    return "default"
 
 
 class KISClient:
     """KIS API REST 호출 클라이언트.
 
-    rate limiter 내장 (스레드 세이프).
+    rate limiter 내장 (스레드 세이프, endpoint group별 차등).
     """
 
     def __init__(self, token_manager: KISTokenManager, is_paper: bool = False) -> None:
         self._tm = token_manager
-        self._min_interval = PAPER_MIN_INTERVAL_SEC if is_paper else DEFAULT_MIN_INTERVAL_SEC
-        self._last_call_at = 0.0
+        # 모의투자도 동일 정책 (PAPER_MIN_INTERVAL_SEC는 default group에만 영향)
+        intervals = dict(ENDPOINT_INTERVALS_SEC)
+        if is_paper:
+            intervals["default"] = PAPER_MIN_INTERVAL_SEC
+        self._endpoint_intervals = intervals
+        self._endpoint_last_call: dict[str, float] = {g: 0.0 for g in intervals}
         self._lock = threading.Lock()
 
     @property
@@ -82,7 +116,7 @@ class KISClient:
         timeout: int = 10,
     ) -> dict:
         """공통 호출 로직 (rate limit + 에러 처리)."""
-        self._throttle()
+        self._throttle(path)
 
         url = f"{self._tm.host}{path}"
         headers = self._tm.auth_headers(tr_id)
@@ -111,11 +145,13 @@ class KISClient:
 
         return data
 
-    def _throttle(self) -> None:
-        """rate limit. 마지막 호출 후 min_interval 미만이면 sleep."""
+    def _throttle(self, path: str) -> None:
+        """rate limit. endpoint group별 마지막 호출 후 min_interval 미만이면 sleep."""
+        group = classify_endpoint(path)
+        interval = self._endpoint_intervals[group]
         with self._lock:
             now = time.monotonic()
-            elapsed = now - self._last_call_at
-            if elapsed < self._min_interval:
-                time.sleep(self._min_interval - elapsed)
-            self._last_call_at = time.monotonic()
+            elapsed = now - self._endpoint_last_call[group]
+            if elapsed < interval:
+                time.sleep(interval - elapsed)
+            self._endpoint_last_call[group] = time.monotonic()

--- a/tests/test_kis_rate_limit.py
+++ b/tests/test_kis_rate_limit.py
@@ -1,0 +1,113 @@
+"""KIS rate limiter (endpoint group별 차등 throttle) 테스트."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from cryptobot.exchange.kis.client import (
+    ENDPOINT_INTERVALS_SEC,
+    KISClient,
+    classify_endpoint,
+)
+
+
+class TestClassifyEndpoint:
+    """classify_endpoint() 분류 정확성 테스트."""
+
+    def test_minute_chart(self):
+        assert classify_endpoint("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice") == "minute_chart"
+
+    def test_balance(self):
+        assert classify_endpoint("/uapi/overseas-stock/v1/trading/inquire-balance") == "balance"
+        assert classify_endpoint("/uapi/overseas-stock/v1/trading/inquire-present-balance") == "balance"
+        assert classify_endpoint("/uapi/domestic-stock/v1/trading/inquire-balance") == "balance"
+
+    def test_order(self):
+        assert classify_endpoint("/uapi/overseas-stock/v1/trading/order") == "order"
+        assert classify_endpoint("/uapi/domestic-stock/v1/trading/order-cash") == "order"
+
+    def test_default(self):
+        assert classify_endpoint("/uapi/overseas-price/v1/quotations/price") == "default"
+        assert classify_endpoint("/uapi/overseas-price/v1/quotations/dailyprice") == "default"
+        assert classify_endpoint("/uapi/domestic-stock/v1/quotations/inquire-price") == "default"
+
+
+class TestEndpointIntervals:
+    """ENDPOINT_INTERVALS_SEC 설정값 검증."""
+
+    def test_groups_present(self):
+        for g in ("minute_chart", "balance", "order", "default"):
+            assert g in ENDPOINT_INTERVALS_SEC
+
+    def test_minute_chart_strictest(self):
+        """분봉이 가장 보수적이어야 함."""
+        mc = ENDPOINT_INTERVALS_SEC["minute_chart"]
+        for g, v in ENDPOINT_INTERVALS_SEC.items():
+            if g != "minute_chart":
+                assert mc >= v, f"minute_chart({mc}s)가 {g}({v}s)보다 짧음"
+
+    def test_default_fastest(self):
+        """default가 가장 빨라야 함 (또는 동률)."""
+        dft = ENDPOINT_INTERVALS_SEC["default"]
+        for v in ENDPOINT_INTERVALS_SEC.values():
+            assert dft <= v
+
+
+def _make_client() -> KISClient:
+    tm = MagicMock()
+    tm.host = "https://test"
+    tm.auth_headers = MagicMock(return_value={})
+    return KISClient(tm)
+
+
+class TestThrottlePerEndpoint:
+    """endpoint group별 독립 throttle 동작 검증."""
+
+    def test_separate_groups_dont_block_each_other(self):
+        """다른 group 호출은 서로 막지 않음."""
+        client = _make_client()
+        # 분봉 group을 막 호출한 것처럼 시뮬레이션
+        client._endpoint_last_call["minute_chart"] = time.monotonic()
+        # default group throttle 호출은 즉시 통과해야 함
+        start = time.monotonic()
+        client._throttle("/uapi/overseas-price/v1/quotations/price")
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1, f"default group이 minute_chart 때문에 막힘: {elapsed}s"
+
+    def test_same_group_blocks(self):
+        """같은 group 호출은 interval 만큼 sleep."""
+        client = _make_client()
+        # 첫 호출
+        client._throttle("/uapi/overseas-price/v1/quotations/price")
+        # 즉시 두 번째 호출 — default interval(0.25s)만큼 sleep되어야
+        start = time.monotonic()
+        client._throttle("/uapi/overseas-price/v1/quotations/price")
+        elapsed = time.monotonic() - start
+        # 약간의 마진 (0.2 ~ 0.35)
+        assert 0.2 <= elapsed <= 0.4, f"default interval 미적용: {elapsed}s"
+
+    def test_minute_chart_blocks_longer(self):
+        """분봉은 1초 이상 sleep."""
+        client = _make_client()
+        client._throttle("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice")
+        start = time.monotonic()
+        client._throttle("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice")
+        elapsed = time.monotonic() - start
+        assert 0.9 <= elapsed <= 1.15, f"minute_chart interval 미적용: {elapsed}s"
+
+
+@pytest.mark.parametrize(
+    "path,expected_group",
+    [
+        ("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice", "minute_chart"),
+        ("/uapi/overseas-stock/v1/trading/inquire-balance", "balance"),
+        ("/uapi/overseas-stock/v1/trading/inquire-present-balance", "balance"),
+        ("/uapi/overseas-stock/v1/trading/order", "order"),
+        ("/uapi/domestic-stock/v1/trading/order-cash", "order"),
+        ("/uapi/overseas-price/v1/quotations/price", "default"),
+        ("/uapi/overseas-price/v1/quotations/dailyprice", "default"),
+    ],
+)
+def test_classify_endpoint_param(path: str, expected_group: str):
+    assert classify_endpoint(path) == expected_group


### PR DESCRIPTION
## Summary

기존 모든 endpoint 일괄 0.5s throttle → endpoint group별 독립 last_call 추적 + 차등 interval.

| Group | Interval | 대상 endpoint |
|---|---:|---|
| minute_chart | **1.0s** | \`inquire-time-itemchartprice\` (가장 엄격) |
| balance | 0.5s | \`inquire-balance\`, \`inquire-present-balance\` |
| order | 0.4s | \`/trading/order\`, \`/trading/order-cash\` |
| default | 0.25s | 현재가, 일봉 등 일반 조회 |

분봉만 보수적, 일반 조회는 4배 빠름. 기존 OHLCV 240s 캐시 + balance 60s 캐시와 결합 시 실효 호출 빈도는 충분히 낮음.

## Test plan

- [x] \`tests/test_kis_rate_limit.py\` 17건 통과
  - endpoint 분류 정확성 (paramterized 7건 + 4건 그룹 검증)
  - 다른 group 호출은 서로 막지 않음
  - 같은 group 호출은 interval 만큼 sleep
  - minute_chart는 1초 이상 sleep
- [x] 전체 테스트 회귀 OK (534건 통과)

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)