### PR TITLE
fix: zarattini_3x_atr ATR 계산에서 오늘 (incomplete) 일봉 제외 (#364)

### DIFF
--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -505,6 +505,11 @@ class KISUSBot:
             except APIError as e:
                 logger.warning("%s 일봉 조회 실패 — ATR 계산 불가: %s", symbol, e)
                 return None
+            # ATR은 *완성된* 14일 (오늘 진행 중 일봉은 high/low 부분 정보)이라
+            # 오늘 봉을 명시적으로 제외하고 계산해야 정확. KIS API 응답에 오늘이
+            # 포함될 수 있으므로 방어적으로 필터.
+            if hasattr(df_daily.index, "date"):
+                df_daily = df_daily[df_daily.index.date < ny_today]
             signal_ = evaluate_zarattini_3x_atr(df_today, df_daily, params=self._params)
             sl_price = signal_.stop_loss_price
             tp_price = None  # 3X 변형: TP 없음

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -800,3 +800,32 @@ def test_zarattini_3x_atr_evaluate_sell_atr_stop_fires():
     )
     assert sig.should_sell is True
     assert sig.is_profit_taking is False
+
+
+def test_calc_atr_excludes_partial_today():
+    """ATR이 오늘 (incomplete) 일봉 포함 시 정확도 영향 — 호출자가 필터해야 함.
+
+    이 테스트는 calc_atr이 마지막 봉을 그대로 사용한다는 *현재 동작*을 명시.
+    호출자(run_kis_us._evaluate_buy_only)에서 오늘을 제외하고 전달해야 함.
+    """
+    from cryptobot.bot.kis_strategy import calc_atr
+
+    # 정상 14일: TR=2 → ATR=2
+    closes = [30.0] * 16
+    highs = [c + 1.0 for c in closes]
+    lows = [c - 1.0 for c in closes]
+    df_full = _daily_df(highs, lows, closes)
+    atr_full = calc_atr(df_full, period=14)
+
+    # 마지막 봉만 inflate (오늘 incomplete 시뮬, high-low=0.1만)
+    highs_partial = highs[:-1] + [closes[-1] + 0.05]
+    lows_partial = lows[:-1] + [closes[-1] - 0.05]
+    df_partial = _daily_df(highs_partial, lows_partial, closes)
+    atr_partial = calc_atr(df_partial, period=14)
+
+    # 오늘 봉의 작은 range가 ATR을 떨어뜨림
+    assert atr_partial < atr_full
+    # 호출자는 df.iloc[:-1]로 오늘을 제외해서 정확한 ATR 얻음
+    atr_excluded = calc_atr(df_partial.iloc[:-1], period=14)
+    # 14일 완성 데이터로 계산 → ATR=2.0
+    assert abs(atr_excluded - 2.0) < 0.1


### PR DESCRIPTION
## Summary

KIS daily API가 진행 중인 오늘 일봉을 포함해 반환할 수 있어 ATR(14d) 계산이 inflate-down 되는 미세 정확도 이슈 수정.

Related: #364

## 증상

NY 09:35 직후 \`zarattini_3x_atr\` 모드 평가 시:
- KIS daily API → 오늘 일봉 포함 (high/low가 첫 5분봉만 반영, 매우 작음)
- \`calc_atr\`의 \`rolling(14).mean().iloc[-1]\` → 마지막 14봉에 오늘 포함
- ATR이 실제값보다 작게 나옴 → 0.05 × ATR 손절이 *더 좁아짐* → 노이즈 stop-out 빈발

## 수정

\`run_kis_us._evaluate_buy_only\` zarattini_3x_atr 분기에서 df_daily 필터:
\`\`\`python
if hasattr(df_daily.index, "date"):
    df_daily = df_daily[df_daily.index.date < ny_today]
\`\`\`

## Test plan

- [x] 신규 테스트 \`test_calc_atr_excludes_partial_today\` — partial 오늘 봉 영향 확인 + 호출자 필터로 정확값 회복
- [x] \`pytest tests/\` 전체 579건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)