### PR TITLE
feat: KIS US Slack 통합 보고 — 매수/매도/장 시작/일일 결산 (#393)

### DIFF
--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -283,6 +283,10 @@ class KISUSBot:
         # 같은 에러 반복(176회) 방지 + Slack 알림 폭주 방지
         self._insufficient_funds_cooldown: dict[str, float] = {}  # symbol -> 다음 시도 가능 epoch
         self._insufficient_funds_cooldown_sec = INSUFFICIENT_FUNDS_COOLDOWN_SEC
+        # #393: Slack 통합 보고 — 장 시작/일일 결산 1회 가드 (NY 날짜별)
+        self._market_open_sent_date: str | None = None  # NY date "YYYY-MM-DD"
+        self._daily_summary_sent_date: str | None = None
+        self._usd_start_of_day: float | None = None  # 장 시작 시점 USD 잔고 (일일 손익 계산용)
 
     def start(self) -> None:
         mode = "단타(데일리)" if self._params.day_trading_mode else "스윙"
@@ -337,6 +341,9 @@ class KISUSBot:
 
     def _tick(self) -> None:
         self._tick_count += 1
+        #393: 장 시작 / 일일 결산 트리거 (시장 상태 무관)
+        self._maybe_send_market_open()
+        self._maybe_send_daily_summary()
         if not self._is_trading_enabled():
             logger.debug("kis_us 거래 DB에서 비활성. 스킵")
             return
@@ -697,6 +704,99 @@ class KISUSBot:
             cost = qty * price_usd
             budget_usd = max(0.0, budget_usd - cost)
 
+    def _maybe_send_market_open(self) -> None:
+        """#393: NY 09:30 직후 1회 장 시작 알림."""
+        ny_now = datetime.now(NY)
+        if ny_now.weekday() >= 5:
+            return  # 주말
+        # 09:30~09:32 사이만 (3분 윈도우)
+        if not (ny_now.hour == 9 and 30 <= ny_now.minute <= 32):
+            return
+        today = ny_now.strftime("%Y-%m-%d")
+        if self._market_open_sent_date == today:
+            return
+        if not (self._notifier and self._notifier.is_configured):
+            self._market_open_sent_date = today
+            return
+        try:
+            from cryptobot.notifier.kis_us_reports import format_market_open
+
+            usd = self._exchange.get_balance("USD")
+            try:
+                fx = self._exchange.get_fx_rate_krw_per_usd()
+            except Exception:
+                fx = 1400.0
+            msg = format_market_open(
+                universe=list(self._universe),
+                usd_available=usd,
+                fx_krw_per_usd=fx,
+            )
+            self._notifier.notify_trade_message(msg)
+            self._usd_start_of_day = usd
+            self._market_open_sent_date = today
+            logger.info("[Slack] 장 시작 알림 발송 (%s)", today)
+        except Exception as e:
+            logger.warning("장 시작 알림 실패: %s", e)
+
+    def _maybe_send_daily_summary(self) -> None:
+        """#393: NY 16:05 ~ 16:10 사이 1회 일일 결산."""
+        ny_now = datetime.now(NY)
+        if ny_now.weekday() >= 5:
+            return
+        # 16:05~16:10 윈도우 (마감 5~10분 후)
+        if not (ny_now.hour == 16 and 5 <= ny_now.minute <= 10):
+            return
+        today = ny_now.strftime("%Y-%m-%d")
+        if self._daily_summary_sent_date == today:
+            return
+        if not (self._notifier and self._notifier.is_configured):
+            self._daily_summary_sent_date = today
+            return
+        try:
+            from cryptobot.notifier.kis_us_reports import (
+                calc_period_pnl,
+                calc_today_pnl,
+                format_daily_summary,
+            )
+
+            today_pnl, today_trades = calc_today_pnl(self._db)
+            week_pnl, week_days = calc_period_pnl(self._db, days=7)
+            month_pnl, _ = calc_period_pnl(self._db, days=30)
+            total_pnl, _ = calc_period_pnl(self._db, days=3650)  # 10년 = 사실상 전체
+
+            usd_now = self._exchange.get_balance("USD")
+            usd_start = self._usd_start_of_day if self._usd_start_of_day is not None else usd_now - today_pnl
+
+            # 매매 없는 날 → skip 사유 수집
+            skip_reasons: dict[str, str] = {}
+            if not today_trades:
+                # 가장 최근 evaluation을 종목별로 1건씩
+                for symbol in self._universe:
+                    row = self._db.execute(
+                        "SELECT reason FROM kis_us_evaluations "
+                        "WHERE ticker = ? AND evaluated_at >= date('now', '-1 day') "
+                        "ORDER BY id DESC LIMIT 1",
+                        (symbol,),
+                    ).fetchone()
+                    if row:
+                        skip_reasons[symbol] = (dict(row).get("reason") or "")[:60]
+
+            msg = format_daily_summary(
+                today_trades=today_trades,
+                skip_reasons=skip_reasons,
+                usd_now=usd_now,
+                usd_start_of_day=usd_start,
+                week_pnl_usd=week_pnl,
+                week_trade_days=week_days,
+                month_pnl_usd=month_pnl,
+                total_pnl_usd=total_pnl if abs(total_pnl) > 0.01 else None,
+            )
+            self._notifier.notify_trade_message(msg)
+            self._daily_summary_sent_date = today
+            logger.info("[Slack] 일일 결산 발송 (%s, 매매 %d건)", today, len(today_trades))
+        except Exception as e:
+            logger.exception("일일 결산 알림 실패: %s", e)
+
     def _mark_insufficient_funds(self, symbol: str, budget: float, cost: float) -> None:
         """#390: 자금 부족 종목 cooldown 등록 + Slack 1회 알림."""
         cd_sec = self._insufficient_funds_cooldown_sec
@@ -763,8 +863,25 @@ class KISUSBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
+            #393: 통합 보고 포맷
+            from cryptobot.notifier.kis_us_reports import format_buy
+
+            try:
+                budget = self._exchange.get_balance("USD")
+            except Exception:
+                budget = None
+            stop = self._stop_loss_price_at_buy.get(symbol)
+            risk = abs(stop - result.price) * result.amount if stop else None
             self._notifier.notify_trade_message(
-                f"[KIS_US][매수] {symbol} {result.amount:.4f}주 @ ${result.price:.2f} — {reason}"
+                format_buy(
+                    symbol=symbol,
+                    qty=result.amount,
+                    price=result.price,
+                    signal_reason=reason,
+                    stop_loss_price=stop,
+                    risk_usd=risk,
+                    account_usd=budget,
+                )
             )
 
     def _sell(self, symbol: str, reason: str, pnl_pct: float) -> None:
@@ -791,8 +908,41 @@ class KISUSBot:
             order_uuid=result.order_uuid,
         )
         if self._notifier.is_configured:
