### PR TITLE
improve: VWAP-ORB 트레일링 최소 익절 가드 (#372)

### DIFF
--- a/src/cryptobot/backtest/reporter.py
+++ b/src/cryptobot/backtest/reporter.py
@@ -30,8 +30,12 @@ SWEEP_CONFIGS: dict[str, dict[str, list]] = {
     "bb_rsi_combined": {"rsi_oversold": [25, 30, 35], "bb_std": [1.5, 2.0]},
     # #226: 진입 임계값(공포지수, RSI) 두 축으로 sweep
     "long_term_swing": {"fear_threshold": [25, 30, 35], "rsi_entry_max": [40, 45, 50]},
-    # #321: ORB 시간 + 거래량 임계 sweep
-    "vwap_orb_breakout": {"orb_minutes": [60, 90], "volume_spike_multiplier": [1.5, 2.0]},
+    # #321/#372: ORB 시간 + 거래량 + 트레일링 최소익절 가드 sweep
+    "vwap_orb_breakout": {
+        "orb_minutes": [60, 90],
+        "volume_spike_multiplier": [1.5, 2.0],
+        "min_profit_for_trailing": [0.5, 1.5, 2.5],
+    },
 }
 
 
@@ -168,6 +172,8 @@ class BacktestReporter:
             "grid_count": "grid",
             "entry_period": "entry",
             "oversold": "os",
+            "min_profit_for_trailing": "min_tp",
+            "volume_spike_multiplier": "vol_sp",
         }
         for key in sweep:
             if key in params:

--- a/src/cryptobot/llm/analyzer.py
+++ b/src/cryptobot/llm/analyzer.py
@@ -1104,6 +1104,9 @@ class LLMAnalyzer:
             "signal_period": "sig",
             "squeeze_lookback": "sq_lb",
             "range_pct": "range",
+            "min_profit_for_trailing": "min_tp",
+            "volume_spike_multiplier": "vol_sp",
+            "orb_minutes": "orb_m",
         }
         parts = []
         for key, value in params.items():

--- a/src/cryptobot/strategies/vwap_orb_breakout.py
+++ b/src/cryptobot/strategies/vwap_orb_breakout.py
@@ -46,6 +46,10 @@ ORB_HOUR_KST = 22       # ORB 시작 KST 시
 EOD_HOUR_KST = 11       # EOD 청산 KST 시
 ENTRY_WINDOW_HOURS = 5  # ORB 형성(1h) 후 진입 허용 시간
 
+# #372: 트레일링 발동 최소 익절 임계 (net_pnl 기준 %)
+# 0.5%대 푼돈 트레일링 매도 회피. 미만 수익권은 EOD까지 보유.
+MIN_PROFIT_FOR_TRAILING = 1.5
+
 
 class VwapOrbBreakout(BaseStrategy):
     """VWAP + ORB + 거래량 spike 단타 (코인용, KST 22:00 ORB + 11:00 EOD)."""
@@ -55,6 +59,9 @@ class VwapOrbBreakout(BaseStrategy):
         self._orb_minutes = int(self.params.extra.get("orb_minutes", 60))
         self._volume_spike = float(self.params.extra.get("volume_spike_multiplier", 1.5))
         self._bar_minutes = int(self.params.extra.get("bar_minutes", 15))
+        self._min_profit_for_trailing = float(
+            self.params.extra.get("min_profit_for_trailing", MIN_PROFIT_FOR_TRAILING)
+        )
 
     def info(self) -> StrategyInfo:
         return StrategyInfo(
@@ -159,16 +166,21 @@ class VwapOrbBreakout(BaseStrategy):
             )
 
         drop_pct = (current_price - self._highest_price) / self._highest_price * 100
-        if drop_pct <= self.params.trailing_stop_pct and net_pnl > 0:
+        if drop_pct <= self.params.trailing_stop_pct and net_pnl >= self._min_profit_for_trailing:
             return Signal(
                 "sell",
                 0.8,
-                f"트레일링 (실질 {net_pnl:+.2f}%)",
+                f"트레일링 (실질 {net_pnl:+.2f}%, ≥{self._min_profit_for_trailing}% 가드)",
                 trigger_value=round(drop_pct, 2),
                 is_profit_taking=True,
             )
 
-        return Signal("hold", 0.0, f"보유 유지 (실질 {net_pnl:+.2f}%, EOD 청산 대기)")
+        return Signal(
+            "hold",
+            0.0,
+            f"보유 유지 (실질 {net_pnl:+.2f}%, "
+            f"트레일링 가드 ≥{self._min_profit_for_trailing}%, EOD 청산 대기)",
+        )
 
 
 def is_eod_window(now: datetime | None = None, window_minutes: int = 5) -> bool:

--- a/tests/test_vwap_orb_breakout.py
+++ b/tests/test_vwap_orb_breakout.py
@@ -241,3 +241,65 @@ def test_check_sell_holds_in_normal_run():
     s = _strategy_with_roi_table()
     sig = s.check_sell(df=None, current_price=101.5, buy_price=100.0)
     assert sig.signal_type == "hold"
