### PR TITLE
improve: 어드민 대시보드 코인 섹션 레이아웃 정리 (#367)

### DIFF
--- a/admin/src/components/PnLHero.tsx
+++ b/admin/src/components/PnLHero.tsx
@@ -22,38 +22,38 @@ export default function PnLHero({
 
   return (
     <Card className={cn(
-      "p-6 border-l-4",
+      "p-5 border-l-4",
       isPositive && "border-l-success",
       isNegative && "border-l-destructive",
       !isPositive && !isNegative && "border-l-muted",
     )}>
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div>
           <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             🪙 코인 봇 — 누적 손익률
           </div>
           <div className={cn(
-            "mt-2 text-4xl font-bold",
+            "mt-2 text-3xl font-bold",
             isPositive && "text-success",
             isNegative && "text-destructive",
           )}>
             {pnlPct !== null
               ? `${pnlPct > 0 ? "+" : ""}${pnlPct.toFixed(2)}%`
-              : <span className="text-2xl text-muted-foreground">기준 미설정</span>}
+              : <span className="text-xl text-muted-foreground">기준 미설정</span>}
           </div>
           {totalPnl !== null && (
             <div className="mt-1 text-sm text-muted-foreground">
-              {totalPnl > 0 ? "+" : ""}₩{Math.abs(totalPnl).toLocaleString()}
+              {totalPnl > 0 ? "+" : ""}₩{Math.round(Math.abs(totalPnl)).toLocaleString()}
               {totalPnl < 0 && " 손실"}
-              {totalDeposits && ` · 누적 입금 ₩${totalDeposits.toLocaleString()}`}
+              {totalDeposits && ` · 누적 입금 ₩${Math.round(totalDeposits).toLocaleString()}`}
             </div>
           )}
         </div>
 
-        <div className="text-right">
+        <div className="text-right shrink-0">
           <div className="text-xs font-medium text-muted-foreground uppercase">총 자산</div>
-          <div className="mt-1 text-2xl font-bold">
-            {totalAsset !== null ? `₩${totalAsset.toLocaleString()}` : "-"}
+          <div className="mt-1 text-xl font-bold">
+            {totalAsset !== null ? `₩${Math.round(totalAsset).toLocaleString()}` : "-"}
           </div>
           <div className="mt-1 text-xs text-muted-foreground">
             {positionCount > 0 ? `${positionCount}종목 보유` : "포지션 없음"}

--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -158,8 +158,8 @@ export default function DashboardPage() {
               totalDeposits={totalDeposits}
               positionCount={pos.length}
             />
-            {/* 기존 KPI 그리드 — 매수/평가 정보 */}
-            <div className="kpi-grid mt-4">
+            {/* #367: 매수/평가/현금만 (총 보유 자산은 PnLHero와 중복이라 제거) */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
               <StatCard
                 label="매수 금액"
                 value={formatKRW(totalCost)}
@@ -168,18 +168,19 @@ export default function DashboardPage() {
               <StatCard
                 label="평가 금액"
                 value={formatKRW(totalValue)}
-                valueClass={totalValue > totalCost ? "positive" : totalValue < totalCost ? "negative" : ""}
-                sub={totalCost > 0 ? `${formatPercent((totalValue - totalCost) / totalCost * 100)} 수익률` : "포지션 없음"}
+                valueClass={totalCost > 0 && totalValue > 0 ? (totalValue > totalCost ? "positive" : "negative") : ""}
+                sub={
+                  totalCost > 0 && totalValue === 0
+                    ? "⚠️ 현재가 조회 실패"
+                    : totalCost > 0
+                      ? `${formatPercent((totalValue - totalCost) / totalCost * 100)} 수익률`
+                      : "포지션 없음"
+                }
               />
               <StatCard
                 label="현금 (KRW)"
                 value={formatKRW(balance?.krw_balance || 0)}
                 sub="다음 매수 가용"
-              />
-              <StatCard
-                label="총 보유 자산"
-                value={balance ? formatKRW(totalAsset) : "-"}
-                sub="KRW + 코인 평가"
               />
             </div>
           </>


### PR DESCRIPTION
## Summary

코인 탭 상단 영역 시각적 정리:

| 변경 | Before | After |
|---|---|---|
| PnLHero 크기 | p-6 + text-4xl + text-2xl | p-5 + text-3xl + text-xl |
| 손익 금액 표시 | ₩657,268.081 | ₩657,268 (정수 반올림) |
| KPI 카드 수 | 4개 (매수/평가/현금/**총 보유 자산**) | 3개 (총 자산 PnLHero와 중복이라 제거) |
| 평가 금액 ₩0 | "-100% 수익률" | "⚠️ 현재가 조회 실패" |

## Test plan

- [x] \`npm run build\` 성공
- [ ] dev 서버 시각 확인

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)