+            #393: 통합 보고 포맷 — 손절/EOD 익절/EOD 손실 분기
+            from cryptobot.notifier.kis_us_reports import format_sell
+
+            # sell_type 분류
+            reason_lower = (reason or "").lower()
+            is_eod = "day_trading_close" in reason_lower or "eod" in reason_lower or "강제" in (reason or "")
+            if is_eod:
+                sell_type = "eod_profit" if pnl_pct > 0 else "eod_loss"
+            else:
+                sell_type = "stop_loss"
+            # 보유 시간 추정 (last_buy_price 기준, 정확도 낮으나 표시용)
+            hold_min = 0
+            try:
+                buy_row = self._db.execute(
+                    "SELECT timestamp FROM trades WHERE market='kis_us' AND coin=? AND side='buy' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (symbol,),
+                ).fetchone()
+                if buy_row:
+                    from datetime import datetime as _dt
+                    buy_t = _dt.strptime(dict(buy_row)["timestamp"], "%Y-%m-%d %H:%M:%S")
+                    hold_min = int((_dt.utcnow() - buy_t).total_seconds() / 60)
+            except Exception:
+                pass
+            pnl_usd = result.amount * (result.price - (self._last_buy_price.get(symbol, result.price)))
             self._notifier.notify_trade_message(
-                f"[KIS_US][매도] {symbol} {result.amount:.4f}주 @ ${result.price:.2f} ({pnl_pct:+.2f}%) — {reason}"
+                format_sell(
+                    symbol=symbol,
+                    qty=result.amount,
+                    price=result.price,
+                    pnl_pct=pnl_pct,
+                    pnl_usd=pnl_usd,
+                    hold_minutes=hold_min,
+                    sell_type=sell_type,
+                )
             )
         self._last_buy_price.pop(symbol, None)
         self._highest_since_buy.pop(symbol, None)

