### PR TITLE
fix: 코인 EOD/ORB/Entry 시간 env 분기 제거 — 코드에서만 관리 (#370)

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -497,11 +497,15 @@ class CryptoBot:
             )
 
     def _maybe_eod_clearance(self) -> None:
-        """#322: vwap_orb_breakout 활성 시 KST 09:00 ±5분에 보유 코인 강제 매도.
+        """#322: vwap_orb_breakout 활성 시 EOD 시점 ±5분에 보유 코인 강제 매도.
 
-        Zarattini 논문 EOD 청산 — 24/7 코인 시장에선 사용자 정의 시점(KST 09:00).
+        Zarattini 논문 EOD 청산 — 24/7 코인 시장에선 사용자 정의 시점 (EOD_HOUR_KST).
         """
-        from cryptobot.strategies.vwap_orb_breakout import VwapOrbBreakout, is_eod_window
+        from cryptobot.strategies.vwap_orb_breakout import (
+            EOD_HOUR_KST,
+            VwapOrbBreakout,
+            is_eod_window,
+        )
 
         s = self._strategy_sel.current_strategy
         if not isinstance(s, VwapOrbBreakout):
@@ -522,7 +526,8 @@ class CryptoBot:
         if not active_buys:
             return
 
-        logger.info("[EOD 청산] 보유 %d종목 청산 시작 (KST 09:00)", len(active_buys))
+        eod_label = f"KST {EOD_HOUR_KST:02d}:00"
+        logger.info("[EOD 청산] 보유 %d종목 청산 시작 (%s)", len(active_buys), eod_label)
 
         for trade in active_buys:
             coin = trade["coin"]
@@ -539,7 +544,7 @@ class CryptoBot:
                         price=order.price, amount=order.amount,
                         total_krw=order.total_krw, fee_krw=order.fee_krw,
                         strategy="vwap_orb_breakout",
-                        trigger_reason="EOD 청산 (KST 09:00)",
+                        trigger_reason=f"EOD 청산 ({eod_label})",
                         profit_pct=pnl_pct, buy_trade_id=trade["id"],
                     )
                     logger.info("[EOD] %s 매도 @ %.2f (%.2f%%)", coin, order.price, pnl_pct)

--- a/src/cryptobot/strategies/vwap_orb_breakout.py
+++ b/src/cryptobot/strategies/vwap_orb_breakout.py
@@ -30,7 +30,6 @@ Option 1 (#360, 2026-05-09 채택):
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime, time as dtime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -42,22 +41,10 @@ from cryptobot.strategies.base import BaseStrategy, Signal, StrategyInfo
 logger = logging.getLogger(__name__)
 KST = ZoneInfo("Asia/Seoul")
 
-# Option 1 디폴트 (#360, 백테스트 1위 조합)
-ORB_HOUR_KST = 22       # ORB 시작 KST 시 (env COIN_ORB_HOUR_KST)
-EOD_HOUR_KST = 11       # EOD 청산 KST 시 (env COIN_EOD_HOUR_KST)
-ENTRY_WINDOW_HOURS = 5  # ORB 형성(1h) 후 진입 허용 시간 (env COIN_ENTRY_WINDOW_HOURS)
-
-
-def _orb_hour() -> int:
-    return int(os.getenv("COIN_ORB_HOUR_KST", str(ORB_HOUR_KST)))
-
-
-def _eod_hour() -> int:
-    return int(os.getenv("COIN_EOD_HOUR_KST", str(EOD_HOUR_KST)))
-
-
-def _entry_window_h() -> int:
-    return int(os.getenv("COIN_ENTRY_WINDOW_HOURS", str(ENTRY_WINDOW_HOURS)))
+# Option 1 디폴트 (#360, 백테스트 1위 조합) — 코드에서만 관리 (env 분기 제거)
+ORB_HOUR_KST = 22       # ORB 시작 KST 시
+EOD_HOUR_KST = 11       # EOD 청산 KST 시
+ENTRY_WINDOW_HOURS = 5  # ORB 형성(1h) 후 진입 허용 시간
 
 
 class VwapOrbBreakout(BaseStrategy):
@@ -187,13 +174,13 @@ class VwapOrbBreakout(BaseStrategy):
 def is_eod_window(now: datetime | None = None, window_minutes: int = 5) -> bool:
     """EOD 시점 ±window_minutes 사이면 True (강제 청산 윈도우).
 
