### PR TITLE
improve: KIS US 매수 직전 잔고 사전 검증 + 자금부족 cooldown (#390)

### DIFF
--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -244,6 +244,12 @@ class KISUSBot:
         self._last_sell_at: dict[str, float] = {}  # 종목별 마지막 매도 timestamp (epoch)
         self._stop_loss_price_at_buy: dict[str, float] = {}  # #305 ORB 모드 OR_low 손절가
         self._pending_stop_loss: float | None = None  # #305 매수 직전 OR_low 임시
+        # #390: 자금 부족 종목별 cooldown — 한 번 자금 부족 발생 시 N분간 같은 종목 매수 시도 안 함
+        # 같은 에러 반복(176회) 방지 + Slack 알림 폭주 방지
+        self._insufficient_funds_cooldown: dict[str, float] = {}  # symbol -> 다음 시도 가능 epoch
+        self._insufficient_funds_cooldown_sec = int(
+            os.getenv("KIS_US_INSUFFICIENT_FUNDS_COOLDOWN_SEC", "300")  # 디폴트 5분
+        )
 
     def start(self) -> None:
         mode = "단타(데일리)" if self._params.day_trading_mode else "스윙"
@@ -543,22 +549,39 @@ class KISUSBot:
         return signal_, sl_price, tp_price, rps
 
     def _execute_buy_queue(self, candidates: list) -> None:
-        """매수 후보 신뢰도 정렬 후 순차 매수. 자금 부족하면 다음 후보 skip.
+        """매수 후보 신뢰도 정렬 후 순차 매수.
 
+        #390: 매수 직전 fresh 잔고 조회 + 자금 부족 종목 cooldown 적용.
         candidates 튜플: (symbol, price, sig, sl_price, tp_price, risk_per_share)
         Pure Zarattini 모드는 risk_per_share 기반 1% 사이징, 그 외엔 풀매수.
         """
+        # #390: 매수 직전 캐시 무효화 후 fresh 잔고 조회
+        # KIS settlement 지연 + 봇 캐시(60s)로 stale 잔고 위험 → 매번 fresh 호출
+        if hasattr(self._exchange, "invalidate_balance_cache"):
+            self._exchange.invalidate_balance_cache()
         try:
             budget_usd = self._exchange.get_balance("USD")
         except APIError as e:
             logger.warning("USD 예수금 조회 실패 — 매수 큐 스킵: %s", e)
             return
+        logger.info("[매수 큐] 가용 USD = $%.2f (출금가능액 기준)", budget_usd)
+
+        now_epoch = _time.time()
 
         for entry in candidates:
             symbol, price_usd, sig, sl_price, tp_price, rps = entry
             if budget_usd <= 0:
                 logger.info("USD 잔고 0 — 남은 후보 %d건 매수 스킵", len([c for c in candidates if c[0] != symbol]))
                 break
+
+            # #390: 자금 부족 cooldown 체크 — 5분 내 자금 부족 발생한 종목 skip
+            cd_until = self._insufficient_funds_cooldown.get(symbol, 0)
+            if cd_until > now_epoch:
+                remaining = int(cd_until - now_epoch)
+                logger.info(
+                    "%s 자금부족 cooldown 남은 %d초 — 매수 시도 skip", symbol, remaining,
+                )
+                continue
 
             is_fractional = symbol not in INTEGER_ONLY_TICKERS
 
@@ -586,15 +609,54 @@ class KISUSBot:
                 )
                 continue
 
+            # #390: 매수 직전 사전 검증 — qty × price × 1.015 (buffer) ≤ budget
+            estimated_cost = qty * price_usd * 1.015
+            if estimated_cost > budget_usd:
+                logger.warning(
+                    "%s 사전 검증 실패: 예상 매수액 $%.2f > 가용 $%.2f — 매수 큐 중단",
+                    symbol, estimated_cost, budget_usd,
+                )
+                self._mark_insufficient_funds(symbol, budget_usd, estimated_cost)
+                continue
+
             logger.info(
-                "[매수실행] %s conf=%.2f @ $%.2f — %s | %s",
+                "[매수실행] %s conf=%.2f @ $%.2f — %s | %s | 예상비용 $%.2f / 가용 $%.2f",
                 symbol, sig.confidence, price_usd, sig.reason, size_reason,
+                estimated_cost, budget_usd,
             )
             self._pending_stop_loss = sl_price
             self._pending_take_profit = tp_price
-            self._buy(symbol, qty, price_usd, sig.reason)
+            buy_success = self._buy(symbol, qty, price_usd, sig.reason)
+            if buy_success is False:
+                # 자금 부족 등 실패 시 cooldown 등록 (Slack 1회 알림)
+                self._mark_insufficient_funds(symbol, budget_usd, estimated_cost)
+                # 잔고 재조회 (다음 후보 계산 정확하게)
+                if hasattr(self._exchange, "invalidate_balance_cache"):
+                    self._exchange.invalidate_balance_cache()
+                try:
+                    budget_usd = self._exchange.get_balance("USD")
+                except APIError:
+                    break
+                continue
             cost = qty * price_usd
             budget_usd = max(0.0, budget_usd - cost)
+
+    def _mark_insufficient_funds(self, symbol: str, budget: float, cost: float) -> None:
+        """#390: 자금 부족 종목 cooldown 등록 + Slack 1회 알림."""
+        cd_sec = self._insufficient_funds_cooldown_sec
+        prev = self._insufficient_funds_cooldown.get(symbol, 0)
+        # 이미 cooldown 중이면 Slack 알림 안 함 (중복 방지)
+        already_cooldown = prev > _time.time()
+        self._insufficient_funds_cooldown[symbol] = _time.time() + cd_sec
+        if not already_cooldown and self._notifier and self._notifier.is_configured:
+            try:
+                self._notifier.notify_trade_message(
+                    f"⚠️ [KIS_US] {symbol} 매수 자금 부족 — "
+                    f"필요 ${cost:.2f} / 가용 ${budget:.2f} (부족 ${cost - budget:.2f}). "
+                    f"{cd_sec // 60}분 cooldown."
+                )
+            except Exception as e:
+                logger.warning("Slack 알림 실패: %s", e)
 
     def _evaluate_sell_with_price(self, symbol: str, price_usd: float) -> None:
         """#309: _evaluate_symbol 매도 분기 추출 (price 외부 주입)."""

--- a/tests/test_kis_us_balance_precheck.py
+++ b/tests/test_kis_us_balance_precheck.py
@@ -1,0 +1,127 @@
+"""#390: KIS US 매수 직전 잔고 사전 검증 + cooldown 테스트.
+
+핵심 로직 단위 테스트 — 무거운 mock 없이.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+
+def test_insufficient_funds_cooldown_tracking():
+    """자금 부족 발생 → cooldown 등록 → 같은 종목 N분간 skip."""
+    cooldown = {}
+    cooldown_sec = 300
+    now = time.time()
+    symbol = "SOXS"
+
+    # 첫 자금 부족 발생
+    cooldown[symbol] = now + cooldown_sec
+    assert symbol in cooldown
+    assert cooldown[symbol] > now
+
+    # 즉시 재시도 시 cooldown 안 풀림
+    assert cooldown[symbol] > time.time()
+
+    # 5분 후 (시뮬레이션)
+    future = now + cooldown_sec + 1
+    assert cooldown[symbol] < future  # 풀림
+
+
+def test_estimated_cost_validation():
+    """매수 사전 검증: qty × price × 1.015 (buffer) > budget 이면 skip."""
+    budget_usd = 647.88
+    price_usd = 9.63
+    qty = 70  # 사용자 케이스
+
+    estimated_cost = qty * price_usd * 1.015  # buffer 포함
+    # 70 × 9.63 × 1.015 = $684.20
+    assert estimated_cost > budget_usd, "70주 매수는 $647 예산으로 불가"
+
+    # 66주는 통과
+    qty_safe = 66
+    safe_cost = qty_safe * price_usd * 1.015
+    # 66 × 9.63 × 1.015 = $645.21
+    assert safe_cost <= budget_usd, "66주는 $647 예산 내 통과"
+
+
+def test_buffer_factor_value():
+    """buffer = 1.5% (지정가 0.5% + slip 1%) 가 일관 적용."""
+    buffer = 1.015
+    # 100 USD × 1.015 ≈ 101.5 (float 부정확 허용)
+    assert abs(100 * buffer - 101.5) < 0.001
+
+
+def test_cooldown_duplicate_alert_prevention():
+    """이미 cooldown 중이면 Slack 알림 중복 안 됨."""
+    cooldown = {}
+    cooldown_sec = 300
+    now = time.time()
+    symbol = "SOXS"
+    notifier_call_count = [0]
+
+    def maybe_notify(sym):
+        prev = cooldown.get(sym, 0)
+        already_cooldown = prev > time.time()
+        cooldown[sym] = time.time() + cooldown_sec
+        if not already_cooldown:
+            notifier_call_count[0] += 1
+
+    # 첫 자금 부족 — 알림 발송
+    maybe_notify(symbol)
+    assert notifier_call_count[0] == 1
+
+    # 즉시 두번째 시도 — cooldown 중이라 알림 안 보냄
+    maybe_notify(symbol)
+    assert notifier_call_count[0] == 1, "중복 알림 발송됨"
+
+    # 세번째 — 여전히 cooldown
+    maybe_notify(symbol)
+    assert notifier_call_count[0] == 1
+
+
+def test_cooldown_resets_after_expiry():
+    """cooldown 만료 후 새 알림 가능."""
+    cooldown = {}
+    cooldown_sec = 1  # 짧게
+    symbol = "SOXS"
+    notifier_call_count = [0]
+
+    def maybe_notify(sym):
+        prev = cooldown.get(sym, 0)
+        already_cooldown = prev > time.time()
+        cooldown[sym] = time.time() + cooldown_sec
+        if not already_cooldown:
+            notifier_call_count[0] += 1
+
+    maybe_notify(symbol)
+    assert notifier_call_count[0] == 1
+
+    time.sleep(1.1)  # cooldown 만료 대기
+    maybe_notify(symbol)
+    assert notifier_call_count[0] == 2, "cooldown 만료 후 새 알림 안 발송됨"
+
+
+def test_calc_position_size_388_388_integration():
+    """#388 buffer + #390 fresh balance 통합 — SOXS 실케이스."""
+    from cryptobot.bot.kis_strategy import KISStrategyParams, calc_position_size
+
+    qty, reason = calc_position_size(
+        available_budget=647.88,  # frcr_drwg_psbl_amt_1
+        current_price=9.63,
+        fractional=False,
+        params=KISStrategyParams(max_position_per_symbol_pct=100.0),
+    )
+    # 1.5% buffer 적용 후 66주
+    assert qty == 66.0
+    # 사전 검증: 66 × 9.63 × 1.015 ≤ 647.88
+    estimated = qty * 9.63 * 1.015
+    assert estimated <= 647.88, f"매수액 {estimated:.2f} > 예산 647.88"
+
+
+def test_no_cooldown_for_new_symbol():
+    """첫 매수 시도 시 cooldown 없음 (정상 진행)."""
+    cooldown = {}
+    cd_until = cooldown.get("NEW_SYMBOL", 0)
+    assert cd_until <= time.time()  # cooldown 없음


### PR DESCRIPTION
## Summary

user 요청: \"매수하기 전에 가용 잔고 체크 추가.\"

## 변경

\`run_kis_us.py\` \`_execute_buy_queue\`:
1. 매수 큐 시작 시 \`invalidate_balance_cache()\` + fresh 잔고 호출 → settlement 지연 / 캐시 stale 방지
2. 사전 검증: \`qty × price × 1.015 ≤ budget\` 체크 (1.5% buffer 포함)
3. 자금 부족 발생 시 \`_mark_insufficient_funds()\` — 종목별 5분 cooldown 등록
4. cooldown 중 동일 종목 매수 시도 skip (176회 반복 방지)
5. Slack 알림 1회만 (cooldown 중복 알림 방지)

## Test plan

- [x] 7건 신규 (cooldown / 사전 검증 / Slack 중복 방지 / SOXS 실케이스)
- [x] 전체 675건 통과

Closes #390