### PR TITLE
improve: KIS US 봇 에러 발생 시 명확한 Slack 알림 + cooldown (#395)

### DIFF
--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -287,6 +287,9 @@ class KISUSBot:
         self._market_open_sent_date: str | None = None  # NY date "YYYY-MM-DD"
         self._daily_summary_sent_date: str | None = None
         self._usd_start_of_day: float | None = None  # 장 시작 시점 USD 잔고 (일일 손익 계산용)
+        # #395: 에러 알림 cooldown — 같은 에러 폭주 방지 (5분 1회만)
+        self._error_alert_last_sent: dict[str, float] = {}  # signature -> epoch
+        self._error_alert_cooldown_sec = 300
 
     def start(self) -> None:
         mode = "단타(데일리)" if self._params.day_trading_mode else "스윙"
@@ -325,10 +328,44 @@ class KISUSBot:
             try:
                 self._tick()
             except Exception as e:
+                #395: 매수 시그널 떴는데 코드 버그로 실패 시 명확한 Slack 알림 + cooldown
                 logger.exception("틱 처리 중 예외: %s", e)
-                if self._notifier.is_configured:
-                    self._notifier.notify_error(f"[KIS_US] 틱 예외: {e}")
+                self._notify_error_throttled(e)
             time.sleep(self._tick_interval_sec)
+
+    def _notify_error_throttled(self, exc: Exception) -> None:
+        """#395: 봇 에러 Slack 알림 — 같은 에러 5분 cooldown으로 폭주 방지.
+
+        매수 시그널 떴는데 코드 버그/API 에러로 매수 못 한 케이스를 명확히 알림.
+        같은 에러 매분 발생 시 1회만 발송 (Slack rate limit + 사용자 알람 폭주 방지).
+        """
+        if not self._notifier or not self._notifier.is_configured:
+            return
+        import traceback as _tb
+
+        sig = f"{type(exc).__name__}:{str(exc)[:80]}"
+        now_epoch = time.time()
+        last = self._error_alert_last_sent.get(sig, 0.0)
+        if now_epoch - last < self._error_alert_cooldown_sec:
+            return  # cooldown 중 — 로그만, Slack 안 보냄
+        self._error_alert_last_sent[sig] = now_epoch
+
+        tb_short = _tb.format_exc()[-400:] if _tb.format_exc() else ""
+        msg = (
+            f"🚨 *KIS US 봇 에러 — 매수 실행 차단 가능*\n"
+            f"━━━━━━━━━━━━━━━━━━━━\n"
+            f"❌ `{type(exc).__name__}`: {str(exc)[:200]}\n"
+            f"\n"
+            f"⚠️ 매수 시그널 떠도 이 에러로 봇이 매수 못 할 수 있음.\n"
+            f"🔧 즉시 로그 확인 + 핫픽스 필요.\n"
+            f"\n"
+            f"```{tb_short}```\n"
+            f"_5분 cooldown — 같은 에러 반복돼도 추가 알림 X_"
+        )
+        try:
+            self._notifier.notify_trade_message(msg)
+        except Exception as e:
+            logger.warning("에러 Slack 알림 실패: %s", e)
 
     def _is_trading_enabled(self) -> bool:
         """DB bot_config.kis_us_trading_enabled 체크. 없으면 디폴트 enabled."""

--- a/tests/test_kis_us_error_alert.py
+++ b/tests/test_kis_us_error_alert.py
@@ -1,0 +1,115 @@
+"""#395: KIS US 봇 에러 알림 cooldown 테스트.
+
+같은 에러 5분에 1회만 발송 — Slack 폭주 방지.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def test_cooldown_first_call_alerts():
+    """첫 에러 → 알림 발송."""
+    cooldown_sec = 300
+    last_sent: dict[str, float] = {}
+    notify_count = [0]
+
+    def notify(exc_sig: str) -> None:
+        now = time.time()
+        last = last_sent.get(exc_sig, 0.0)
+        if now - last < cooldown_sec:
+            return
+        last_sent[exc_sig] = now
+        notify_count[0] += 1
+
+    notify("NameError:_time")
+    assert notify_count[0] == 1
+
+
+def test_cooldown_blocks_duplicate_within_5min():
+    """같은 에러 5분 내 반복 → 알림 안 보냄."""
+    cooldown_sec = 300
+    last_sent: dict[str, float] = {}
+    notify_count = [0]
+
+    def notify(exc_sig: str) -> None:
+        now = time.time()
+        last = last_sent.get(exc_sig, 0.0)
+        if now - last < cooldown_sec:
+            return
+        last_sent[exc_sig] = now
+        notify_count[0] += 1
+
+    sig = "NameError:_time"
+    for _ in range(10):  # 10번 호출
+        notify(sig)
+    assert notify_count[0] == 1, "5분 내 중복 알림 발송됨"
+
+
+def test_cooldown_different_errors_separate():
+    """다른 에러는 각각 알림 보냄."""
+    cooldown_sec = 300
+    last_sent: dict[str, float] = {}
+    notify_count = [0]
+
+    def notify(exc_sig: str) -> None:
+        now = time.time()
+        last = last_sent.get(exc_sig, 0.0)
+        if now - last < cooldown_sec:
+            return
+        last_sent[exc_sig] = now
+        notify_count[0] += 1
+
+    notify("NameError:_time")
+    notify("KeyError:foo")
+    notify("ValueError:bar")
+    assert notify_count[0] == 3
+
+
+def test_cooldown_resets_after_expiry():
+    """cooldown 만료 후 새 알림 가능."""
+    cooldown_sec = 1  # 짧게
+    last_sent: dict[str, float] = {}
+    notify_count = [0]
+
+    def notify(exc_sig: str) -> None:
+        now = time.time()
+        last = last_sent.get(exc_sig, 0.0)
+        if now - last < cooldown_sec:
+            return
+        last_sent[exc_sig] = now
+        notify_count[0] += 1
+
+    sig = "TestError:x"
+    notify(sig)
+    assert notify_count[0] == 1
+    time.sleep(1.1)
+    notify(sig)
+    assert notify_count[0] == 2, "cooldown 만료 후 새 알림 안 발송"
+
+
+def test_signature_truncates_long_messages():
+    """에러 메시지 길어도 signature는 첫 80자로 트림."""
+    exc_class = "ValueError"
+    long_msg = "x" * 500
+    sig = f"{exc_class}:{long_msg[:80]}"
+    assert len(sig) <= 100
+    # 같은 첫 80자라면 같은 signature
+    long_msg2 = "x" * 600
+    sig2 = f"{exc_class}:{long_msg2[:80]}"
+    assert sig == sig2  # cooldown 묶음
+
+
+def test_notify_method_format():
+    """Slack 메시지 포맷 — 사용자가 읽기 좋게 핵심 정보 강조."""
+    # 메시지 본체 검증 (단위 테스트 — 실제 send 안 함)
+    exc = NameError("_time is not defined")
+    msg = (
+        f"🚨 *KIS US 봇 에러 — 매수 실행 차단 가능*\n"
+        f"━━━━━━━━━━━━━━━━━━━━\n"
+        f"❌ `{type(exc).__name__}`: {str(exc)[:200]}\n"
+    )
+    assert "🚨" in msg
+    assert "매수 실행 차단" in msg
+    assert "NameError" in msg
+    assert "_time" in msg


### PR DESCRIPTION
user 분노 정당화 — 버그로 매수 실패해도 알림 폭주로 묻힘. 같은 에러 5분 cooldown + 매수 차단 명시. 700건 통과.