### PR TITLE
chore: 봇 시작 시 SQL 마이그레이션 자동 적용 (#384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,22 @@ make start
 
 | 명령어 | 설명 |
 |---|---|
-| `make start` | 전체 실행 |
+| `make start` | 전체 실행 (포그라운드) |
+| `make daemon` | 백그라운드 실행 |
+| `make stop` / `make status` | 종료 / 상태 |
 | `make bot` | 트레이딩 봇 |
 | `make api` | API 서버 |
 | `make web` | Admin 개발 서버 |
 | `make news` | 뉴스 수집기 |
-| `make test` | 테스트 (101건) |
+| `make test` | 테스트 (660건) |
+
+### 업데이트
+
+```bash
+git pull && make daemon
+```
+
+`scripts/migrate_*.sql` 파일은 봇 시작 시 자동 적용됩니다 (#384). 별도 SQL 실행 불요.
 
 ---
 

--- a/src/cryptobot/data/database.py
+++ b/src/cryptobot/data/database.py
@@ -1422,9 +1422,60 @@ class Database:
             conn.execute("DROP TABLE IF EXISTS market_snapshots_old")
 
             conn.commit()
+
+            # #384: SQL 마이그레이션 자동 적용 (scripts/migrate_*.sql)
+            self._apply_pending_sql_migrations()
+
             logger.debug("데이터베이스 연결 준비 완료: %s", self._db_path)
         except sqlite3.Error as e:
             raise DatabaseError(f"데이터베이스 초기화 실패: {e}") from e
+
+    def _apply_pending_sql_migrations(self) -> None:
+        """#384: scripts/migrate_*.sql 미적용 파일 자동 실행 + 이력 기록.
+
+        실행 이력은 schema_migrations 테이블에서 추적 — 멱등성 보장.
+        파일은 정렬 순서 (사전순) 로 실행. 트랜잭션 단위.
+        """
+        import glob
+        import os
+
+        conn = self.connection
+        # 이력 테이블 (멱등)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                filename TEXT PRIMARY KEY,
+                applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.commit()
+
+        # 프로젝트 루트의 scripts/ 폴더 위치 추정 (database.py로부터 ../../../scripts)
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+        scripts_dir = os.path.join(repo_root, "scripts")
+        if not os.path.isdir(scripts_dir):
+            return  # 개발 환경 외 (단위 테스트 등)에선 폴더 없을 수 있음
+
+        applied = {
+            row[0] for row in conn.execute("SELECT filename FROM schema_migrations").fetchall()
+        }
+        files = sorted(glob.glob(os.path.join(scripts_dir, "migrate_*.sql")))
+        for path in files:
+            fname = os.path.basename(path)
+            if fname in applied:
+                continue
+            try:
+                with open(path, encoding="utf-8") as f:
+                    sql = f.read()
+                # executescript은 자체 트랜잭션 관리 → COMMIT 포함된 SQL도 안전
+                conn.executescript(sql)
+                conn.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES (?)", (fname,)
+                )
+                conn.commit()
+                logger.info("자동 마이그레이션 적용: %s", fname)
+            except sqlite3.Error as e:
+                logger.error("자동 마이그레이션 실패 (%s) — 다음 시작 시 재시도: %s", fname, e)
+                # 다른 마이그레이션은 계속 시도 (실패한 것만 skip)
 
     def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
         """SQL 실행 후 커서 반환."""

--- a/tests/test_sql_migrations.py
+++ b/tests/test_sql_migrations.py
@@ -1,0 +1,120 @@
+"""#384: SQL 마이그레이션 자동 실행 시스템 (scripts/migrate_*.sql) 테스트."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+
+
+def test_schema_migrations_table_created_on_initialize(tmp_path):
+    """initialize() 이후 schema_migrations 테이블 존재."""
+    db = Database(tmp_path / "test.db")
+    db.initialize()
+    row = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+    ).fetchone()
+    assert row is not None
+    db.close()
+
+
+def test_real_migration_file_applied(tmp_path):
+    """실제 scripts/migrate_activate_bb_rsi_swing.sql 가 초기화 시 자동 적용."""
+    db = Database(tmp_path / "test.db")
+    db.initialize()
+
+    # 활성 전략 = bb_rsi_combined (마이그레이션 적용 증거)
+    row = db.execute("SELECT name FROM strategies WHERE is_active = 1").fetchone()
+    assert row is not None
+    assert dict(row)["name"] == "bb_rsi_combined"
+
+    # bot_config 시드도 적용
+    row2 = db.execute(
+        "SELECT value FROM bot_config WHERE key = 'coin_backtest_filter_enabled'"
+    ).fetchone()
+    assert row2 is not None
+    assert dict(row2)["value"] == "false"
+
+    # 이력 기록
+    row3 = db.execute(
+        "SELECT applied_at FROM schema_migrations WHERE filename = 'migrate_activate_bb_rsi_swing.sql'"
+    ).fetchone()
+    assert row3 is not None
+
+    db.close()
+
+
+def test_idempotent_reinitialize(tmp_path):
+    """initialize() 두 번 호출해도 마이그레이션 중복 적용 안 됨 (멱등)."""
+    db_path = tmp_path / "test.db"
+    db = Database(db_path)
+    db.initialize()
+    count_first = db.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+    db.close()
+
+    db2 = Database(db_path)
+    db2.initialize()
+    count_second = db2.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+
+    assert count_first == count_second
+    db2.close()
+
+
+def test_initialize_n_times_no_duplication(tmp_path):
+    """N번 initialize 호출해도 이력 중복 없음."""
+    db_path = tmp_path / "test.db"
+    db = None
+    for _ in range(5):
+        if db is not None:
+            db.close()
+        db = Database(db_path)
+        db.initialize()
+
+    rows = db.execute("SELECT filename FROM schema_migrations").fetchall()
+    filenames = [r[0] for r in rows]
+    assert len(filenames) == len(set(filenames))
+    db.close()
+
+
+def test_legacy_db_gets_migration_applied(tmp_path):
+    """이미 vwap_orb_breakout 활성인 legacy DB → 봇 시작 시 bb_rsi로 전환."""
+    db_path = tmp_path / "legacy.db"
+    db = Database(db_path)
+    db.initialize()
+
+    # 마이그레이션 이력 강제 삭제 + vwap_orb 재활성 (legacy 상태 시뮬레이션)
+    db.execute("DELETE FROM schema_migrations WHERE filename = 'migrate_activate_bb_rsi_swing.sql'")
+    db.execute("UPDATE strategies SET is_active = 0")
+    db.execute("UPDATE strategies SET is_active = 1 WHERE name = 'vwap_orb_breakout'")
+    db.commit()
+
+    # 확인: legacy 상태
+    row = db.execute("SELECT name FROM strategies WHERE is_active = 1").fetchone()
+    assert dict(row)["name"] == "vwap_orb_breakout"
+    db.close()
+
+    # 봇 재시작 시뮬레이션 — initialize() 재호출
+    db2 = Database(db_path)
+    db2.initialize()
+    row2 = db2.execute("SELECT name FROM strategies WHERE is_active = 1").fetchone()
+    assert dict(row2)["name"] == "bb_rsi_combined", "마이그레이션 자동 재적용 실패"
+    db2.close()
+
+
+def test_migrations_run_in_filename_order(tmp_path):
+    """파일명 사전 순으로 정렬 실행 (예: 01_, 02_, ...)."""
+    db = Database(tmp_path / "test.db")
+    db.initialize()
+
+    # schema_migrations에 기록된 순서 != applied_at 순서일 수도 있지만,
+    # 같은 종류 (migrate_*.sql) 파일은 사전 순.
+    rows = db.execute(
+        "SELECT filename FROM schema_migrations ORDER BY filename"
+    ).fetchall()
+    filenames = [r[0] for r in rows]
+    assert filenames == sorted(filenames)
+    db.close()


### PR DESCRIPTION
## Summary

user 피드백: \"명령어가 너무 많다. pull + 재시작이면 안 되나\". 답: 봇이 자동으로 마이그레이션 감지·적용하면 됨.

**Before:**
\`\`\`bash
git pull
sqlite3 data/cryptobot.db < scripts/migrate_*.sql   # ← 수동
make stop && make daemon
\`\`\`

**After:**
\`\`\`bash
git pull && make daemon
# scripts/migrate_*.sql 자동 적용
\`\`\`

## 변경

\`Database.initialize()\` 끝에 \`_apply_pending_sql_migrations()\`:
- \`schema_migrations(filename, applied_at)\` 테이블로 적용 이력 추적
- \`scripts/migrate_*.sql\` 사전순 정렬 실행
- 한 파일 실패해도 다른 파일 계속 시도 (skip, 다음 시작 시 재시도)
- 멱등 — 같은 마이그레이션 중복 실행 X

## Test plan

- [x] \`tests/test_sql_migrations.py\` 6건 신규
  - schema_migrations 테이블 생성
  - 실제 #382 마이그레이션 자동 적용 (bb_rsi 활성)
  - 멱등성 (5번 호출해도 중복 X)
  - **legacy DB (vwap_orb 활성) → bb_rsi 자동 전환** (가장 중요)
  - 파일명 사전순 실행
- [x] 전체 660건 통과
- [x] README \"업데이트\" 섹션 추가

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)