### PR TITLE
feat: backtest-validated 코인 자동 필터 (#378)

### DIFF
--- a/src/cryptobot/bot/backtest_coin_filter.py
+++ b/src/cryptobot/bot/backtest_coin_filter.py
@@ -1,0 +1,89 @@
+"""#378: 백테스트 검증 통과 코인만 매수 풀에 포함하는 필터.
+
+실제 데이터 분석:
+- 백테스트 데이터 없는 신생 알트 매수 → 큰 손실 (NEWT -31k원 등)
+- 백테스트에서 양수 결과 본 알트 (BIO/WET/0G/TOKAMAK) → 실제도 양수
+→ 백테스트 검증 통과 코인만 매수 허용으로 위험 제거.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BacktestCoinFilter:
+    """백테스트 결과로 매수 코인 풀 자동 필터.
+
+    조건: 최신 백테스트 run에서 한 코인에 대해 어느 strategy/params 조합이든
+    `avg_profit_pct >= min_avg_profit` AND `num_trades >= min_trades` 모두 만족.
+
+    한 코인이 여러 결과를 가질 때 (sweep) 어느 하나라도 통과하면 통과로 간주.
+    """
+
+    DEFAULT_MIN_AVG_PROFIT = 5.0
+    DEFAULT_MIN_TRADES = 3
+
+    def __init__(
+        self,
+        db,
+        min_avg_profit: float | None = None,
+        min_trades: int | None = None,
+    ) -> None:
+        self._db = db
+        self._min_avg_profit = (
+            min_avg_profit if min_avg_profit is not None else self.DEFAULT_MIN_AVG_PROFIT
+        )
+        self._min_trades = (
+            min_trades if min_trades is not None else self.DEFAULT_MIN_TRADES
+        )
+
+    def get_validated_coins(self) -> set[str]:
+        """최신 백테스트 run에서 기준 통과 코인 set 반환.
+
+        Returns:
+            통과 코인 set. 백테스트 결과 없으면 빈 set.
+        """
+        rows = self._db.execute(
+            """
+            SELECT DISTINCT coin
+            FROM backtest_results
+            WHERE run_date = (SELECT MAX(run_date) FROM backtest_results)
+              AND avg_profit_pct >= ?
+              AND num_trades >= ?
+            """,
+            (self._min_avg_profit, self._min_trades),
+        ).fetchall()
+        return {r["coin"] if hasattr(r, "keys") else r[0] for r in rows}
+
+    def filter_coins(self, coins: list[str]) -> list[str]:
+        """입력 코인 리스트를 백테스트 검증 통과 코인으로 필터.
+
+        - 백테스트 결과 없으면 원본 그대로 반환 (안전 fallback).
+        - 통과 코인 집합과 교집합 계산.
+        - 입력 순서 유지.
+
+        Args:
+            coins: 원본 코인 리스트
+
+        Returns:
+            필터링된 코인 리스트
+        """
+        validated = self.get_validated_coins()
+        if not validated:
+            logger.warning(
+                "backtest_coin_filter: 백테스트 검증 결과 없음 — 원본 코인 그대로 사용 (%d종)",
+                len(coins),
+            )
+            return list(coins)
+
+        filtered = [c for c in coins if c in validated]
+        logger.info(
+            "backtest_coin_filter: 검증 통과 %d종 (원본 %d종, 기준 avg≥%.1f%% trades≥%d)",
+            len(filtered),
+            len(coins),
+            self._min_avg_profit,
+            self._min_trades,
+        )
+        return filtered

--- a/src/cryptobot/bot/coin_manager.py
+++ b/src/cryptobot/bot/coin_manager.py
@@ -35,12 +35,32 @@ class CoinManager:
         self._init_collectors()
 
     def _get_whitelist(self) -> list[str] | None:
-        """#228: 활성 화이트리스트 반환. None이면 화이트리스트 미사용 (기존 동작)."""
+        """#228: 활성 화이트리스트 반환. None이면 화이트리스트 미사용 (기존 동작).
+
+        #378: coin_backtest_filter_enabled=True 시 백테스트 검증 통과 코인만 남김.
+        """
         if not self._config.get_bool("coin_whitelist_enabled", True):
             return None
         raw = self._config.get("coin_whitelist", ",".join(self.DEFAULT_WHITELIST))
         coins = [c.strip() for c in raw.split(",") if c.strip()]
-        return coins if coins else None
+        if not coins:
+            return None
+
+        # #378: backtest-validated 필터 (옵션)
+        if self._config.get_bool("coin_backtest_filter_enabled", False):
+            from cryptobot.bot.backtest_coin_filter import BacktestCoinFilter
+
+            filter_obj = BacktestCoinFilter(
+                self._db,
+                min_avg_profit=float(self._config.get("coin_backtest_min_avg_profit", "5.0")),
+                min_trades=int(self._config.get("coin_backtest_min_trades", "3")),
+            )
+            coins = filter_obj.filter_coins(coins)
+            if not coins:
+                logger.warning("backtest 필터 후 빈 리스트 — 원본 디폴트 유지")
+                return list(self.DEFAULT_WHITELIST)
+
+        return coins
 
     def _init_collectors(self) -> None:
         """활성 코인별 DataCollector 초기화 + 불필요한 collector 정리."""

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -708,6 +708,31 @@ _DEFAULT_BOT_CONFIG = [
         "display_name": "화이트리스트 코인 (CSV)",
         "description": "화이트리스트 모드에서 매매 허용 코인. T1: BTC/ETH/XRP/SOL, T2: ADA/DOGE/AVAX/LINK. 백테스트 +10.94%.",
     },
+    # #378: 백테스트 검증 필터 — 화이트리스트 ∩ (avg_profit≥X% AND num_trades≥N)
+    {
+        "key": "coin_backtest_filter_enabled",
+        "value": "false",
+        "value_type": "bool",
+        "category": "coin",
+        "display_name": "백테스트 검증 필터",
+        "description": "ON: 화이트리스트 ∩ 백테스트 통과 코인만 매수. 미검증 종목 손실(NEWT 등) 차단.",
+    },
+    {
+        "key": "coin_backtest_min_avg_profit",
+        "value": "5.0",
+        "value_type": "float",
+        "category": "coin",
+        "display_name": "백테스트 최소 평균 익절 (%)",
+        "description": "백테스트 결과 avg_profit_pct가 이 값 이상인 코인만 통과. 기본 5%.",
+    },
+    {
+        "key": "coin_backtest_min_trades",
+        "value": "3",
+        "value_type": "int",
+        "category": "coin",
+        "display_name": "백테스트 최소 거래 건수",
+        "description": "백테스트 결과 num_trades가 이 값 이상인 코인만 통과. 표본 부족 코인 제외.",
+    },
     {
         "key": "min_volume_krw",
         "value": "1000000000",

--- a/tests/test_backtest_coin_filter.py
+++ b/tests/test_backtest_coin_filter.py
@@ -1,0 +1,141 @@
+"""#378: BacktestCoinFilter 단위 + 통합 테스트."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from cryptobot.bot.backtest_coin_filter import BacktestCoinFilter
+
+
+def _create_db() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("""
+        CREATE TABLE backtest_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_date TEXT,
+            strategy_name TEXT,
+            coin TEXT,
+            num_trades INTEGER,
+            avg_profit_pct REAL
+        )
+    """)
+    return db
+
+
+def _insert(db, run_date: str, coin: str, strategy: str, num_trades: int, avg_profit_pct: float) -> None:
+    db.execute(
+        "INSERT INTO backtest_results (run_date, coin, strategy_name, num_trades, avg_profit_pct) VALUES (?, ?, ?, ?, ?)",
+        (run_date, coin, strategy, num_trades, avg_profit_pct),
+    )
+
+
+# === 디폴트 값 검증 ===
+
+
+def test_default_thresholds():
+    assert BacktestCoinFilter.DEFAULT_MIN_AVG_PROFIT == 5.0
+    assert BacktestCoinFilter.DEFAULT_MIN_TRADES == 3
+
+
+# === get_validated_coins 단위 ===
+
+
+def test_returns_coins_above_thresholds():
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-BIO", "bollinger_bands", 5, 8.5)  # 통과
+    _insert(db, "2026-05-10", "KRW-WET", "volatility_breakout", 4, 5.0)  # 통과 (정확히 5%)
+    _insert(db, "2026-05-10", "KRW-NEWT", "vwap_orb_breakout", 4, 2.0)  # 평균익절 미달
+    _insert(db, "2026-05-10", "KRW-LOW", "bb_rsi_combined", 2, 8.0)  # 거래수 미달
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    coins = f.get_validated_coins()
+    assert coins == {"KRW-BIO", "KRW-WET"}
+
+
+def test_only_latest_run_date():
+    """오래된 run_date는 무시."""
+    db = _create_db()
+    _insert(db, "2026-05-03", "KRW-OLD", "x", 5, 10.0)  # 이전 run, 무시
+    _insert(db, "2026-05-10", "KRW-NEW", "x", 5, 8.0)
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    coins = f.get_validated_coins()
+    assert "KRW-OLD" not in coins
+    assert "KRW-NEW" in coins
+
+
+def test_any_param_combo_passes():
+    """한 코인이 여러 strategy/params 결과 가지면 어느 하나라도 통과 시 통과."""
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-BIO", "vol_breakout(k=0.3)", 5, 3.0)  # 미달
+    _insert(db, "2026-05-10", "KRW-BIO", "bollinger_bands(bb=2)", 4, 8.5)  # 통과
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    assert "KRW-BIO" in f.get_validated_coins()
+
+
+def test_empty_results():
+    db = _create_db()
+    f = BacktestCoinFilter(db)
+    assert f.get_validated_coins() == set()
+
+
+def test_custom_thresholds():
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-A", "x", 5, 4.0)  # 디폴트 5%면 탈락, 3%면 통과
+    db.commit()
+
+    f_default = BacktestCoinFilter(db)
+    assert "KRW-A" not in f_default.get_validated_coins()
+
+    f_relaxed = BacktestCoinFilter(db, min_avg_profit=3.0)
+    assert "KRW-A" in f_relaxed.get_validated_coins()
+
+
+# === filter_coins 통합 ===
+
+
+def test_filter_intersects_with_validated():
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-BIO", "x", 5, 10.0)
+    _insert(db, "2026-05-10", "KRW-WET", "x", 5, 8.0)
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    coins = ["KRW-BTC", "KRW-BIO", "KRW-WET", "KRW-NEWT"]
+    filtered = f.filter_coins(coins)
+    assert filtered == ["KRW-BIO", "KRW-WET"]
+
+
+def test_filter_preserves_input_order():
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-A", "x", 5, 10.0)
+    _insert(db, "2026-05-10", "KRW-B", "x", 5, 10.0)
+    _insert(db, "2026-05-10", "KRW-C", "x", 5, 10.0)
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    filtered = f.filter_coins(["KRW-C", "KRW-A", "KRW-B"])
+    assert filtered == ["KRW-C", "KRW-A", "KRW-B"]
+
+
+def test_filter_empty_validation_returns_original():
+    """백테스트 결과 없으면 원본 그대로 (안전 fallback)."""
+    db = _create_db()
+    f = BacktestCoinFilter(db)
+    coins = ["KRW-BTC", "KRW-ETH"]
+    assert f.filter_coins(coins) == coins
+
+
+def test_filter_no_intersection_returns_empty():
+    """입력 코인 중 통과한 게 없으면 빈 리스트."""
+    db = _create_db()
+    _insert(db, "2026-05-10", "KRW-ALT1", "x", 5, 10.0)
+    db.commit()
+
+    f = BacktestCoinFilter(db)
+    assert f.filter_coins(["KRW-BTC", "KRW-ETH"]) == []

--- a/tests/test_coin_whitelist_228.py
+++ b/tests/test_coin_whitelist_228.py
@@ -138,3 +138,73 @@ def test_empty_whitelist_returns_none(db):
     """빈 문자열 → None (화이트리스트 미사용 효과)."""
     mgr = _make_mgr(db, coin_whitelist="")
     assert mgr._get_whitelist() is None
+
+
+# ===================================================================
+# #378: 백테스트 검증 필터 통합
+# ===================================================================
+
+
+def _seed_backtest(db, coin: str, num_trades: int, avg_profit_pct: float, run_date: str = "2026-05-10"):
+    """backtest_results에 시드 (모든 NOT NULL 컬럼 채움)."""
+    db.execute(
+        "INSERT INTO backtest_results "
+        "(run_date, strategy_name, coin, period, num_trades, win_rate, "
+        " total_return_pct, max_drawdown_pct, sharpe_ratio, avg_profit_pct, "
+        " avg_loss_pct, best_trade_pct, worst_trade_pct, params_json) "
+        "VALUES (?, 'test', ?, '30d', ?, 60.0, 5.0, -3.0, 1.0, ?, -1.0, 5.0, -3.0, '{}')",
+        (run_date, coin, num_trades, avg_profit_pct),
+    )
+    db.commit()
+
+
+def test_backtest_filter_disabled_keeps_whitelist(db):
+    """coin_backtest_filter_enabled=False → 화이트리스트 그대로."""
+    _seed_backtest(db, "KRW-BTC", num_trades=5, avg_profit_pct=10.0)
+    mgr = _make_mgr(db, coin_backtest_filter_enabled="false")
+    wl = mgr._get_whitelist()
+    assert set(wl) == set(CoinManager.DEFAULT_WHITELIST)
+
+
+def test_backtest_filter_enabled_intersects_with_validated(db):
+    """필터 ON + 일부 코인만 백테스트 통과 → 화이트리스트 ∩ validated."""
+    _seed_backtest(db, "KRW-BTC", num_trades=5, avg_profit_pct=10.0)
+    _seed_backtest(db, "KRW-ETH", num_trades=4, avg_profit_pct=6.0)
+    # SOL은 통과 미달
+    _seed_backtest(db, "KRW-SOL", num_trades=2, avg_profit_pct=2.0)
+    mgr = _make_mgr(db, coin_backtest_filter_enabled="true")
+    wl = mgr._get_whitelist()
+    assert set(wl) == {"KRW-BTC", "KRW-ETH"}
+
+
+def test_backtest_filter_no_results_falls_back_to_whitelist(db):
+    """필터 ON + 백테스트 결과 없음 → 원본 화이트리스트 (안전 fallback)."""
+    mgr = _make_mgr(db, coin_backtest_filter_enabled="true")
+    wl = mgr._get_whitelist()
+    # 백테스트 결과 없으면 filter_coins가 원본 그대로 반환
+    assert set(wl) == set(CoinManager.DEFAULT_WHITELIST)
+
+
+def test_backtest_filter_empty_intersection_returns_default_whitelist(db):
+    """필터 ON + 통과 코인이 있지만 화이트리스트와 겹치지 않으면 디폴트 유지."""
+    _seed_backtest(db, "KRW-BIO", num_trades=5, avg_profit_pct=10.0)
+    mgr = _make_mgr(
+        db,
+        coin_backtest_filter_enabled="true",
+        coin_whitelist="KRW-BTC,KRW-ETH",  # BIO는 화이트리스트 밖
+    )
+    wl = mgr._get_whitelist()
+    # 교집합 ∅ → DEFAULT_WHITELIST 유지 (안전)
+    assert set(wl) == set(CoinManager.DEFAULT_WHITELIST)
+
+
+def test_backtest_filter_custom_thresholds(db):
+    """coin_backtest_min_avg_profit / coin_backtest_min_trades 커스텀."""
+    _seed_backtest(db, "KRW-BTC", num_trades=5, avg_profit_pct=4.0)  # 디폴트 5% 미달, 3% 통과
+    mgr = _make_mgr(
+        db,
+        coin_backtest_filter_enabled="true",
+        coin_backtest_min_avg_profit="3.0",
+    )
+    wl = mgr._get_whitelist()
+    assert "KRW-BTC" in wl


### PR DESCRIPTION
## Summary

실제 매매 데이터: NEWT 단일 알트 -31,056원 (한 달 손해의 1.5배). 백테스트 데이터 없는 신생 코인 매수가 진짜 손실 원인. 백테스트 검증 통과 코인만 매수 풀에 포함하는 필터 추가 (Tier 1 / 4단계 중 2단계).

## 변경

**신규 \`bot/backtest_coin_filter.py\`:**
- \`get_validated_coins()\` — 최신 run_date에서 \`avg_profit_pct >= 5% AND num_trades >= 3\` 통과 코인 set
- 한 코인에 여러 strategy/params 결과 (sweep) 있으면 어느 하나라도 통과 시 OK
- \`filter_coins(list)\` — 교집합, 입력 순서 보존, 빈 결과 시 원본 fallback

**\`coin_manager.py\` 통합:**
- \`coin_backtest_filter_enabled=True\` 시 화이트리스트 ∩ validated 적용
- 교집합 ∅ 시 DEFAULT_WHITELIST 유지 (안전 가드)

**bot_config 시드 (3개):**
- \`coin_backtest_filter_enabled\` (디폴트 **false**, 사용자가 명시적 ON)
- \`coin_backtest_min_avg_profit\` (5.0)
- \`coin_backtest_min_trades\` (3)

## Test plan

- [x] \`tests/test_backtest_coin_filter.py\` 10건 신규 (단위)
- [x] \`tests/test_coin_whitelist_228.py\` 5건 통합 추가 (필터 OFF/ON, fallback, custom threshold, ∅)
- [x] 전체 625건 통과
- [ ] 어드민 Config 페이지에서 토글 ON 검증 (PR4에서)

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)