### PR TITLE
feat: KIS US 시그널-매수 갭 가드 + 일일 매매 history 테이블 (#396)

### DIFF
--- a/scripts/migrate_kis_us_daily_history.sql
+++ b/scripts/migrate_kis_us_daily_history.sql
@@ -1,0 +1,33 @@
+-- #396: KIS US 일일 매매 history 테이블 (자산 축적용)
+--
+-- 매일 종목별 1행 기록:
+-- - bar1 패턴 (양봉/음봉/도지)
+-- - 매수/매도 여부, 손익
+-- - skip 이유 (도지, 갭 가드, 자금 부족 등)
+
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS kis_us_daily_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trade_date TEXT NOT NULL,            -- NY 거래일 "YYYY-MM-DD"
+    ticker TEXT NOT NULL,
+    bar1_pattern TEXT,                   -- "bullish" / "bearish" / "doji" / null (데이터 없음)
+    bar1_body_pct REAL,                  -- bar1 |close-open|/open × 100
+    signal_price REAL,                   -- bar1 close (시그널 가격)
+    bought INTEGER NOT NULL DEFAULT 0,
+    sold INTEGER NOT NULL DEFAULT 0,
+    buy_price REAL,
+    sell_price REAL,
+    qty REAL,
+    pnl_usd REAL,
+    pnl_pct REAL,
+    sell_type TEXT,                      -- "stop_loss" / "eod_profit" / "eod_loss" / null
+    skip_reason TEXT,                    -- "도지" / "음봉" / "갭 가드 (-2.1%)" / "자금 부족" 등
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(trade_date, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kis_us_daily_history_date
+    ON kis_us_daily_history(trade_date DESC);
+
+COMMIT;

--- a/src/cryptobot/bot/kis_strategy.py
+++ b/src/cryptobot/bot/kis_strategy.py
@@ -50,6 +50,11 @@ class KISBuySignal:
     take_profit_price: float | None = None
     # #364 Pure Zarattini Bar-1: 1% 리스크 사이징용 risk_per_share (= |entry − stop|)
     risk_per_share: float | None = None
+    # #396: 시그널 발생 시점의 entry 가격 (bar1 close). 매수 직전 갭 가드 비교용.
+    signal_price: float | None = None
+    # #396: bar1 패턴 ("bullish" / "bearish" / "doji" / None). 일일 history 기록용.
+    bar1_pattern: str | None = None
+    bar1_body_pct: float | None = None
 
 
 @dataclass
@@ -425,6 +430,8 @@ def evaluate_zarattini_3x_atr(
         return KISBuySignal(
             False,
             f"Bar-1 도지 (몸통 {body_pct:.3f}% < {params.doji_threshold_pct}% — 매매 X)",
+            bar1_pattern="doji",
+            bar1_body_pct=body_pct,
         )
 
     # 음봉 — 인버스 ETF는 별도 호출
@@ -432,6 +439,8 @@ def evaluate_zarattini_3x_atr(
         return KISBuySignal(
             False,
             f"Bar-1 음봉 ${c:.2f} < ${o:.2f} — 이 종목 매수 X (인버스 ETF 별도 평가)",
+            bar1_pattern="bearish",
+            bar1_body_pct=body_pct,
         )
 
     # 양봉 — ATR 손절 계산
@@ -440,6 +449,8 @@ def evaluate_zarattini_3x_atr(
         return KISBuySignal(
             False,
             f"ATR({params.atr_period}d) 계산 불가 — 일봉 데이터 부족 ({len(df_daily) if df_daily is not None else 0}봉)",
+            bar1_pattern="bullish",
+            bar1_body_pct=body_pct,
         )
 
     entry = c  # 첫 봉 close ≈ 둘째 봉 open (실 체결가는 주문 시 결정)
@@ -449,6 +460,8 @@ def evaluate_zarattini_3x_atr(
         return KISBuySignal(
             False,
             f"ATR 손절 계산 이상 (entry ${entry:.2f}, ATR ${atr:.2f}, stop_dist ${stop_distance:.4f})",
+            bar1_pattern="bullish",
+            bar1_body_pct=body_pct,
         )
 
     # 신뢰도: 양봉 몸통 + ATR 대비 진입가 (정성적)
@@ -461,6 +474,9 @@ def evaluate_zarattini_3x_atr(
         f"{params.atr_stop_pct}% × ATR) | TP 없음 (EOD까지)",
         confidence=max(conf, 0.3),
         stop_loss_price=stop,
+        signal_price=entry,  # #396: 갭 가드 비교용
+        bar1_pattern="bullish",
+        bar1_body_pct=body_pct,
         take_profit_price=None,  # 3X 변형: TP 없음, EOD가 익절
         risk_per_share=stop_distance,
     )

--- a/src/cryptobot/entrypoints/run_kis_us.py
+++ b/src/cryptobot/entrypoints/run_kis_us.py
@@ -141,6 +141,11 @@ DOJI_THRESHOLD_PCT = 0.05
 RISK_PCT_PER_TRADE = 1.0
 R_MULTIPLE_TARGET = 10.0
 
+# #396: 시그널-매수 가격 갭 가드 (%)
+# 시그널(bar1 close) 대비 매수 직전 가격이 이 % 이상 빠졌으면 매수 skip.
+# 매수 즉시 stop 아래 진입 방지 (#394 _time 버그 시점 SOXL -1.95% 갭 같은 사례).
+GAP_GUARD_PCT = 1.0
+
 # 종목당 최대 포지션 (#309: 풀매수, 여러 종목은 신뢰도 정렬로 순차)
 MAX_POSITION_PER_SYMBOL_PCT = 100.0
 
@@ -644,6 +649,11 @@ class KISUSBot:
         self._record_evaluation(symbol, price_usd, signal_, df=df, holds_already=False)
         if not signal_.should_buy:
             logger.debug("%s 매수 미판정: %s", symbol, signal_.reason)
+            #396: 도지/음봉 skip을 일일 history에 기록 (매일 1행, 첫 평가 시점)
+            pattern = getattr(signal_, "bar1_pattern", None)
+            if pattern in ("doji", "bearish") and self._params.day_trading_mode:
+                reason_short = "도지" if pattern == "doji" else "음봉 (페어 평가)"
+                self._record_history_skip(symbol, signal_, reason_short)
             return signal_, None, None, None
 
         return signal_, sl_price, tp_price, rps
@@ -709,6 +719,23 @@ class KISUSBot:
                 )
                 continue
 
+            # #396: 시그널-매수 가격 갭 가드
+            # 시그널 발생 시점(bar1 close) 대비 현재가가 -1% 이상 빠졌으면 매수 skip
+            # → 매수 즉시 stop 아래로 진입하는 케이스 방지 (시그널 시점부터 진입까지
+            # 가격이 크게 빠진 경우. 봇 재시작·delay·burst 시 발생)
+            signal_price = getattr(sig, "signal_price", None)
+            if signal_price and signal_price > 0:
+                gap_pct = (price_usd - signal_price) / signal_price * 100
+                if gap_pct < -GAP_GUARD_PCT:
+                    skip_msg = (
+                        f"{symbol} 갭 가드 skip — 시그널 ${signal_price:.2f} → 현재 ${price_usd:.2f} "
+                        f"({gap_pct:+.2f}%, 임계 -{GAP_GUARD_PCT}%)"
+                    )
+                    logger.warning(skip_msg)
+                    # 도지처럼 "오늘 안 산 날"로 history 기록
+                    self._record_history_skip(symbol, sig, f"갭 가드 ({gap_pct:.2f}%)")
+                    continue
+
             # #390: 매수 직전 사전 검증 — qty × price × 1.015 (buffer) ≤ budget
             estimated_cost = qty * price_usd * 1.015
             if estimated_cost > budget_usd:
@@ -717,6 +744,7 @@ class KISUSBot:
                     symbol, estimated_cost, budget_usd,
                 )
                 self._mark_insufficient_funds(symbol, budget_usd, estimated_cost)
+                self._record_history_skip(symbol, sig, "자금 부족")
                 continue
 
             logger.info(
@@ -834,6 +862,57 @@ class KISUSBot:
         except Exception as e:
             logger.exception("일일 결산 알림 실패: %s", e)
 
+    def _record_history_skip(self, symbol: str, sig, skip_reason: str) -> None:
+        """#396: 매수 안 한 날(도지/음봉/갭 가드/자금 부족) history 기록."""
+        try:
+            from cryptobot.notifier.kis_us_reports import record_daily_history
+
+            record_daily_history(
+                self._db,
+                ticker=symbol,
+                bar1_pattern=getattr(sig, "bar1_pattern", None),
+                bar1_body_pct=getattr(sig, "bar1_body_pct", None),
+                signal_price=getattr(sig, "signal_price", None),
+                bought=False,
+                skip_reason=skip_reason,
+            )
+        except Exception as e:
+            logger.debug("history skip 기록 실패 (%s): %s", symbol, e)
+
+    def _record_history_buy(self, symbol: str, sig, qty: float, buy_price: float) -> None:
+        """#396: 매수 체결 시 history 기록."""
+        try:
+            from cryptobot.notifier.kis_us_reports import record_daily_history
+
+            record_daily_history(
+                self._db,
+                ticker=symbol,
+                bar1_pattern=getattr(sig, "bar1_pattern", None),
+                bar1_body_pct=getattr(sig, "bar1_body_pct", None),
+                signal_price=getattr(sig, "signal_price", None),
+                bought=True,
+                buy_price=buy_price,
+                qty=qty,
+            )
+        except Exception as e:
+            logger.debug("history buy 기록 실패 (%s): %s", symbol, e)
+
+    def _record_history_sell(self, symbol: str, sell_price: float, pnl_usd: float, pnl_pct: float, sell_type: str) -> None:
+        """#396: 매도 시 history 업데이트."""
+        try:
+            from cryptobot.notifier.kis_us_reports import update_daily_history_sell
+
+            update_daily_history_sell(
+                self._db,
+                ticker=symbol,
+                sell_price=sell_price,
+                pnl_usd=pnl_usd,
+                pnl_pct=pnl_pct,
+                sell_type=sell_type,
+            )
+        except Exception as e:
+            logger.debug("history sell 기록 실패 (%s): %s", symbol, e)
+
     def _mark_insufficient_funds(self, symbol: str, budget: float, cost: float) -> None:
         """#390: 자금 부족 종목 cooldown 등록 + Slack 1회 알림."""
         cd_sec = self._insufficient_funds_cooldown_sec
@@ -899,6 +978,21 @@ class KISUSBot:
             trigger_reason=reason,
             order_uuid=result.order_uuid,
         )
+        #396: 일일 history 기록 (매수 체결)
+        try:
+            from cryptobot.notifier.kis_us_reports import record_daily_history
+
+            record_daily_history(
+                self._db,
+                ticker=symbol,
+                signal_price=None,  # _buy 시점엔 sig 객체 없음 — 매수가만
+                bought=True,
+                buy_price=result.price,
+                qty=result.amount,
+            )
+        except Exception as e:
+            logger.debug("history buy 기록 실패 (%s): %s", symbol, e)
+
         if self._notifier.is_configured:
             #393: 통합 보고 포맷
             from cryptobot.notifier.kis_us_reports import format_buy
@@ -944,17 +1038,33 @@ class KISUSBot:
             profit_pct=pnl_pct,
             order_uuid=result.order_uuid,
         )
+        # sell_type 분류 (history + Slack 메시지 공통 사용)
+        reason_lower = (reason or "").lower()
+        is_eod = "day_trading_close" in reason_lower or "eod" in reason_lower or "강제" in (reason or "")
+        if is_eod:
+            sell_type = "eod_profit" if pnl_pct > 0 else "eod_loss"
+        else:
+            sell_type = "stop_loss"
+        pnl_usd_val = result.amount * (result.price - (self._last_buy_price.get(symbol, result.price)))
+
+        #396: 일일 history 업데이트 (매도)
+        try:
+            from cryptobot.notifier.kis_us_reports import update_daily_history_sell
+
+            update_daily_history_sell(
+                self._db,
+                ticker=symbol,
+                sell_price=result.price,
+                pnl_usd=pnl_usd_val,
+                pnl_pct=pnl_pct,
+                sell_type=sell_type,
+            )
+        except Exception as e:
+            logger.debug("history sell 기록 실패 (%s): %s", symbol, e)
+
         if self._notifier.is_configured:
             #393: 통합 보고 포맷 — 손절/EOD 익절/EOD 손실 분기
             from cryptobot.notifier.kis_us_reports import format_sell
-
-            # sell_type 분류
-            reason_lower = (reason or "").lower()
-            is_eod = "day_trading_close" in reason_lower or "eod" in reason_lower or "강제" in (reason or "")
-            if is_eod:
-                sell_type = "eod_profit" if pnl_pct > 0 else "eod_loss"
-            else:
-                sell_type = "stop_loss"
             # 보유 시간 추정 (last_buy_price 기준, 정확도 낮으나 표시용)
             hold_min = 0
             try:
@@ -969,14 +1079,13 @@ class KISUSBot:
                     hold_min = int((_dt.utcnow() - buy_t).total_seconds() / 60)
             except Exception:
                 pass
-            pnl_usd = result.amount * (result.price - (self._last_buy_price.get(symbol, result.price)))
             self._notifier.notify_trade_message(
                 format_sell(
                     symbol=symbol,
                     qty=result.amount,
                     price=result.price,
                     pnl_pct=pnl_pct,
-                    pnl_usd=pnl_usd,
+                    pnl_usd=pnl_usd_val,
                     hold_minutes=hold_min,
                     sell_type=sell_type,
                 )

--- a/src/cryptobot/notifier/kis_us_reports.py
+++ b/src/cryptobot/notifier/kis_us_reports.py
@@ -285,6 +285,82 @@ def calc_today_pnl(db, symbol_filter: str = "kis_us") -> tuple[float, list[dict]
     return pnl_total, trades_summary
 
 
+# === #396: 일일 매매 history 기록 ===
+
+
+def _ny_today_str() -> str:
+    """오늘 NY 거래일 'YYYY-MM-DD'."""
+    return _now_ny().strftime("%Y-%m-%d")
+
+
+def record_daily_history(
+    db,
+    ticker: str,
+    bar1_pattern: str | None = None,
+    bar1_body_pct: float | None = None,
+    signal_price: float | None = None,
+    bought: bool = False,
+    buy_price: float | None = None,
+    qty: float | None = None,
+    skip_reason: str | None = None,
+) -> None:
+    """매수 시도 시점에 history 기록 (UPSERT).
+
+    매수 안 한 경우 (도지/음봉/갭가드/자금부족) skip_reason 기록.
+    매도는 update_daily_history_sell() 로 별도.
+    """
+    today = _ny_today_str()
+    db.execute(
+        """
+        INSERT INTO kis_us_daily_history
+            (trade_date, ticker, bar1_pattern, bar1_body_pct, signal_price,
+             bought, buy_price, qty, skip_reason, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(trade_date, ticker) DO UPDATE SET
+            bar1_pattern = excluded.bar1_pattern,
+            bar1_body_pct = excluded.bar1_body_pct,
+            signal_price = excluded.signal_price,
+            bought = MAX(kis_us_daily_history.bought, excluded.bought),
+            buy_price = COALESCE(excluded.buy_price, kis_us_daily_history.buy_price),
+            qty = COALESCE(excluded.qty, kis_us_daily_history.qty),
+            skip_reason = COALESCE(excluded.skip_reason, kis_us_daily_history.skip_reason),
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        (
+            today, ticker, bar1_pattern, bar1_body_pct, signal_price,
+            1 if bought else 0,
+            buy_price, qty, skip_reason,
+        ),
+    )
+    db.commit()
+
+
+def update_daily_history_sell(
+    db,
+    ticker: str,
+    sell_price: float,
+    pnl_usd: float,
+    pnl_pct: float,
+    sell_type: str,  # "stop_loss" / "eod_profit" / "eod_loss"
+) -> None:
+    """매도 발생 시 history 업데이트."""
+    today = _ny_today_str()
+    db.execute(
+        """
+        UPDATE kis_us_daily_history
+        SET sold = 1,
+            sell_price = ?,
+            pnl_usd = ?,
+            pnl_pct = ?,
+            sell_type = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE trade_date = ? AND ticker = ?
+        """,
+        (sell_price, pnl_usd, pnl_pct, sell_type, today, ticker),
+    )
+    db.commit()
+
+
 def calc_period_pnl(db, days: int, symbol_filter: str = "kis_us") -> tuple[float, int]:
     """최근 N일 손익 + 매매일 수."""
     from datetime import timedelta, timezone

--- a/tests/test_kis_us_daily_history.py
+++ b/tests/test_kis_us_daily_history.py
@@ -1,0 +1,195 @@
+"""#396: KIS US 일일 매매 history 테이블 + 갭 가드 테스트."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cryptobot.data.database import Database
+from cryptobot.notifier.kis_us_reports import (
+    record_daily_history,
+    update_daily_history_sell,
+)
+
+
+@pytest.fixture
+def db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.db")
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _get_today_row(db, ticker: str) -> dict | None:
+    from cryptobot.notifier.kis_us_reports import _ny_today_str
+    row = db.execute(
+        "SELECT * FROM kis_us_daily_history WHERE trade_date = ? AND ticker = ?",
+        (_ny_today_str(), ticker),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+# === record_daily_history ===
+
+
+def test_record_skip_doji(db):
+    """도지 skip 기록."""
+    record_daily_history(
+        db, "SOXL",
+        bar1_pattern="doji",
+        bar1_body_pct=0.02,
+        signal_price=180.0,
+        bought=False,
+        skip_reason="도지",
+    )
+    r = _get_today_row(db, "SOXL")
+    assert r is not None
+    assert r["bar1_pattern"] == "doji"
+    assert r["bought"] == 0
+    assert r["skip_reason"] == "도지"
+
+
+def test_record_skip_bearish(db):
+    """음봉 skip 기록."""
+    record_daily_history(
+        db, "SOXL",
+        bar1_pattern="bearish",
+        bar1_body_pct=0.5,
+        bought=False,
+        skip_reason="음봉",
+    )
+    r = _get_today_row(db, "SOXL")
+    assert r["bar1_pattern"] == "bearish"
+
+
+def test_record_skip_gap_guard(db):
+    """갭 가드 skip 기록."""
+    record_daily_history(
+        db, "SOXL",
+        bar1_pattern="bullish",
+        bar1_body_pct=1.8,
+        signal_price=182.80,
+        bought=False,
+        skip_reason="갭 가드 (-1.95%)",
+    )
+    r = _get_today_row(db, "SOXL")
+    assert r["bar1_pattern"] == "bullish"
+    assert "갭 가드" in r["skip_reason"]
+
+
+def test_record_buy(db):
+    """매수 체결 기록."""
+    record_daily_history(
+        db, "SOXL",
+        bar1_pattern="bullish",
+        bar1_body_pct=1.8,
+        signal_price=180.0,
+        bought=True,
+        buy_price=179.5,
+        qty=3,
+    )
+    r = _get_today_row(db, "SOXL")
+    assert r["bought"] == 1
+    assert r["buy_price"] == 179.5
+    assert r["qty"] == 3
+
+
+def test_upsert_same_day_same_ticker(db):
+    """같은 trade_date + ticker는 1행만 (UPSERT)."""
+    record_daily_history(db, "SOXL", bar1_pattern="bullish", bar1_body_pct=1.0)
+    record_daily_history(db, "SOXL", bar1_pattern="bullish", bought=True, buy_price=180.0, qty=3)
+    rows = db.execute(
+        "SELECT * FROM kis_us_daily_history WHERE ticker = 'SOXL'"
+    ).fetchall()
+    assert len(rows) == 1
+    assert dict(rows[0])["bought"] == 1
+    assert dict(rows[0])["buy_price"] == 180.0
+
+
+def test_update_sell_after_buy(db):
+    """매수 후 매도 → 한 행에 통합."""
+    record_daily_history(db, "SOXL", bought=True, buy_price=180.0, qty=3, bar1_pattern="bullish")
+    update_daily_history_sell(
+        db, "SOXL",
+        sell_price=185.0,
+        pnl_usd=15.0,
+        pnl_pct=2.78,
+        sell_type="eod_profit",
+    )
+    r = _get_today_row(db, "SOXL")
+    assert r["bought"] == 1
+    assert r["sold"] == 1
+    assert r["sell_price"] == 185.0
+    assert r["sell_type"] == "eod_profit"
+    assert r["pnl_usd"] == 15.0
+
+
+def test_different_tickers_separate_rows(db):
+    """SOXL과 SOXS는 별개 행."""
+    record_daily_history(db, "SOXL", bar1_pattern="bullish")
+    record_daily_history(db, "SOXS", bar1_pattern="bearish")
+    rows = db.execute(
+        "SELECT ticker, bar1_pattern FROM kis_us_daily_history ORDER BY ticker"
+    ).fetchall()
+    assert len(rows) == 2
+    assert dict(rows[0])["bar1_pattern"] == "bullish"
+    assert dict(rows[1])["bar1_pattern"] == "bearish"
+
+
+# === 갭 가드 로직 단위 검증 ===
+
+
+def test_gap_guard_calculation():
+    """가격 갭 % 계산: 시그널-현재 차이."""
+    signal_price = 182.80
+    current = 179.22
+    gap_pct = (current - signal_price) / signal_price * 100
+    assert gap_pct < -1.0  # -1.95%
+    assert -2.0 < gap_pct < -1.0
+
+
+def test_gap_guard_safe_zone():
+    """갭 -1% 이내면 매수 진행."""
+    signal_price = 182.80
+    current = 182.00
+    gap_pct = (current - signal_price) / signal_price * 100
+    assert gap_pct > -1.0  # -0.44%
+
+
+def test_gap_guard_positive_price():
+    """가격이 시그널 위 (양수 갭) → 매수 진행."""
+    signal_price = 182.80
+    current = 183.50
+    gap_pct = (current - signal_price) / signal_price * 100
+    assert gap_pct > 0
+
+
+# === KISBuySignal signal_price 필드 ===
+
+
+def test_buy_signal_has_signal_price():
+    from cryptobot.bot.kis_strategy import KISBuySignal
+
+    sig = KISBuySignal(
+        should_buy=True,
+        reason="test",
+        stop_loss_price=180.0,
+        signal_price=182.80,
+        bar1_pattern="bullish",
+        bar1_body_pct=1.8,
+    )
+    assert sig.signal_price == 182.80
+    assert sig.bar1_pattern == "bullish"
+    assert sig.bar1_body_pct == 1.8
+
+
+def test_buy_signal_optional_fields_default_none():
+    """signal_price/bar1_pattern 미지정 시 None."""
+    from cryptobot.bot.kis_strategy import KISBuySignal
+
+    sig = KISBuySignal(should_buy=False, reason="test")
+    assert sig.signal_price is None
+    assert sig.bar1_pattern is None


### PR DESCRIPTION
옵션 A (갭 -1% 가드) + 매일 매매 history 통합. 자산 축적용. 712건 통과.