### PR TITLE
feat: 활성 전략을 bb_rsi_combined swing으로 전환 (#382)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,23 @@
 
 ---
 
-## 핵심 알고리즘 — Zarattini ORB 단타
+## 핵심 알고리즘
 
-학술 근거: Zarattini & Aziz (2023) ["Can Day Trading Really Be Profitable?"](https://www.semanticscholar.org/paper/Can-Day-Trading-Really-Be-Profitable-Evidence-of-in-Zarattini-Aziz/4d55f526cc56f08662cb8976796cd3b719ef6d2b)
-QQQ 5분 ORB 백테스트 → **누적 +1,484%** (2016~2023, 8년) / 연환산 알파 33%.
+**주식 (KIS US):** Zarattini ORB 단타 — 학술 근거 Zarattini & Aziz (2023) ["Can Day Trading Really Be Profitable?"](https://www.semanticscholar.org/paper/Can-Day-Trading-Really-Be-Profitable-Evidence-of-in-Zarattini-Aziz/4d55f526cc56f08662cb8976796cd3b719ef6d2b) — QQQ 5분 ORB 8년 +1,484%.
+
+**코인 (Upbit, #382):** BB+RSI Swing — 학술 근거 [Liu/Tsyvinski J.Finance 2022](https://onlinelibrary.wiley.com/doi/abs/10.1111/jofi.13119) (momentum factor) + BB+RSI 결합 정확도 87.5% ([ResearchGate 2024](https://www.researchgate.net/publication/392316831_Effectiveness_of_RSI_and_Bollinger_Bands_in_Identifying_Buy_and_Sell_Signals)).
+
+### 코인 Swing 모드 (#376/#378/#380/#382, 2026-05-12 채택)
+
+> BB 하단 + RSI 과매도 동시 충족 시 저점 진입 → **+5% 도달 후** 추세 끝까지 보유 → 피크 -2.5% 빠지면 트레일링 매도. 시간 기반 익절(roi_table) 우회. ATR 변동성 regime별 adaptive 파라미터 옵션.
+
+**구현 4단계:**
+1. **Tier 1 (#376):** bb_rsi_combined의 roi_table 우회 + `min_profit_for_trailing=5.0` 가드
+2. **백테스트 필터 (#378):** 최신 백테스트 `avg_profit_pct ≥ 5% AND num_trades ≥ 3` 통과 코인만 매수 (실데이터: NEWT 단일 -31k 같은 미검증 알트 차단)
+3. **Tier 2 (#380):** ATR(14) 변동성 regime — `low` (가드 3%), `normal` (5%), `high` (7%) 동적 파라미터
+4. **활성 전환 (#382):** 활성 전략 = bb_rsi_combined, DB 마이그레이션 `scripts/migrate_activate_bb_rsi_swing.sql`
+
+### Zarattini ORB (주식)
 
 ### 한 줄 요약
 

--- a/scripts/migrate_activate_bb_rsi_swing.sql
+++ b/scripts/migrate_activate_bb_rsi_swing.sql
@@ -1,0 +1,38 @@
+-- #382: bb_rsi_combined swing 모드 활성화 + 백테스트 필터 시드.
+--
+-- 변경:
+-- 1. 활성 전략 vwap_orb_breakout → bb_rsi_combined
+-- 2. bb_rsi_combined default_params 업데이트 (bb_std=1.5, rsi_oversold=25, min_profit_for_trailing=5.0)
+-- 3. coin_backtest_filter_enabled / min_avg_profit / min_trades 시드 (기존 DB 호환)
+--
+-- 멱등성: 여러 번 실행해도 동일 결과.
+
+BEGIN TRANSACTION;
+
+-- 1. 기존 활성 전략 모두 비활성화
+UPDATE strategies SET is_active = 0;
+
+-- 2. bb_rsi_combined 활성화 + 파라미터 업데이트
+UPDATE strategies
+SET is_active = 1,
+    default_params_json = '{"bb_std": 1.5, "bb_period": 20, "rsi_period": 14, "rsi_oversold": 25, "rsi_overbought": 50, "min_profit_for_trailing": 5.0}'
+WHERE name = 'bb_rsi_combined';
+
+-- 3. bot_config 시드 (이미 있으면 무시 — INSERT OR IGNORE)
+INSERT OR IGNORE INTO bot_config (key, value, value_type, category, display_name, description)
+VALUES
+    ('coin_backtest_filter_enabled', 'false', 'bool', 'coin',
+     '백테스트 검증 필터',
+     'ON: 화이트리스트 ∩ 백테스트 통과 코인만 매수. 미검증 종목 손실(NEWT 등) 차단.'),
+    ('coin_backtest_min_avg_profit', '5.0', 'float', 'coin',
+     '백테스트 최소 평균 익절 (%)',
+     '백테스트 결과 avg_profit_pct가 이 값 이상인 코인만 통과. 기본 5%.'),
+    ('coin_backtest_min_trades', '3', 'int', 'coin',
+     '백테스트 최소 거래 건수',
+     '백테스트 결과 num_trades가 이 값 이상인 코인만 통과. 표본 부족 코인 제외.');
+
+COMMIT;
+
+-- 검증 쿼리 (실행 후 수동 확인용):
+-- SELECT name, is_active, default_params_json FROM strategies WHERE is_active = 1;
+-- SELECT key, value FROM bot_config WHERE key LIKE 'coin_backtest%';

--- a/tests/test_bb_rsi_swing_smoke.py
+++ b/tests/test_bb_rsi_swing_smoke.py
@@ -1,0 +1,142 @@
+"""#382: bb_rsi_combined swing 활성 시 통합 smoke test.
+
+- 전략 selector가 bb_rsi_combined을 로드할 수 있는가
+- DB default_params_json이 strategy 인스턴스에 반영되는가
+- min_profit_for_trailing 5.0 디폴트가 작동하는가
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from cryptobot.bot.strategy_selector import STRATEGY_CLASSES
+from cryptobot.data.database import Database
+from cryptobot.strategies.base import StrategyParams
+from cryptobot.strategies.bb_rsi_combined import BBRSICombined
+
+
+@pytest.fixture
+def db_with_active_bb_rsi():
+    """bb_rsi_combined을 활성으로 시드한 임시 DB."""
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    # PR4 마이그레이션 적용
+    db.execute("UPDATE strategies SET is_active = 0")
+    db.execute(
+        "UPDATE strategies SET is_active = 1, default_params_json = ? WHERE name = 'bb_rsi_combined'",
+        (json.dumps({
+            "bb_std": 1.5,
+            "bb_period": 20,
+            "rsi_period": 14,
+            "rsi_oversold": 25,
+            "rsi_overbought": 50,
+            "min_profit_for_trailing": 5.0,
+        }),),
+    )
+    db.commit()
+    yield db
+    db.close()
+
+
+def test_bb_rsi_combined_in_strategy_classes():
+    """레지스트리에 bb_rsi_combined 등록 확인."""
+    assert "bb_rsi_combined" in STRATEGY_CLASSES
+    assert STRATEGY_CLASSES["bb_rsi_combined"] is BBRSICombined
+
+
+def test_db_active_strategy_is_bb_rsi(db_with_active_bb_rsi):
+    """DB 활성 전략 = bb_rsi_combined."""
+    row = db_with_active_bb_rsi.execute(
+        "SELECT name FROM strategies WHERE is_active = 1"
+    ).fetchone()
+    assert dict(row)["name"] == "bb_rsi_combined"
+
+
+def test_default_params_load_into_strategy(db_with_active_bb_rsi):
+    """DB default_params_json이 BBRSICombined 인스턴스에 반영."""
+    row = db_with_active_bb_rsi.execute(
+        "SELECT default_params_json FROM strategies WHERE name = 'bb_rsi_combined'"
+    ).fetchone()
+    params_dict = json.loads(dict(row)["default_params_json"])
+    s = BBRSICombined(StrategyParams(stop_loss_pct=-5.0, trailing_stop_pct=-2.5, extra=params_dict))
+    assert s._bb_std == 1.5
+    assert s._rsi_oversold == 25
+    assert s._min_profit_for_trailing == 5.0
+
+
+def test_swing_mode_holds_at_4pct_profit():
+    """+4% 수익 (5% 가드 미달) → hold (swing 모드 핵심 동작)."""
+    s = BBRSICombined(StrategyParams(
+        stop_loss_pct=-5.0,
+        trailing_stop_pct=-2.5,
+        extra={"bb_std": 1.5, "rsi_oversold": 25, "min_profit_for_trailing": 5.0},
+    ))
+    # 평탄한 가격 → BB std=0이라 영향 없음. RSI ~50 정도.
+    df = pd.DataFrame({
+        "open": [100.0] * 25, "high": [100.5] * 25, "low": [99.5] * 25,
+        "close": [100.0] * 25, "volume": [1000] * 25,
+    })
+    # +4% gross, net 3.9%, 5% 가드 미달
+    sig = s.check_sell(df, current_price=104.0, buy_price=100.0)
+    assert sig.signal_type == "hold"
+    assert "가드" in sig.reason
+
+
+def test_swing_mode_fires_trailing_at_6pct_profit_after_peak():
+    """피크 +10% → 피크-3% drop, net 6.9% > 5% 가드 → trailing 매도."""
+    s = BBRSICombined(StrategyParams(
+        stop_loss_pct=-5.0,
+        trailing_stop_pct=-2.5,
+        extra={"bb_std": 1.5, "rsi_oversold": 25, "min_profit_for_trailing": 5.0},
+    ))
+    df = pd.DataFrame({
+        "open": [100.0] * 25, "high": [100.5] * 25, "low": [99.5] * 25,
+        "close": [100.0] * 25, "volume": [1000] * 25,
+    })
+    s.check_sell(df, current_price=110.0, buy_price=100.0)  # 피크 갱신
+    sig = s.check_sell(df, current_price=106.5, buy_price=100.0)  # -3.18% from peak, +6.5% gross
+    assert sig.signal_type == "sell"
+
+
+def test_stop_loss_5pct_fires_unconditionally():
+    """-5% 손절은 가드 무관 작동."""
+    s = BBRSICombined(StrategyParams(
+        stop_loss_pct=-5.0,
+        trailing_stop_pct=-2.5,
+        extra={"min_profit_for_trailing": 5.0},
+    ))
+    df = pd.DataFrame({
+        "open": [100.0] * 25, "high": [100.5] * 25, "low": [99.5] * 25,
+        "close": [100.0] * 25, "volume": [1000] * 25,
+    })
+    sig = s.check_sell(df, current_price=94.5, buy_price=100.0)  # -5.5%
+    assert sig.signal_type == "sell"
+    assert "손절" in sig.reason
+    assert sig.is_profit_taking is False
+
+
+def test_backtest_filter_config_seeded(db_with_active_bb_rsi):
+    """bot_config에 백테스트 필터 시드 (이미 있으면 그대로)."""
+    # initialize() 시 자동 시드되거나, 마이그레이션이 추가
+    rows = db_with_active_bb_rsi.execute(
+        "SELECT key, value FROM bot_config WHERE key LIKE 'coin_backtest%'"
+    ).fetchall()
+    keys = {dict(r)["key"] for r in rows}
+    # 시드 키 3개 모두 존재
+    assert "coin_backtest_filter_enabled" in keys
+    assert "coin_backtest_min_avg_profit" in keys
+    assert "coin_backtest_min_trades" in keys
+
+
+def test_backtest_filter_disabled_by_default(db_with_active_bb_rsi):
+    """coin_backtest_filter_enabled 디폴트 false (사용자가 명시적 ON)."""
+    row = db_with_active_bb_rsi.execute(
+        "SELECT value FROM bot_config WHERE key = 'coin_backtest_filter_enabled'"
+    ).fetchone()
+    assert dict(row)["value"] == "false"


### PR DESCRIPTION
## Summary

코인 swing 모드 4단계 중 마지막 — 활성 전략 전환 + production-ready smoke test.

## 변경

1. **\`scripts/migrate_activate_bb_rsi_swing.sql\`** — 멱등 마이그레이션
   - \`strategies\`: vwap_orb_breakout 비활성, **bb_rsi_combined 활성**
   - default_params: \`bb_std=1.5, rsi_oversold=25, min_profit_for_trailing=5.0\`
   - bot_config 시드 (INSERT OR IGNORE): backtest 필터 3개 키

2. **\`tests/test_bb_rsi_swing_smoke.py\` 8건** — production smoke
   - strategy_selector 등록 / DB 활성 / default_params 로딩
   - swing 핵심 (+4% hold / +6% peak 후 trailing / -5.5% 손절)
   - bot_config 시드 + 디폴트 OFF

3. **README** — swing 모드 4단계 (#376/#378/#380/#382) + 학술 근거 (Liu/Tsyvinski J.Finance 2022, BB+RSI 87.5% ResearchGate 2024)

## Test plan

- [x] 마이그레이션 실측 DB 적용 + 검증
- [x] smoke test 8건
- [x] 전체 654건 통과
- [x] admin build 성공

## 운영 적용 순서

\`\`\`bash
git pull --ff-only
sqlite3 data/cryptobot.db < scripts/migrate_activate_bb_rsi_swing.sql
make stop && make daemon
# (선택) admin UI에서 coin_backtest_filter_enabled 토글 ON
\`\`\`

Closes #382. Stack: #376→#378→#380→#382 (모두 머지됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)