+
+
+# === #372: 트레일링 최소 익절 가드 ===
+
+
+def test_trailing_blocked_below_min_profit():
+    """net_pnl이 min_profit_for_trailing 미만이면 트레일링 hold."""
+    s = _strategy_with_roi_table()
+    # 피크 102.0까지 올렸다가 99.0으로 -2.94% drop (trailing -3% 거의 발동선)
+    s.check_sell(df=None, current_price=102.0, buy_price=100.0)
+    s.check_sell(df=None, current_price=101.5, buy_price=100.0)
+    # current 101.0 (net +0.8%, drop_pct from 102 = -0.98%) — net_pnl=0.8% < 1.5% 가드
+    sig = s.check_sell(df=None, current_price=101.0, buy_price=100.0)
+    assert sig.signal_type == "hold"
+    assert "보유 유지" in sig.reason
+
+
+def test_trailing_blocked_with_drop_but_below_gate():
+    """drop이 trailing 임계 넘어도 net_pnl < 1.5%면 hold."""
+    s = _strategy_with_roi_table()
+    s.check_sell(df=None, current_price=101.0, buy_price=100.0)
+    # 피크 101 → 97.8 (-3.17%): 트레일링 임계 넘었지만 net_pnl = -2.3% (음수)
+    # → 가드 안되더라도 net_pnl < 1.5%여서 hold
+    sig = s.check_sell(df=None, current_price=97.8, buy_price=100.0)
+    assert sig.signal_type == "hold"
+
+
+def test_trailing_fires_when_above_gate():
+    """net_pnl >= 1.5%이고 drop >= trailing 임계면 매도."""
+    s = _strategy_with_roi_table()
+    # 피크 110, current 105 → drop -4.5%, net_pnl = ~4.8% (1.5% 가드 통과)
+    s.check_sell(df=None, current_price=110.0, buy_price=100.0)
+    sig = s.check_sell(df=None, current_price=105.0, buy_price=100.0)
+    assert sig.signal_type == "sell"
+    assert sig.is_profit_taking is True
+    assert "트레일링" in sig.reason
+
+
+def test_min_profit_for_trailing_override_via_params():
+    """params.extra.min_profit_for_trailing 으로 가드값 override 가능."""
+    from cryptobot.strategies.base import StrategyParams
+
+    params = StrategyParams(
+        stop_loss_pct=-5.0,
+        trailing_stop_pct=-3.0,
+        extra={"min_profit_for_trailing": 0.5},  # 가드 낮춤
+    )
+    s = VwapOrbBreakout(params)
+    # 피크 102, current 99 → drop -2.94% < -3.0 미발동
+    s.check_sell(df=None, current_price=102.0, buy_price=100.0)
+    # 피크 102, current 98.9 → drop -3.04%, net_pnl ~-1.2% < 0.5%
+    sig = s.check_sell(df=None, current_price=98.9, buy_price=100.0)
+    assert sig.signal_type == "hold"  # net 손실권
+
+
+def test_default_min_profit_constant():
+    """디폴트 MIN_PROFIT_FOR_TRAILING 상수 노출."""
+    from cryptobot.strategies.vwap_orb_breakout import MIN_PROFIT_FOR_TRAILING
+
+    assert MIN_PROFIT_FOR_TRAILING == 1.5
+    s = _strategy_with_roi_table()
+    assert s._min_profit_for_trailing == 1.5


### PR DESCRIPTION
## Summary

XRP 5/11 사례 — 매수 ₩2,119 → 피크 ~₩2,186 (+3.16%) → 트레일링 -2.5% 발동 → 매도 +0.51% net. 푼돈 매도 회피 위해 최소 익절 가드 추가.

## 변경

| 항목 | Before | After |
|---|---|---|
| 트레일링 발동 조건 | \`net_pnl > 0\` | \`net_pnl >= min_profit_for_trailing\` (디폴트 1.5%) |
| 신규 파라미터 | - | \`min_profit_for_trailing\` (param.extra) |
| SWEEP_CONFIGS | orb_minutes × volume_spike | 위 + min_profit_for_trailing [0.5, 1.5, 2.5] |

손실권은 \`stop_loss_pct=-5%\` 기존 그대로. 가드 미달 수익은 EOD까지 보유.

## Trade-off

- ✅ +0.5% 푼돈 매도 회피, 큰 추세 끝까지 보유
- ⚠️ +0.5%~+1.4% 정점 후 반전 시 EOD까지 끌고 가다 손실 마감 가능 → 주간 sweep으로 검증

## Test plan

- [x] 신규 5건: 가드 미달 hold, drop 발생해도 net<1.5%는 hold, 가드 통과 시 trailing, params override, 디폴트 상수
- [x] 기존 vwap_orb 18건 + backtest_sweep 16건 모두 통과
- [ ] 다음 주간 sweep에서 \`min_profit_for_trailing\` 최적값 데이터 확인

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)