-    EOD 시각은 _eod_hour() (env COIN_EOD_HOUR_KST 또는 디폴트 KST 11:00).
+    EOD 시각은 EOD_HOUR_KST (현재 KST 11:00).
     """
     if now is None:
         now = datetime.now(KST)
     elif now.tzinfo is None:
         now = now.replace(tzinfo=KST)
-    eod = now.replace(hour=_eod_hour(), minute=0, second=0, microsecond=0)
+    eod = now.replace(hour=EOD_HOUR_KST, minute=0, second=0, microsecond=0)
     delta = abs((now - eod).total_seconds())
     return delta <= window_minutes * 60
 
@@ -209,10 +196,8 @@ def is_entry_window(now: datetime | None = None) -> bool:
     elif now.tzinfo is None:
         now = now.replace(tzinfo=KST)
 
-    orb_h = _orb_hour()
-    window_h = _entry_window_h()
-    entry_start = (orb_h + 1) % 24
-    entry_end = (orb_h + 1 + window_h) % 24
+    entry_start = (ORB_HOUR_KST + 1) % 24
+    entry_end = (ORB_HOUR_KST + 1 + ENTRY_WINDOW_HOURS) % 24
 
     h = now.hour
     if entry_start <= entry_end:
@@ -235,12 +220,11 @@ def filter_session_bars(df: pd.DataFrame, now: datetime | None = None) -> pd.Dat
     if now is None:
         now = datetime.now(KST)
 
-    orb_h = _orb_hour()
-    if now.hour >= orb_h:
-        session_start = now.replace(hour=orb_h, minute=0, second=0, microsecond=0)
+    if now.hour >= ORB_HOUR_KST:
+        session_start = now.replace(hour=ORB_HOUR_KST, minute=0, second=0, microsecond=0)
     else:
         session_start = (now - timedelta(days=1)).replace(
-            hour=orb_h, minute=0, second=0, microsecond=0
+            hour=ORB_HOUR_KST, minute=0, second=0, microsecond=0
         )
 
     if df.index.tz is None:


### PR DESCRIPTION
## 문제

\`.env\`에 \`COIN_EOD_HOUR_KST=0\`이 잔존 → 코드 디폴트 \`EOD_HOUR_KST=11\`과 충돌. 봇이 KST **00:00**에 EOD 청산 수행 (의도된 11:00 ≠ 실제 00:00).

또한 \`bot/main.py:542\`의 EOD 청산 \`trigger_reason\`이 \`\"EOD 청산 (KST 09:00)\"\` 으로 하드코딩 → 실제 EOD 시각과 무관하게 항상 \"09:00\" 텍스트 기록.

## 변경

- \`vwap_orb_breakout.py\`: \`_orb_hour\` / \`_eod_hour\` / \`_entry_window_h\` 함수 제거, \`ORB_HOUR_KST\` / \`EOD_HOUR_KST\` / \`ENTRY_WINDOW_HOURS\` 상수 직접 사용. \`import os\` 제거.
- \`bot/main.py\`: EOD 청산 메시지를 \`f\"EOD 청산 (KST {EOD_HOUR_KST:02d}:00)\"\` 으로 동적 생성.
- \`.env\` 로컬 파일에서 \`COIN_EOD_HOUR_KST\` 라인 삭제 (gitignore 대상이라 커밋엔 미포함).

향후 시간 변경은 \`vwap_orb_breakout.py\` 상단 3개 상수에서만 관리 → 환경별 불일치 제거.

## Test plan

- [x] 전체 테스트 579건 통과
- [x] \`vwap_orb_breakout\` + \`backtest_sweep\` 34건 통과
- [ ] 봇 재시작 후 다음 EOD 윈도우(KST 11:00)에 청산 동작 검증

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)