### PR TITLE
hotfix: KIS US 매수 자금 초과 에러 — 출금가능액 + buffer (#388)

### DIFF
--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -115,6 +115,10 @@ def calc_position_size(
     - 종목당 한도: 가용예산 × max_position_per_symbol_pct / 100
     - 한국주식(1주 단위): qty = floor(한도 / 가격). 0이면 skip
     - 미국주식(소수점): qty = 한도 / 가격 (소수점 4자리)
+
+    #388: KIS US는 시장가 미지원 → 지정가 +0.5% buffer로 주문하므로
+    실제 주문가는 current_price × 1.005. 거기에 슬리피지·환율 변동 흡수용
+    추가 1% safety margin → 가용예산 × 0.985 기준으로 수량 산정.
     """
     if available_budget <= 0:
         return 0.0, "가용 예산 없음"
@@ -123,18 +127,22 @@ def calc_position_size(
 
     target = available_budget * (params.max_position_per_symbol_pct / 100.0)
 
+    # #388: 지정가 buffer(0.5%) + 안전 마진(1%) = 1.5% 차감해서 수량 산정
+    # → KIS API "주문가능금액 초과" 에러 방지
+    safe_price = current_price * 1.015
+
     if not fractional:
-        qty = int(target // current_price)
+        qty = int(target // safe_price)
         if qty < 1:
             return 0.0, (
-                f"예산 부족 (한도 {target:,.0f} < 1주 가격 {current_price:,.0f})"
+                f"예산 부족 (한도 {target:,.0f} < 1주 가격 {current_price:,.0f} × 1.015 buffer)"
             )
-        return float(qty), f"{qty}주 (한도 {target:,.0f})"
+        return float(qty), f"{qty}주 (한도 {target:,.0f}, buffer 1.5%)"
 
-    qty = round(target / current_price, 4)
+    qty = round(target / safe_price, 4)
     if qty < 0.001:
         return 0.0, "수량 < 0.001 (소수점 한도)"
-    return qty, f"{qty:.4f}주 (한도 {target:,.2f})"
+    return qty, f"{qty:.4f}주 (한도 {target:,.2f}, buffer 1.5%)"
 
 
 def _calc_rsi(prices: pd.Series, period: int = 14) -> float | None:

--- a/src/cryptobot/exchange/kis_us.py
+++ b/src/cryptobot/exchange/kis_us.py
@@ -187,17 +187,21 @@ class KISUSExchange(Exchange):
         """자산별 잔고.
 
         Args:
-            asset: "USD"(외화예수금) / "KRW"(원화예수금) / 종목 ticker (예: "NVDA")
+            asset: "USD"(외화 주문가능액) / "KRW"(원화예수금) / 종목 ticker
 
-        USD/KRW 예수금은 inquire-present-balance API의 output2/output3에서 조회.
-        - output2: 통화별 외화 잔고 (USD 단위 frcr_dncl_amt_2)
-        - output3.tot_dncl_amt: 원화예수금 (KRW)
-        종목 보유는 inquire-balance API의 output1.
+        USD는 **출금가능금액**(frcr_drwg_psbl_amt_1)을 반환 — 미체결 주문에 묶인
+        매수 증거금(frcr_buy_mgn_amt) 제외 후 실질 매수 가능액. (#388 핫픽스)
+        과거 frcr_dncl_amt_2(외화예수금)는 묶인 금액 포함 → 매수 시 자금 초과 에러.
         """
         if asset == "USD":
             present = self._inquire_present_balance()
             for row in present.get("output2") or []:
                 if row.get("crcy_cd") == "USD":
+                    # #388: frcr_drwg_psbl_amt_1 = 외화 출금가능금액 (안전한 매수 한도)
+                    # fallback: frcr_dncl_amt_2 = 외화예수금 (구버전 호환)
+                    drwg = row.get("frcr_drwg_psbl_amt_1")
+                    if drwg is not None:
+                        return float(drwg)
                     return float(row.get("frcr_dncl_amt_2", 0))
             return 0.0
 

--- a/tests/test_kis_strategy.py
+++ b/tests/test_kis_strategy.py
@@ -120,7 +120,7 @@ def test_position_size_kr_integer_shares():
         fractional=False,
         params=KISStrategyParams(max_position_per_symbol_pct=40.0),
     )
-    # 한도 80,000 / 70,000 = 1주
+    # #388: 한도 80,000 / (70,000 × 1.015 = 71,050) = floor(1.126) = 1주
     assert qty == 1.0
     assert "1주" in reason
 
@@ -143,9 +143,9 @@ def test_position_size_us_fractional():
         fractional=True,
         params=KISStrategyParams(max_position_per_symbol_pct=30.0),
     )
-    # 한도 60,000 / 100,000 = 0.6주
-    assert qty == 0.6
-    assert "0.6" in reason
+    # #388: 한도 60,000 / (100,000 × 1.015 = 101,500) ≈ 0.5911
+    assert 0.58 < qty < 0.60
+    assert "0.59" in reason
 
 
 def test_position_size_zero_budget():
@@ -156,6 +156,48 @@ def test_position_size_zero_budget():
     )
     assert qty == 0.0
     assert "예산" in reason
+
+
+# #388: 핫픽스 — 가용 예산 vs 실제 매수액에 buffer 반영
+def test_position_size_388_real_case_soxs():
+    """SOXS @ $9.63 + 가용 $647.88 → 70주 이상이면 자금 초과.
+    1.5% buffer 반영해서 약 66주 안전 수량 산출."""
+    qty, reason = calc_position_size(
+        available_budget=647.88,
+        current_price=9.63,
+        fractional=False,
+        params=KISStrategyParams(max_position_per_symbol_pct=100.0),
+    )
+    # safe_price = 9.63 × 1.015 = 9.77445
+    # 647.88 / 9.77445 = 66.28 → 66주
+    assert qty == 66.0
+    # 66주 × 9.77445 = $645 — KIS 한도 $647 안전 통과
+    actual_with_buffer = qty * 9.63 * 1.005
+    assert actual_with_buffer < 647.88, f"buffer 적용 후도 예산 초과: {actual_with_buffer}"
+
+
+def test_position_size_388_buffer_prevents_overflow():
+    """기존 버그: 가용 100 / 가격 10 → 10주 → 매수 시 100 × 1.005 = 101 초과.
+    핫픽스 후: 100 / (10 × 1.015) = 9.85 → 9주 → 9 × 10.05 = 90.45 안전."""
+    qty, _ = calc_position_size(
+        available_budget=100.0, current_price=10.0, fractional=False,
+        params=KISStrategyParams(max_position_per_symbol_pct=100.0),
+    )
+    assert qty == 9.0  # 10주 아님!
+    # buffer 적용 후 실제 주문가 확인
+    actual = qty * 10.0 * 1.005
+    assert actual <= 100.0, f"매수액 {actual} 가 예산 초과"
+
+
+def test_position_size_388_fractional_buffer():
+    """fractional 종목도 buffer 적용. budget 100, price 10 → 9.852주."""
+    qty, reason = calc_position_size(
+        available_budget=100.0, current_price=10.0, fractional=True,
+        params=KISStrategyParams(max_position_per_symbol_pct=100.0),
+    )
+    # 100 / (10 × 1.015) = 9.8522
+    assert 9.84 < qty < 9.86
+    assert "buffer" in reason
 
 
 def test_position_size_us_skip_when_dust():


### PR DESCRIPTION
## Summary

KIS US 봇이 강한 매수 시그널 떴는데 \`APBK0952 주문가능금액 초과\` 에러로 매분 실패.
즉시 적용 필요.

## 변경

1. \`get_balance(\"USD\")\` → \`frcr_drwg_psbl_amt_1\` (출금가능액) 우선 사용
2. \`calc_position_size\` 에 1.5% buffer (지정가 0.5% + slip 1%)

## Test

- 668건 통과 (신규 3 + 보정 3)

Closes #388