### PR TITLE
fix: 봇 재시작 시 missed-EOD 복구 — 보유분 즉시 청산 (#373)

### DIFF
--- a/src/cryptobot/bot/main.py
+++ b/src/cryptobot/bot/main.py
@@ -497,12 +497,18 @@ class CryptoBot:
             )
 
     def _maybe_eod_clearance(self) -> None:
-        """#322: vwap_orb_breakout 활성 시 EOD 시점 ±5분에 보유 코인 강제 매도.
+        """#322/#373: vwap_orb_breakout 활성 시 EOD 시점 또는 missed-EOD 시 보유 코인 강제 매도.
 
         Zarattini 논문 EOD 청산 — 24/7 코인 시장에선 사용자 정의 시점 (EOD_HOUR_KST).
+        봇 재시작·장애로 EOD 윈도우(±5분)를 놓친 경우, EOD ~ 다음 ORB(22시) 사이에
+        재시작 시 즉시 청산하여 다음 사이클에 현금 확보.
         """
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
         from cryptobot.strategies.vwap_orb_breakout import (
             EOD_HOUR_KST,
+            ORB_HOUR_KST,
             VwapOrbBreakout,
             is_eod_window,
         )
@@ -510,7 +516,15 @@ class CryptoBot:
         s = self._strategy_sel.current_strategy
         if not isinstance(s, VwapOrbBreakout):
             return
-        if not is_eod_window():
+
+        in_window = is_eod_window()
+        now_kst = datetime.now(ZoneInfo("Asia/Seoul"))
+        # #373: missed-EOD 복구 — EOD 윈도우 밖이지만 EOD 지나서 다음 ORB 전이면 복구 청산
+        missed_eod = (
+            not in_window
+            and EOD_HOUR_KST <= now_kst.hour < ORB_HOUR_KST
+        )
+        if not in_window and not missed_eod:
             return
 
         if not self._trader.is_ready:
@@ -526,7 +540,10 @@ class CryptoBot:
         if not active_buys:
             return
 
-        eod_label = f"KST {EOD_HOUR_KST:02d}:00"
+        if missed_eod:
+            eod_label = f"KST {EOD_HOUR_KST:02d}:00 지연 복구"
+        else:
+            eod_label = f"KST {EOD_HOUR_KST:02d}:00"
         logger.info("[EOD 청산] 보유 %d종목 청산 시작 (%s)", len(active_buys), eod_label)
 
         for trade in active_buys:

--- a/tests/test_eod_recovery.py
+++ b/tests/test_eod_recovery.py
@@ -1,0 +1,103 @@
+"""#373: missed-EOD 복구 로직 테스트.
+
+봇 재시작·장애로 EOD 윈도우(±5분)를 놓친 경우, EOD 시각부터 다음 ORB 사이의
+재시작 시 즉시 청산되어야 함.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _is_eod_or_missed(now_kst: datetime, eod_hour: int, orb_hour: int) -> tuple[bool, bool]:
+    """bot/main.py:_maybe_eod_clearance 의 윈도우 판정 로직 미러.
+
+    Returns:
+        (in_window, missed_eod)
+    """
+    # in_window: ±5분 (is_eod_window 디폴트)
+    eod = now_kst.replace(hour=eod_hour, minute=0, second=0, microsecond=0)
+    delta = abs((now_kst - eod).total_seconds())
+    in_window = delta <= 5 * 60
+
+    missed_eod = (
+        not in_window
+        and eod_hour <= now_kst.hour < orb_hour
+    )
+    return in_window, missed_eod
+
+
+# Option 1: EOD 11:00, ORB 22:00
+
+
+def test_in_window_at_eod_exact():
+    """KST 11:00 정각 → in_window."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 11, 0, tzinfo=KST), 11, 22)
+    assert in_w is True
+    assert missed is False
+
+
+def test_in_window_within_5min():
+    """KST 11:04 → in_window."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 11, 4, tzinfo=KST), 11, 22)
+    assert in_w is True
+    assert missed is False
+
+
+def test_missed_eod_just_after_window():
+    """KST 11:06 → missed-EOD 복구."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 11, 6, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is True
+
+
+def test_missed_eod_at_15h():
+    """KST 15:00 → missed-EOD 복구."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 15, 0, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is True
+
+
+def test_missed_eod_at_21h59():
+    """KST 21:59 → missed-EOD 복구 마지막 분."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 21, 59, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is True
+
+
+def test_no_action_at_22h_orb_start():
+    """KST 22:00 ORB 시작 → 청산 안함 (다음 사이클 진입)."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 22, 0, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is False
+
+
+def test_no_action_during_entry_window():
+    """KST 23:30 진입 윈도우 안 → 청산 안함 (오늘 매수 중)."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 23, 30, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is False
+
+
+def test_no_action_at_midnight():
+    """KST 00:30 → 청산 안함 (어제 시작된 진입 윈도우 안)."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 0, 30, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is False
+
+
+def test_no_action_at_05h_pre_eod():
+    """KST 05:00 진입 윈도우 끝난 직후 ~ EOD 전 → 청산 안함 (보유 유지)."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 5, 0, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is False
+
+
+def test_no_action_at_10h_just_before_eod():
+    """KST 10:00 → 청산 안함 (EOD 1시간 전)."""
+    in_w, missed = _is_eod_or_missed(datetime(2026, 5, 11, 10, 0, tzinfo=KST), 11, 22)
+    assert in_w is False
+    assert missed is False


### PR DESCRIPTION
## Summary

봇이 KST 11:00 EOD 윈도우(±5분) 사이에 동작하지 않으면 보유분 청산 누락 → 다음날 11:00까지 ~24h 자금 잠김 → 그 사이 ORB 사이클(KST 23~04) 진입 시 현금 부족.

## 변경

\`bot/main.py:_maybe_eod_clearance()\` 에 missed-EOD 복구 로직 추가:

\`\`\`python
in_window = is_eod_window()      # ±5분
missed_eod = (
    not in_window
    and EOD_HOUR_KST <= now.hour < ORB_HOUR_KST  # 11~22시
)
if not in_window and not missed_eod:
    return
\`\`\`

복구 윈도우: 약 **KST 11:05 ~ 22:00**. 이 사이 보유분 있으면 즉시 강제 매도.

\`trigger_reason\` 구분:
- 정상: \`EOD 청산 (KST 11:00)\`
- 복구: \`EOD 청산 (KST 11:00 지연 복구)\`

## Test plan

- [x] 10건 신규 boundary 검증 (정상 윈도우 / 복구 윈도우 / 진입 윈도우 / ORB 시작 / 자정 / pre-EOD)
- [x] 전체 589건 통과

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)