### PR TITLE
feat: KIS US Pure Zarattini 3X 변형 (ATR 손절 + No TP, +9,350% 백테스트, #364)

### DIFF
--- a/docs/active-strategy.md
+++ b/docs/active-strategy.md
@@ -119,7 +119,9 @@ KIS US 봇은 **별도 sell 경로**(`src/cryptobot/bot/kis_strategy.py:evaluate
 
 ## 현재 활성 전략
 
-**`zarattini_bar1`** — Pure Zarattini Bar-1 directional (#364, 2026-05-09)
+**`zarattini_3x_atr`** — Pure Zarattini 3X 변형 (논문 TQQQ 변형, #364, 2026-05-09)
+
+> 백테스트(논문): TQQQ 2016~2023 **+9,350% / 연환산 알파 93%** (3X 레버리지 최적화)
 
 ### 핵심 파라미터
 
@@ -129,12 +131,19 @@ KIS US 봇은 **별도 sell 경로**(`src/cryptobot/bot/kis_strategy.py:evaluate
 | 봉 | 5분봉 | `KIS_US_OHLCV_INTERVAL` |
 | OR 형성 | 첫 5분봉 (NY 09:30~09:35) | — |
 | 진입 룰 | 첫 봉 양봉 → 종목 매수 / 음봉/도지 → skip | — |
-| 도지 임계 | 0.05% (몸통 비율) | `KISStrategyParams.doji_threshold_pct` |
-| 손절 | 첫 봉 low (절대가) | — |
-| **익절** | **10R = entry + 10×(entry−stop)** | `KISStrategyParams.r_multiple_target` |
+| 도지 임계 | 0.05% (몸통 비율) | `KIS_US_DOJI_THRESHOLD_PCT` |
+| **손절** | **0.05 × ATR(14d)** (절대가, 14일 변동성에 적응) | `KIS_US_ATR_STOP_PCT`, `KIS_US_ATR_PERIOD` |
+| **익절** | **없음 — EOD까지 hold** (큰 추세 끝까지 잡음) | — |
 | EOD | NY 15:50 (마감 10분 전) | `KIS_US_FORCE_SELL_BEFORE_CLOSE_MIN` |
-| 사이징 | 1% 리스크/거래 | `KISStrategyParams.risk_pct_per_trade` |
+| 사이징 | 1% 리스크/거래 | `KIS_US_RISK_PCT` |
 | 페어 mutex | SOXL ↔ SOXS 동시 보유 X | `ZARATTINI_PAIRS` 상수 |
+
+### 왜 3X 변형이 baseline(bar1+10R TP)보다 좋은가 (논문 근거)
+
+- 3X ETF는 일일 변동성이 큼 → bar1 low 손절은 좁아 가짜 stop-out 빈발
+- 0.05 × ATR(14) 손절 = 14일 변동성에 적응 (여전히 tight하지만 noise 흡수)
+- No TP = 큰 모멘텀 날 EOD까지 hold (10R 제한 X)
+- 결과: TQQQ 베이스라인(+1,484%) → 3X 최적화(+9,350%) 6배 개선
 
 ### 핵심 로직 (논문 그대로)
 
@@ -158,8 +167,17 @@ NY 09:35 ─── 둘째 봉 시작 = 진입 평가 시점
 
 | 날짜 | PR | 변경 | 사유 |
 |---|---|---|---|
-| 2026-05-09 | #364 | Pure Zarattini Bar-1 채택 (SOXL/SOXS 페어) | 기존 ORB+VWAP+거래량 spike 혼합은 시그널 거의 안 발생, 논문 정신 회복 |
+| 2026-05-09 | #364 (3X-ATR) | **Pure Zarattini 3X 변형 채택** (ATR 손절, No TP) | 논문 TQQQ 변형 +9,350% 알파 |
+| 2026-05-09 | #364 (baseline) | Pure Zarattini Bar-1 baseline 추가 (10R TP) | 논문 baseline (+1,484%), 3X-ATR 도입 전 단계 |
 | 2026-05-08 | #305 | Zarattini ORB 모드 추가 (SOXL only) | 논문 80% 충실 — 진입 트리거 + 양방향 갭 |
+
+### 운영 모드 전환 (env)
+
+| 모드 | env | 백테스트 (논문) |
+|---|---|---|
+| **3X 최적 (현재)** | `KIS_US_STRATEGY=zarattini_3x_atr` | **+9,350% / α 93%** |
+| Baseline | `KIS_US_STRATEGY=zarattini_bar1` | +1,484% / α 50% |
+| 기존 혼합 | `KIS_US_STRATEGY=breakout` | (벤치마크) |
 
 ### 데이터 출처
 

--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -89,7 +89,10 @@ class KISStrategyParams:
     # #364 Pure Zarattini Bar-1 모드 파라미터
     doji_threshold_pct: float = 0.05     # bar1 |close-open|/open < N% 이면 도지로 판정 (skip)
     risk_pct_per_trade: float = 1.0      # 계좌 대비 % 리스크/거래 (포지션 사이징)
-    r_multiple_target: float = 10.0      # 익절 = entry + R×(entry−stop)
+    r_multiple_target: float = 10.0      # baseline 모드 익절 = entry + R×(entry−stop)
+    # #364 3X 최적 변형 파라미터 (논문 TQQQ 변형: +9,350% / 93% 알파)
+    atr_stop_pct: float = 5.0            # stop_distance = (atr_stop_pct / 100) × ATR(period)
+    atr_period: int = 14                 # ATR 계산 일수 (논문: 14일)
 
 
 def calc_position_size(
@@ -150,6 +153,35 @@ def _calc_ma(prices: pd.Series, period: int) -> float | None:
     if len(prices) < period:
         return None
     return float(prices.iloc[-period:].mean())
+
+
+def calc_atr(df: pd.DataFrame, period: int = 14) -> float | None:
+    """#364 14일 ATR (Average True Range) 계산.
+
+    True Range = max(high - low, |high - prev_close|, |low - prev_close|).
+    ATR = TR의 period일 단순 이동 평균.
+
+    Args:
+        df: 일봉 OHLCV (high, low, close 컬럼). period+1봉 이상 필요.
+        period: 평균 일수 (논문: 14)
+
+    Returns:
+        ATR 값 ($/주). 데이터 부족 시 None.
+    """
+    if df is None or len(df) < period + 1:
+        return None
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat([
+        high - low,
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    atr = tr.rolling(period).mean().iloc[-1]
+    if pd.isna(atr) or atr <= 0:
+        return None
+    return float(atr)
 
 
 def calc_vwap(df: pd.DataFrame) -> float | None:
@@ -336,6 +368,93 @@ def evaluate_zarattini_bar1(
         stop_loss_price=stop,
         take_profit_price=target,
         risk_per_share=risk_per_share,
+    )
+
+
+def evaluate_zarattini_3x_atr(
+    df_today_5m: pd.DataFrame,
+    df_daily: pd.DataFrame,
+    params: KISStrategyParams = KISStrategyParams(),
+) -> KISBuySignal:
+    """#364 Pure Zarattini 3X 변형 — TQQQ 변형 +9,350% / 93% 알파.
+
+    논문 사양 (3X 레버리지 ETF 최적화):
+    - 진입: bar1 양봉 (도지/음봉은 같은 종목 매수 X)
+    - 손절: 0.05 × ATR(14일) (절대 가격) — bar1 low보다 정밀
+    - 익절: 없음 — EOD까지 hold (큰 모멘텀 끝까지 가져감)
+    - 사이징: 1% 리스크 (calc_position_size_risk_based)
+
+    왜 baseline 변형과 다른가:
+    - 3X ETF는 일일 변동성이 큼 → bar1 low 손절은 좁아 가짜 stop-out 빈발
+    - ATR×5% 손절은 14일 변동성에 적응 (여전히 tight하지만 noise 흡수)
+    - No TP = 큰 추세 끝까지 잡음 (EOD까지 hold)
+    - 백테스트(논문): TQQQ 2016~2023 +9,350%
+
+    Args:
+        df_today_5m: 오늘 5분봉 (bar1 = 첫 봉, 양봉/음봉/도지 판단용)
+        df_daily: 14일 + α 일봉 (ATR 계산용)
+        params: doji_threshold_pct, atr_stop_pct (5.0), atr_period (14), risk_pct_per_trade
+
+    Returns:
+        KISBuySignal:
+          - should_buy=True: 양봉 + ATR 가용 → stop_loss_price 절대가, take_profit_price=None
+          - should_buy=False: 도지/음봉/데이터 부족
+    """
+    if df_today_5m is None or len(df_today_5m) < 1:
+        return KISBuySignal(False, "Bar-1 데이터 없음")
+
+    bar1 = df_today_5m.iloc[0]
+    o = float(bar1["open"])
+    c = float(bar1["close"])
+
+    if o <= 0:
+        return KISBuySignal(False, "Bar-1 open 가격 이상")
+
+    body_pct = abs(c - o) / o * 100
+
+    # 도지 — 매매 X
+    if body_pct < params.doji_threshold_pct:
+        return KISBuySignal(
+            False,
+            f"Bar-1 도지 (몸통 {body_pct:.3f}% < {params.doji_threshold_pct}% — 매매 X)",
+        )
+
+    # 음봉 — 인버스 ETF는 별도 호출
+    if c < o:
+        return KISBuySignal(
+            False,
+            f"Bar-1 음봉 ${c:.2f} < ${o:.2f} — 이 종목 매수 X (인버스 ETF 별도 평가)",
+        )
+
+    # 양봉 — ATR 손절 계산
+    atr = calc_atr(df_daily, period=params.atr_period)
+    if atr is None:
+        return KISBuySignal(
+            False,
+            f"ATR({params.atr_period}d) 계산 불가 — 일봉 데이터 부족 ({len(df_daily) if df_daily is not None else 0}봉)",
+        )
+
+    entry = c  # 첫 봉 close ≈ 둘째 봉 open (실 체결가는 주문 시 결정)
+    stop_distance = (params.atr_stop_pct / 100.0) * atr  # 0.05 × ATR
+    stop = entry - stop_distance
+    if stop <= 0 or stop_distance <= 0:
+        return KISBuySignal(
+            False,
+            f"ATR 손절 계산 이상 (entry ${entry:.2f}, ATR ${atr:.2f}, stop_dist ${stop_distance:.4f})",
+        )
+
+    # 신뢰도: 양봉 몸통 + ATR 대비 진입가 (정성적)
+    conf = round(min(0.95, body_pct / 2.0), 2)
+
+    return KISBuySignal(
+        True,
+        f"3X-ATR 양봉 ${o:.2f}→${c:.2f} (+{body_pct:.2f}%) | "
+        f"ATR(14d)=${atr:.2f} → 손절 ${stop:.2f} (dist ${stop_distance:.4f}, "
+        f"{params.atr_stop_pct}% × ATR) | TP 없음 (EOD까지)",
+        confidence=max(conf, 0.3),
+        stop_loss_price=stop,
+        take_profit_price=None,  # 3X 변형: TP 없음, EOD가 익절
+        risk_per_share=stop_distance,
     )
 
 

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -53,6 +53,7 @@ from cryptobot.bot.kis_strategy import (
     evaluate_buy,
     evaluate_buy_breakout,
     evaluate_sell,
+    evaluate_zarattini_3x_atr,
     evaluate_zarattini_bar1,
 )
 from cryptobot.data.database import Database
@@ -140,12 +141,19 @@ def _build_params(universe_size: int) -> KISStrategyParams:
     is_day_trading = os.getenv("KIS_US_DAY_TRADING", "false").lower() == "true"
     strategy = os.getenv("KIS_US_STRATEGY", "breakout" if is_day_trading else "mean_reversion").strip().lower()
 
-    if is_day_trading and strategy == "zarattini_bar1":
-        # #364 Pure Zarattini Bar-1 — 첫 5분봉 양봉만 진입, 10R TP, OR_low SL
-        default_tp = "999"     # 절대가 take_profit_price가 우선
+    if is_day_trading and strategy == "zarattini_3x_atr":
+        # #364 Pure Zarattini 3X 변형 — TQQQ 변형 +9,350% / 93% 알파
+        # 진입: bar1 양봉, 손절: 0.05 × ATR(14), TP: 없음, EOD까지 hold
+        default_tp = "999"     # TP 없음 (절대가 None으로 처리)
         default_sl = "-4"      # 폴백 (stop_loss_price가 우선)
-        default_tr = "-99"     # 트레일링 끔 (논문엔 트레일링 없음)
-        default_orb = "5"      # 첫 5분봉
+        default_tr = "-99"     # 트레일링 끔
+        default_orb = "5"
+    elif is_day_trading and strategy == "zarattini_bar1":
+        # #364 Pure Zarattini Bar-1 baseline — 10R TP, bar1 low SL
+        default_tp = "999"
+        default_sl = "-4"
+        default_tr = "-99"
+        default_orb = "5"
     elif is_day_trading and strategy == "breakout":
         # 기존 ORB+VWAP+거래량 spike 혼합 모드
         default_tp = "999"
@@ -174,6 +182,12 @@ def _build_params(universe_size: int) -> KISStrategyParams:
         force_sell_window_minutes_before_close=int(os.getenv("KIS_US_FORCE_SELL_BEFORE_CLOSE_MIN", "10")),
         orb_minutes=int(os.getenv("KIS_US_ORB_MINUTES", default_orb)),
         volume_spike_multiplier=float(os.getenv("KIS_US_VOLUME_SPIKE", "2.0")),
+        # #364 Pure Zarattini 파라미터
+        doji_threshold_pct=float(os.getenv("KIS_US_DOJI_THRESHOLD_PCT", "0.05")),
+        risk_pct_per_trade=float(os.getenv("KIS_US_RISK_PCT", "1.0")),
+        r_multiple_target=float(os.getenv("KIS_US_R_MULTIPLE", "10.0")),
+        atr_stop_pct=float(os.getenv("KIS_US_ATR_STOP_PCT", "5.0")),
+        atr_period=int(os.getenv("KIS_US_ATR_PERIOD", "14")),
     )
 
 
@@ -484,8 +498,19 @@ class KISUSBot:
         ny_today = datetime.now(NY).date()
         df_today = df[df.index.date == ny_today] if hasattr(df.index, "date") else df
 
-        if self._strategy == "zarattini_bar1":
-            # #364 Pure Zarattini — 첫 5분봉 방향성만 본다
+        if self._strategy == "zarattini_3x_atr":
+            # #364 Pure Zarattini 3X 변형 — bar1 양봉 + ATR(14d) 손절 + No TP
+            try:
+                df_daily = self._exchange.get_ohlcv(symbol, interval="day", count=20)
+            except APIError as e:
+                logger.warning("%s 일봉 조회 실패 — ATR 계산 불가: %s", symbol, e)
+                return None
+            signal_ = evaluate_zarattini_3x_atr(df_today, df_daily, params=self._params)
+            sl_price = signal_.stop_loss_price
+            tp_price = None  # 3X 변형: TP 없음
+            rps = signal_.risk_per_share
+        elif self._strategy == "zarattini_bar1":
+            # #364 Pure Zarattini baseline — bar1 stop + 10R TP
             signal_ = evaluate_zarattini_bar1(df_today, params=self._params)
             sl_price = signal_.stop_loss_price
             tp_price = signal_.take_profit_price

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -656,3 +656,147 @@ def test_calc_position_size_risk_based_zero_risk():
         fractional=False,
     )
     assert qty == 0.0
+
+
+# ===================================================================
+# #364 Pure Zarattini 3X 변형 (ATR 손절, No TP) 테스트
+# ===================================================================
+
+
+def _daily_df(highs: list[float], lows: list[float], closes: list[float]) -> pd.DataFrame:
+    """일봉 더미 — ATR 계산용."""
+    return pd.DataFrame({
+        "open": closes,  # open=close 단순화
+        "high": highs,
+        "low": lows,
+        "close": closes,
+        "volume": [1_000_000] * len(closes),
+    })
+
+
+def test_calc_atr_basic():
+    """ATR(14) 계산 기본."""
+    from cryptobot.bot.kis_strategy import calc_atr
+
+    # 16봉, 매일 high-low = 2 (간단 케이스)
+    closes = [30.0] * 16
+    highs = [c + 1.0 for c in closes]
+    lows = [c - 1.0 for c in closes]
+    df = _daily_df(highs, lows, closes)
+    atr = calc_atr(df, period=14)
+    # TR = high - low = 2 (모든 봉) → ATR = 2
+    assert atr is not None
+    assert abs(atr - 2.0) < 0.01
+
+
+def test_calc_atr_insufficient_data():
+    """일봉 14+1 미만이면 None."""
+    from cryptobot.bot.kis_strategy import calc_atr
+
+    df = _daily_df([31, 32], [29, 30], [30, 31])
+    assert calc_atr(df, period=14) is None
+
+
+def test_zarattini_3x_atr_bullish_signal():
+    """첫 5분봉 양봉 + ATR 가용 → ATR 손절 시그널 (No TP)."""
+    from cryptobot.bot.kis_strategy import KISStrategyParams, evaluate_zarattini_3x_atr
+
+    df_5m = _bar1_df(30.0, 30.5, 29.95, 30.3)  # 양봉 1%
+    closes = [30.0] * 16
+    highs = [c + 1.0 for c in closes]
+    lows = [c - 1.0 for c in closes]
+    df_d = _daily_df(highs, lows, closes)  # ATR ≈ 2.0
+
+    params = KISStrategyParams(atr_stop_pct=5.0, atr_period=14)
+    sig = evaluate_zarattini_3x_atr(df_5m, df_d, params=params)
+    assert sig.should_buy is True
+    # stop = 30.3 - 0.05 × 2.0 = 30.3 - 0.1 = 30.2
+    assert abs(sig.stop_loss_price - 30.2) < 0.01
+    # 3X 변형은 TP 없음
+    assert sig.take_profit_price is None
+    # risk_per_share = 0.1
+    assert abs(sig.risk_per_share - 0.1) < 0.01
+    assert "3X-ATR" in sig.reason
+    assert "TP 없음" in sig.reason
+
+
+def test_zarattini_3x_atr_doji_skip():
+    """도지 → 매매 X."""
+    from cryptobot.bot.kis_strategy import evaluate_zarattini_3x_atr
+
+    df_5m = _bar1_df(30.0, 30.5, 29.5, 30.001)  # 도지
+    df_d = _daily_df([31] * 16, [29] * 16, [30] * 16)
+    sig = evaluate_zarattini_3x_atr(df_5m, df_d)
+    assert sig.should_buy is False
+    assert "도지" in sig.reason
+
+
+def test_zarattini_3x_atr_bearish_skip():
+    """음봉 → 인버스 ETF 별도 평가."""
+    from cryptobot.bot.kis_strategy import evaluate_zarattini_3x_atr
+
+    df_5m = _bar1_df(30.0, 30.05, 29.5, 29.7)  # 음봉
+    df_d = _daily_df([31] * 16, [29] * 16, [30] * 16)
+    sig = evaluate_zarattini_3x_atr(df_5m, df_d)
+    assert sig.should_buy is False
+    assert "음봉" in sig.reason
+
+
+def test_zarattini_3x_atr_no_daily_data():
+    """일봉 부족 시 ATR 계산 불가 → 매수 X."""
+    from cryptobot.bot.kis_strategy import evaluate_zarattini_3x_atr
+
+    df_5m = _bar1_df(30.0, 30.5, 29.95, 30.3)  # 양봉
+    df_d = _daily_df([31, 32], [29, 30], [30, 31])  # 2봉만
+    sig = evaluate_zarattini_3x_atr(df_5m, df_d)
+    assert sig.should_buy is False
+    assert "ATR" in sig.reason
+
+
+def test_zarattini_3x_atr_pct_configurable():
+    """atr_stop_pct env로 변경 가능."""
+    from cryptobot.bot.kis_strategy import KISStrategyParams, evaluate_zarattini_3x_atr
+
+    df_5m = _bar1_df(30.0, 30.5, 29.95, 30.3)
+    closes = [30.0] * 16
+    df_d = _daily_df([c + 1.0 for c in closes], [c - 1.0 for c in closes], closes)  # ATR=2
+
+    # 5% 디폴트 → stop_distance = 0.1
+    p = KISStrategyParams(atr_stop_pct=5.0, atr_period=14)
+    sig = evaluate_zarattini_3x_atr(df_5m, df_d, params=p)
+    assert abs(sig.risk_per_share - 0.1) < 0.01
+
+    # 10% → stop_distance = 0.2
+    p2 = KISStrategyParams(atr_stop_pct=10.0, atr_period=14)
+    sig2 = evaluate_zarattini_3x_atr(df_5m, df_d, params=p2)
+    assert abs(sig2.risk_per_share - 0.2) < 0.01
+
+
+def test_zarattini_3x_atr_evaluate_sell_no_tp_holds_up():
+    """3X 변형 매도 룰: TP 없음 + take_profit_pct=999 → 가격 올라가도 매도 X (EOD가 처리)."""
+    from cryptobot.bot.kis_strategy import KISStrategyParams, evaluate_sell
+
+    # zarattini_3x_atr 모드 디폴트: take_profit_pct=999, trailing=-99
+    p = KISStrategyParams(take_profit_pct=999.0, trailing_stop_pct=-99.0)
+    sig = evaluate_sell(
+        df=None, current_price=36.0, buy_price=30.0,
+        highest_since_buy=36.0,
+        params=p,
+        stop_loss_price=29.9,
+        take_profit_price=None,
+    )
+    assert sig.should_sell is False
+
+
+def test_zarattini_3x_atr_evaluate_sell_atr_stop_fires():
+    """3X 변형 매도 룰: ATR 손절가 도달 시 매도."""
+    from cryptobot.bot.kis_strategy import evaluate_sell
+
+    sig = evaluate_sell(
+        df=None, current_price=29.9, buy_price=30.3,
+        highest_since_buy=30.5,
+        stop_loss_price=29.9,  # ATR 기반 손절가
+        take_profit_price=None,
+    )
+    assert sig.should_sell is True
+    assert sig.is_profit_taking is False


### PR DESCRIPTION
## Summary

논문 *Zarattini & Aziz (2023)*의 3X 레버리지 최적 변형 추가. TQQQ 백테스트 **+9,350% / α 93%** (baseline +1,484% 대비 6배).

이전 PR #365의 baseline(\`zarattini_bar1\`)과 별개로 추가된 모드. env로 전환 가능.

Related: #364

## 논문 근거

> "An ORB strategy on TQQQ implemented with a stop that was equal to 5% of the 14-day ATR and without any profit target (the position was liquidated at market closure), would have increased by 9,350% between January 1, 2016 and February 17, 2023, and would have produced an annualized alpha of 93%."

— [CXO Advisory](https://www.cxoadvisory.com/technical-trading/day-trading-with-an-opening-range-breakout-strategy/), [SSRN](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4416622)

## 핵심 차이 (vs baseline #365)

| 항목 | baseline (\`zarattini_bar1\`) | **3X 변형 (\`zarattini_3x_atr\`)** |
|---|---|---|
| 손절 | 첫 봉 low | **0.05 × ATR(14일)** |
| 익절 | 10R TP | **없음 — EOD까지 hold** |
| 백테스트 | +1,484% (TQQQ) | **+9,350%** (TQQQ) |
| 진입 / 도지 / 사이징 / 페어 | 동일 | 동일 |

## 왜 3X엔 ATR 손절 + No TP?

- 3X ETF는 일일 변동성 큼 → bar1 low 손절은 좁아 가짜 stop-out 빈발
- 0.05 × ATR(14)는 14일 변동성에 적응 (여전히 tight하지만 noise 흡수)
- No TP = 큰 모멘텀 날 EOD까지 hold (10R 제한 X)
- 손실은 자주 작게, 이익은 가끔 크게 — *비대칭 페이오프* 극대화

## 활성화

\`\`\`bash
export KIS_US_DAY_TRADING=true
export KIS_US_STRATEGY=zarattini_3x_atr
\`\`\`

env 미설정 시 기존 baseline 또는 기존 혼합 모드로 fallback (롤백 안전).

## 신규 env 파라미터

| env | 디폴트 | 설명 |
|---|---|---|
| \`KIS_US_DOJI_THRESHOLD_PCT\` | 0.05 | bar1 도지 임계 (몸통 %) |
| \`KIS_US_RISK_PCT\` | 1.0 | 계좌 대비 % 리스크/거래 |
| \`KIS_US_R_MULTIPLE\` | 10.0 | baseline 익절 (3X 모드는 미사용) |
| \`KIS_US_ATR_STOP_PCT\` | 5.0 | stop_distance = (N/100) × ATR |
| \`KIS_US_ATR_PERIOD\` | 14 | ATR 평균 일수 |

## Test plan

- [x] \`pytest tests/test_kis_strategy.py -v\` — 58건 통과 (신규 9건 + 기존 49건)
- [x] \`pytest tests/\` 전체 578건 통과
- [ ] env 설정 후 봇 재시작
- [ ] NY 09:35 직후 ATR-기반 손절가 / no TP 로그 확인
- [ ] EOD 청산 동작 확인
- [ ] 7일 운영 후 trades 분석

## 운영 자본 시나리오

400,000 KRW (~$290 USD), 1% 리스크 = $2.90.

SOXL @ $30, ATR(14) ≈ $1.5~3:
- 0.05 × $2 = $0.10 stop
- 1% 리스크 사이징: $2.90/$0.10 = 29주 (cost $870, capital 부족)
- 자본 한도: 9주 ($270)
- 실제 리스크: 9 × $0.10 = $0.90 = 0.31% of $290 (target 1%보다 낮음)

→ 작은 자본에선 capital-constrained 자주 발생. 자본 늘면 1% 리스크 fully 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)