### PR TITLE
fix: 코인봇이 KIS US 보유 종목(SOXL) 잘못 잡아 OHLCV 에러 (#362)

### DIFF
--- a/src/cryptobot/bot/coin_manager.py
+++ b/src/cryptobot/bot/coin_manager.py
@@ -129,11 +129,16 @@ class CoinManager:
             logger.error("코인 목록 갱신 실패: %s", e)
 
     def _get_held_coins(self) -> list[str]:
-        """현재 보유 중인 코인 목록."""
+        """현재 보유 중인 코인 목록 (upbit market만).
+
+        market 필터 없으면 KIS US 보유 종목(예: SOXL)이 코인봇 active_coins로
+        잘못 흘러들어가서 pyupbit.get_ohlcv가 실패함.
+        """
         rows = self._db.execute(
             """
             SELECT DISTINCT t.coin FROM trades t
             WHERE t.side = 'buy'
+            AND t.market = 'upbit'
             AND NOT EXISTS (SELECT 1 FROM trades s WHERE s.buy_trade_id = t.id AND s.side = 'sell')
             """
         ).fetchall()

--- a/tests/test_coin_whitelist_228.py
+++ b/tests/test_coin_whitelist_228.py
@@ -57,6 +57,24 @@ def test_core_coins_includes_sol():
     assert "KRW-SOL" in CoinManager.CORE_COINS
 
 
+def test_held_coins_filters_by_market(db):
+    """KIS US 보유 종목(SOXL 등)이 코인봇 active_coins에 흘러들어가면 안됨."""
+    # 코인봇 보유 1건 + KIS US 보유 1건
+    db.execute(
+        "INSERT INTO trades (market, coin, side, price, amount, total_krw, fee_krw, strategy) "
+        "VALUES ('upbit', 'KRW-BTC', 'buy', 100000000, 0.001, 100000, 50, 'test')"
+    )
+    db.execute(
+        "INSERT INTO trades (market, coin, side, price, amount, total_krw, fee_krw, strategy) "
+        "VALUES ('kis_us', 'SOXL', 'buy', 30, 1, 40000, 20, 'test')"
+    )
+    db.commit()
+    mgr = _make_mgr(db)
+    held = mgr._get_held_coins()
+    assert "KRW-BTC" in held
+    assert "SOXL" not in held, "KIS US 종목이 코인봇 보유 목록에 포함되면 안됨"
+
+
 def test_whitelist_seeded_in_db(db):
     """initialize 시 coin_whitelist_enabled / coin_whitelist 시드."""
     enabled = db.execute("SELECT value FROM bot_config WHERE key='coin_whitelist_enabled'").fetchone()


### PR DESCRIPTION
## Summary

\`CoinManager._get_held_coins\`가 market 필터 없어서 KIS US 보유 SOXL이 코인봇 active_coins로 흘러들어가 매 틱 OHLCV 에러 발생. SQL에 \`t.market='upbit'\` 추가.

Related: #362

## Test plan

- [x] \`pytest tests/test_coin_whitelist_228.py -v\` — 10건 통과 (신규 1건 + 기존 9건)
- [ ] 머지 + 봇 재시작 후 ERROR 로그 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)