--- a/src/cryptobot/notifier/kis_us_reports.py
+++ b/src/cryptobot/notifier/kis_us_reports.py
@@ -1,0 +1,319 @@
+"""#393: KIS US 봇 Slack 통합 보고 메시지 포매터.
+
+구성:
+- format_market_open(): 장 시작 알림
+- format_buy(): 매수 체결 알림
+- format_sell(): 매도 알림 (손절/EOD 익절/EOD 손실 분기)
+- format_daily_summary(): 일일 결산 (매매 있는/없는 날 모두)
+
+사용자 가독성 최우선 — 이모지 + 정렬 + 핵심 정보 highlight.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+NY = ZoneInfo("America/New_York")
+
+
+def _now_kst() -> datetime:
+    return datetime.now(KST)
+
+
+def _now_ny() -> datetime:
+    return datetime.now(NY)
+
+
+def format_market_open(
+    universe: list[str],
+    usd_available: float,
+    fx_krw_per_usd: float,
+    strategy: str = "Zarattini Pure 3X",
+) -> str:
+    """장 시작 알림 — NY 09:30 직후 1회."""
+    coins_str = " · ".join(f"`{s}`" for s in universe)
+    krw_eq = int(usd_available * fx_krw_per_usd)
+    return (
+        f"🇺🇸 *KIS 미국주식 봇 — 장 시작!*\n"
+        f"\n"
+        f"📊 *오늘 운영*\n"
+        f"• 종목: {coins_str}\n"
+        f"• 가용: *${usd_available:,.2f}* (≈ ₩{krw_eq:,})\n"
+        f"• 전략: {strategy}\n"
+        f"• 손절: ATR × 5% 동적\n"
+        f"\n"
+        f"⏰ *주요 시점*\n"
+        f"• 진입: NY 09:35 (KST 22:35)\n"
+        f"• EOD: NY 15:50 (KST 04:50)\n"
+        f"\n"
+        f"_좋은 매매 되세요_ 🍀"
+    )
+
+
+def format_buy(
+    symbol: str,
+    qty: float,
+    price: float,
+    signal_reason: str,
+    stop_loss_price: float | None = None,
+    risk_usd: float | None = None,
+    account_usd: float | None = None,
+) -> str:
+    """매수 체결 알림."""
+    qty_str = f"{int(qty)}주" if qty == int(qty) else f"{qty:.4f}주"
+    total = qty * price
+    now_kst = _now_kst()
+    now_ny = _now_ny()
+
+    lines = [
+        f"✅ *매수 체결* — `{symbol}`",
+        "━━━━━━━━━━━━━━━━━━━━",
+        f"💰 *{qty_str}* × ${price:.2f} = *${total:,.2f}*",
+        f"📈 시그널: {signal_reason[:80]}",
+    ]
+    if stop_loss_price is not None and stop_loss_price > 0:
+        stop_pct = (stop_loss_price - price) / price * 100
+        lines.append(f"🛡 손절선: ${stop_loss_price:.2f} ({stop_pct:+.2f}%)")
+    if risk_usd is not None and account_usd is not None and account_usd > 0:
+        risk_pct = risk_usd / account_usd * 100
+        lines.append(f"⚖️ 최대 리스크: ${risk_usd:.2f} (계좌 {risk_pct:.1f}%)")
+    lines.append("")
+    lines.append(f"⏱ {now_kst.strftime('%H:%M:%S')} KST · NY {now_ny.strftime('%H:%M:%S')}")
+    return "\n".join(lines)
+
+
+def format_sell(
+    symbol: str,
+    qty: float,
+    price: float,
+    pnl_pct: float,
+    pnl_usd: float,
+    hold_minutes: int,
+    sell_type: str,  # "stop_loss" / "eod_profit" / "eod_loss"
+    is_one_per_day: bool = True,
+) -> str:
+    """매도 알림 — 손절/EOD 익절/EOD 손실 케이스별."""
+    qty_str = f"{int(qty)}주" if qty == int(qty) else f"{qty:.4f}주"
+    hold_str = _format_hold_duration(hold_minutes)
+
+    if sell_type == "stop_loss":
+        header = f"🔴 *손절* — `{symbol}`"
+        result_emoji = "📉" if pnl_pct < 0 else "📈"
+        result_line = f"{result_emoji} *결과*: *{pnl_usd:+.2f}$* ({pnl_pct:+.2f}%) 😔"
+        extra = (
+            f"⏱ 보유 {hold_str}\n"
+            f"🛡 ATR × 5% stop hit\n"
+            f"\n"
+            f"🔒 오늘 `{symbol}` 매매 종료 (1일 1회 룰)"
+        )
+    elif sell_type == "eod_profit":
+        header = f"🎉 *EOD 익절* — `{symbol}`"
+        result_line = f"📈 *결과*: *+${pnl_usd:.2f}* (+{pnl_pct:.2f}%) ✨"
+        extra = (
+            f"⏱ 보유 {hold_str}\n"
+            f"🏁 마감 10분 전 강제 청산"
+        )
+    elif sell_type == "eod_loss":
+        header = f"🟡 *EOD 청산 (손실)* — `{symbol}`"
+        result_line = f"📉 *결과*: *${pnl_usd:.2f}* ({pnl_pct:.2f}%)"
+        extra = (
+            f"⏱ 보유 {hold_str}\n"
+            f"🏁 손절선 안 닿았지만 마감 청산"
+        )
+    else:
+        header = f"💼 *매도* — `{symbol}`"
+        result_line = f"📊 결과: ${pnl_usd:+.2f} ({pnl_pct:+.2f}%)"
+        extra = f"⏱ 보유 {hold_str}"
+
+    return (
+        f"{header}\n"
+        f"━━━━━━━━━━━━━━━━━━━━\n"
+        f"{result_line}\n"
+        f"💰 매도가: ${price:.2f} × {qty_str}\n"
+        f"{extra}"
+    )
+
+
+def format_daily_summary(
+    today_trades: list[dict],
+    skip_reasons: dict[str, str],  # symbol -> "도지" / "음봉" 등
+    usd_now: float,
+    usd_start_of_day: float,
+    week_pnl_usd: float,
+    week_trade_days: int,
+    month_pnl_usd: float,
+    total_pnl_usd: float | None = None,
+) -> str:
+    """일일 결산 — 매매 있는 날/없는 날 모두 표시."""
+    ny_now = _now_ny()
+    date_str = ny_now.strftime("%Y-%m-%d (%a)").replace(
+        "Mon", "월").replace("Tue", "화").replace("Wed", "수").replace(
+        "Thu", "목").replace("Fri", "금").replace("Sat", "토").replace("Sun", "일")
+    next_day_kst = (_now_kst().replace(hour=22, minute=30, second=0, microsecond=0))
+    from datetime import timedelta
+    if _now_kst().hour >= 22:  # 22:30 이전이면 같은 날, 이후면 내일
+        next_day_kst += timedelta(days=1)
+    next_day_str = next_day_kst.strftime("%m/%d (%a)").replace(
+        "Mon", "월").replace("Tue", "화").replace("Wed", "수").replace(
+        "Thu", "목").replace("Fri", "금").replace("Sat", "토").replace("Sun", "일")
+
+    today_pnl = usd_now - usd_start_of_day
+    today_pnl_pct = (today_pnl / usd_start_of_day * 100) if usd_start_of_day > 0 else 0.0
+    pnl_emoji = "📈" if today_pnl > 0 else ("📉" if today_pnl < 0 else "➡️")
+
+    if today_trades:
+        # 매매 있는 날
+        trade_lines = []
+        for t in today_trades:
+            emoji = {"eod_profit": "🎉", "stop_loss": "🔴", "eod_loss": "🟡"}.get(
+                t.get("sell_type", ""), "💼"
+            )
+            label = {
+                "eod_profit": "EOD 익절",
+                "stop_loss": "손절",
+                "eod_loss": "EOD 손실",
+            }.get(t.get("sell_type", ""), "매도")
+            trade_lines.append(
+                f"  {emoji} {t['symbol']} {label} "
+                f"{t['pnl_usd']:+.2f}$ ({t['pnl_pct']:+.2f}%)"
+            )
+        trade_block = "\n".join(trade_lines)
+
+        msg = (
+            f"📊 *KIS 미국주식 일일 결산*\n"
+            f"*{date_str}*\n"
+            f"━━━━━━━━━━━━━━━━━━━━\n"
+            f"\n"
+            f"✅ *오늘 매매*\n"
+            f"{trade_block}\n"
+            f"\n"
+            f"💰 *오늘 손익*: *{today_pnl:+.2f}$* ({today_pnl_pct:+.2f}%) {pnl_emoji}\n"
+            f"📦 누적 USD: ${usd_start_of_day:.2f} → *${usd_now:.2f}*\n"
+            f"📅 이번 주: ${week_pnl_usd:+.2f} ({week_trade_days}매매일)\n"
+            f"📅 이번 달: ${month_pnl_usd:+.2f}\n"
+        )
+        if total_pnl_usd is not None:
+            msg += f"🏆 운영 누적: ${total_pnl_usd:+.2f}\n"
+    else:
+        # 매매 없는 날
+        skip_lines = []
+        for symbol, reason in skip_reasons.items():
+            skip_lines.append(f"  • `{symbol}` bar1: {reason}")
+        skip_block = "\n".join(skip_lines) if skip_lines else "  • 시장 미동작 또는 데이터 X"
+
+        msg = (
+            f"😴 *KIS 미국주식 일일 결산*\n"
+            f"*{date_str}*\n"
+            f"━━━━━━━━━━━━━━━━━━━━\n"
+            f"\n"
+            f"📭 *오늘 매매 없음*\n"
+            f"\n"
+            f"🔍 시그널 사유\n"
+            f"{skip_block}\n"
+            f"\n"
+            f"💰 누적 USD: *${usd_now:.2f}* (변동 없음)\n"
+            f"📅 이번 주: ${week_pnl_usd:+.2f} ({week_trade_days}매매일)\n"
+        )
+
+    msg += f"\n⏰ 다음: {next_day_str} KST 22:30"
+    return msg
+
+
+def _format_hold_duration(minutes: int) -> str:
+    """N분 → '17분' 또는 '6h 15m' 형식."""
+    if minutes < 60:
+        return f"{minutes}분"
+    h, m = divmod(minutes, 60)
+    return f"{h}h {m}m"
+
+
+# === DB 집계 헬퍼 ===
+
+
+def calc_today_pnl(db, symbol_filter: str = "kis_us") -> tuple[float, list[dict]]:
+    """오늘(NY 거래일) 매매 손익 + 매매 상세 리스트.
+
+    Returns:
+        (today_pnl_usd, trades_list)
+    """
+    from datetime import timezone
+
+    ny_now = _now_ny()
+    ny_midnight = ny_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    ny_midnight_utc = ny_midnight.astimezone(timezone.utc)
+
+    rows = db.execute(
+        """
+        SELECT id, coin, side, price, amount, profit_pct, trigger_reason, timestamp
+        FROM trades
+        WHERE market = ? AND timestamp >= ?
+        ORDER BY timestamp, id
+        """,
+        (symbol_filter, ny_midnight_utc.strftime("%Y-%m-%d %H:%M:%S")),
+    ).fetchall()
+
+    pnl_total = 0.0
+    trades_summary = []
+    # 매수-매도 쌍 매칭
+    buys = {}
+    for r in rows:
+        d = dict(r)
+        if d["side"] == "buy":
+            buys[d["coin"]] = d
+        elif d["side"] == "sell":
+            buy = buys.get(d["coin"])
+            if buy:
+                pnl_usd = (d["price"] - buy["price"]) * d["amount"]
+                pnl_total += pnl_usd
+                trigger = (d.get("trigger_reason") or "").lower()
+                if "손절" in (d.get("trigger_reason") or "") or "stop" in trigger:
+                    sell_type = "stop_loss"
+                elif "eod" in trigger or "day_trading_close" in trigger or "강제" in (d.get("trigger_reason") or ""):
+                    sell_type = "eod_profit" if pnl_usd > 0 else "eod_loss"
+                else:
+                    sell_type = "other"
+                trades_summary.append({
+                    "symbol": d["coin"],
+                    "pnl_usd": pnl_usd,
+                    "pnl_pct": d.get("profit_pct") or 0.0,
+                    "sell_type": sell_type,
+                })
+                del buys[d["coin"]]
+    return pnl_total, trades_summary
+
+
+def calc_period_pnl(db, days: int, symbol_filter: str = "kis_us") -> tuple[float, int]:
+    """최근 N일 손익 + 매매일 수."""
+    from datetime import timedelta, timezone
+
+    cutoff = (_now_ny() - timedelta(days=days)).replace(hour=0, minute=0)
+    cutoff_utc = cutoff.astimezone(timezone.utc)
+
+    rows = db.execute(
+        """
+        SELECT id, coin, side, price, amount, timestamp
+        FROM trades
+        WHERE market = ? AND timestamp >= ?
+        ORDER BY timestamp, id
+        """,
+        (symbol_filter, cutoff_utc.strftime("%Y-%m-%d %H:%M:%S")),
+    ).fetchall()
+
+    pnl = 0.0
+    trade_days: set = set()
+    buys = {}
+    for r in rows:
+        d = dict(r)
+        if d["side"] == "buy":
+            buys[d["coin"]] = d
+        elif d["side"] == "sell":
+            buy = buys.get(d["coin"])
+            if buy:
+                pnl += (d["price"] - buy["price"]) * d["amount"]
+                # NY date 추출 (단순화: timestamp 앞 10자)
+                trade_days.add(d["timestamp"][:10])
+                del buys[d["coin"]]
+    return pnl, len(trade_days)

--- a/tests/test_kis_us_reports.py
+++ b/tests/test_kis_us_reports.py
@@ -1,0 +1,231 @@
+"""#393: KIS US Slack 통합 보고 메시지 포맷 + 집계 테스트."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+from cryptobot.notifier.kis_us_reports import (
+    calc_period_pnl,
+    calc_today_pnl,
+    format_buy,
+    format_daily_summary,
+    format_market_open,
+    format_sell,
+)
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+# === 포맷 테스트 ===
+
+
+def test_format_market_open_basic():
+    msg = format_market_open(
+        universe=["SOXL", "SOXS"],
+        usd_available=647.88,
+        fx_krw_per_usd=1473.0,
+    )
+    assert "장 시작" in msg
+    assert "SOXL" in msg and "SOXS" in msg
+    assert "647" in msg
+    assert "954" in msg  # ₩954,XXX (대략)
+
+
+def test_format_buy_basic():
+    msg = format_buy(
+        symbol="SOXL",
+        qty=3,
+        price=176.08,
+        signal_reason="bar1 양봉 +0.42%",
+        stop_loss_price=175.22,
+        risk_usd=2.58,
+        account_usd=647.88,
+    )
+    assert "매수 체결" in msg
+    assert "SOXL" in msg
+    assert "3주" in msg
+    assert "176.08" in msg
+    assert "528.24" in msg  # 3 × 176.08
+    assert "175.22" in msg
+    assert "리스크" in msg
+
+
+def test_format_buy_fractional_qty():
+    msg = format_buy(
+        symbol="NVDA",
+        qty=0.5,
+        price=200.0,
+        signal_reason="test",
+    )
+    assert "0.5000주" in msg
+
+
+def test_format_sell_stop_loss():
+    msg = format_sell(
+        symbol="SOXL",
+        qty=3,
+        price=175.22,
+        pnl_pct=-0.49,
+        pnl_usd=-2.58,
+        hold_minutes=17,
+        sell_type="stop_loss",
+    )
+    assert "손절" in msg
+    assert "SOXL" in msg
+    assert "-0.49" in msg
+    assert "-2.58" in msg
+    assert "17분" in msg
+    assert "1일 1회 룰" in msg
+
+
+def test_format_sell_eod_profit():
+    msg = format_sell(
+        symbol="SOXL",
+        qty=3,
+        price=182.50,
+        pnl_pct=3.65,
+        pnl_usd=19.26,
+        hold_minutes=375,  # 6h 15m
+        sell_type="eod_profit",
+    )
+    assert "EOD 익절" in msg
+    assert "+3.65" in msg
+    assert "$19.26" in msg
+    assert "6h 15m" in msg
+
+
+def test_format_sell_eod_loss():
+    msg = format_sell(
+        symbol="SOXS",
+        qty=10,
+        price=8.50,
+        pnl_pct=-0.90,
+        pnl_usd=-0.77,
+        hold_minutes=300,
+        sell_type="eod_loss",
+    )
+    assert "EOD 청산" in msg
+    assert "손실" in msg
+    assert "-0.90" in msg
+
+
+# === 일일 결산 ===
+
+
+def test_format_daily_summary_with_trades():
+    trades = [
+        {"symbol": "SOXL", "pnl_usd": 19.26, "pnl_pct": 3.65, "sell_type": "eod_profit"},
+        {"symbol": "SOXS", "pnl_usd": -2.58, "pnl_pct": -0.49, "sell_type": "stop_loss"},
+    ]
+    msg = format_daily_summary(
+        today_trades=trades,
+        skip_reasons={},
+        usd_now=664.56,
+        usd_start_of_day=647.88,
+        week_pnl_usd=16.68,
+        week_trade_days=1,
+        month_pnl_usd=-30.0,
+        total_pnl_usd=50.0,
+    )
+    assert "일일 결산" in msg
+    assert "SOXL" in msg and "SOXS" in msg
+    assert "EOD 익절" in msg
+    assert "손절" in msg
+    assert "+16.68" in msg  # today_pnl
+    assert "664.56" in msg
+    assert "운영 누적" in msg
+
+
+def test_format_daily_summary_no_trades():
+    skip = {
+        "SOXL": "도지 (몸통 0.02% < 0.05%)",
+        "SOXS": "음봉",
+    }
+    msg = format_daily_summary(
+        today_trades=[],
+        skip_reasons=skip,
+        usd_now=647.88,
+        usd_start_of_day=647.88,
+        week_pnl_usd=16.68,
+        week_trade_days=1,
+        month_pnl_usd=0.0,
+    )
+    assert "매매 없음" in msg
+    assert "도지" in msg
+    assert "음봉" in msg
+    assert "변동 없음" in msg
+
+
+# === DB 집계 ===
+
+
+def _ny_today_morning_utc() -> str:
+    """오늘 NY 거래일 10:00 EDT (확실히 NY 자정 이후) UTC ISO 문자열."""
+    from zoneinfo import ZoneInfo
+    ny = ZoneInfo("America/New_York")
+    ny_now = datetime.now(ny)
+    ny_morning = ny_now.replace(hour=10, minute=0, second=0, microsecond=0)
+    return ny_morning.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _seed_trade(db, coin, side, price, amount, pnl_pct=None, reason="", timestamp_utc=None):
+    if timestamp_utc is None:
+        timestamp_utc = _ny_today_morning_utc()
+    db.execute(
+        "INSERT INTO trades (timestamp, market, coin, side, price, amount, total_krw, fee_krw, "
+        "strategy, trigger_reason, profit_pct) "
+        "VALUES (?, 'kis_us', ?, ?, ?, ?, 0, 0, 'zarattini_3x_atr', ?, ?)",
+        (timestamp_utc, coin, side, price, amount, reason, pnl_pct),
+    )
+    db.commit()
+
+
+def test_calc_today_pnl_buy_sell_pair(db):
+    """오늘 buy + sell 쌍 → pnl 계산."""
+    _seed_trade(db, "SOXL", "buy", 176.0, 3.0)
+    _seed_trade(db, "SOXL", "sell", 182.0, 3.0, pnl_pct=3.41, reason="day_trading_close")
+    pnl, trades = calc_today_pnl(db)
+    assert pnl == pytest.approx(18.0, abs=0.01)
+    assert len(trades) == 1
+    assert trades[0]["symbol"] == "SOXL"
+    assert trades[0]["sell_type"] == "eod_profit"
+
+
+def test_calc_today_pnl_stop_loss(db):
+    _seed_trade(db, "SOXS", "buy", 9.0, 50.0)
+    _seed_trade(db, "SOXS", "sell", 8.6, 50.0, pnl_pct=-4.44, reason="손절 -4.5%")
+    _, trades = calc_today_pnl(db)
+    assert trades[0]["sell_type"] == "stop_loss"
+
+
+def test_calc_period_pnl_7d(db):
+    """7일 손익 + 매매일 수."""
+    # 오늘
+    _seed_trade(db, "SOXL", "buy", 100.0, 1.0)
+    _seed_trade(db, "SOXL", "sell", 105.0, 1.0)
+    # 어제
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+    _seed_trade(db, "SOXS", "buy", 10.0, 5.0, timestamp_utc=yesterday)
+    _seed_trade(db, "SOXS", "sell", 11.0, 5.0, timestamp_utc=yesterday)
+    pnl, days = calc_period_pnl(db, days=7)
+    assert pnl == pytest.approx(10.0, abs=0.01)  # 5 (오늘) + 5 (어제)
+    assert days >= 1
+
+
+def test_calc_today_pnl_empty(db):
+    pnl, trades = calc_today_pnl(db)
+    assert pnl == 0.0
+    assert trades == []


### PR DESCRIPTION
user 요청: 매매 활동 보기 좋게 Slack 알림. 5종 메시지 + DB 집계 + 시각 가드. 694건 통과.